### PR TITLE
feat: seed Oaktree Estimator starter (FastAPI + GCP Cloud Run CI/CD, me-central2)

### DIFF
--- a/.codex/CONVENTIONS.md
+++ b/.codex/CONVENTIONS.md
@@ -1,0 +1,3 @@
+- Python 3.11, FastAPI, SQLAlchemy, Alembic.
+- JSON responses use `{ "items": [...] }` for list endpoints.
+- Add docs in README when changing API behavior.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+APP_ENV=local
+APP_NAME=oaktree-estimator
+API_PORT=8000
+
+POSTGRES_USER=oaktree
+POSTGRES_PASSWORD=devpass
+POSTGRES_DB=oaktree
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+
+# Cloud SQL socket hints (set by deploy workflow)
+CLOUD_SQL_CONNECTION_NAME=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -1,0 +1,44 @@
+name: Deploy to GCP (Cloud Run, me-central2)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "app/**"
+      - "Dockerfile"
+      - ".github/workflows/deploy-gcp.yml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  PROJECT_ID: ${{ vars.PROJECT_ID }}
+  REGION: ${{ vars.REGION }}
+  REPO: ${{ vars.AR_REPO }}
+  SERVICE: ${{ vars.SERVICE }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Auth to GCP (OIDC)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github
+          service_account: github-deployer@${{ env.PROJECT_ID }}.iam.gserviceaccount.com
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Build & push image
+        run: |
+          gcloud builds submit --tag ${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/oaktree-estimator:${GITHUB_SHA}
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${SERVICE} \
+            --image ${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/oaktree-estimator:${GITHUB_SHA} \
+            --region ${REGION} --allow-unauthenticated --port 8000 \
+            --add-cloudsql-instances ${PROJECT_ID}:${REGION}:oaktree-sql \
+            --set-env-vars "CLOUD_SQL_CONNECTION_NAME=${PROJECT_ID}:${REGION}:oaktree-sql,POSTGRES_USER=oaktree,POSTGRES_DB=oaktree,POSTGRES_HOST=/cloudsql/${PROJECT_ID}:${REGION}:oaktree-sql,POSTGRES_PORT=5432" \
+            --set-secrets "POSTGRES_PASSWORD=DB_PASSWORD:latest"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+pycache/
+*.pyc
+.venv/
+.env
+node_modules/
+*.log
+data/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# How Codex works on this repo
+
+- One task per PR; run `pytest` before opening PR.
+- Keep endpoints under `/v1/*`; update OpenAPI when behavior changes.
+- No secrets; rely on GitHub OIDC for GCP deploys.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: api db-up db-down db-init test fmt lint
+
+api:
+	uvicorn app.main:app --reload --port 8000
+
+db-up:
+	docker compose up -d db
+
+db-down:
+	docker compose down
+
+db-init:
+	alembic upgrade head
+
+test:
+	pytest -q
+
+fmt:
+	black app tests
+
+lint:
+	flake8 app tests

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 FastAPI + PostgreSQL starter for Oaktree’s cost/revenue estimator app. Built to match the approved blueprint and phased plan. Runs locally via Docker and deploys to **Google Cloud Run** in **Dammam (me-central2)** using keyless GitHub OIDC.  [oai_citation:2‡AI App Blueprint .docx](file-service://file-ALgZg1S1QWVEsFVxeedqkv)  [oai_citation:3‡comprehensive, step‑by‑step, end‑to‑end build guide.docx](file-service://file-2mLQo2SYnT3iuikLqGJy8N)
 
 ## Quick start (local)
+
 ```bash
 cp .env.example .env
 docker compose up -d db
@@ -12,3 +13,24 @@ alembic upgrade head
 uvicorn app.main:app --reload --port 8000
 # open http://127.0.0.1:8000/docs
 pytest -q
+```
+
+### Endpoints (MVP)
+
+- `GET /health`
+- `GET /v1/indices/cci`
+- `GET /v1/indices/rates`
+- `GET /v1/comps`
+- `POST /v1/estimates` (returns placeholder P50 pro-forma)
+
+## Deploy (Google Cloud Run, me-central2)
+
+1. Create a GCP project bound to CNTXT billing; enable: Cloud Run, Cloud SQL Admin, Artifact Registry, Secret Manager, Cloud Build.
+2. Create an Artifact Registry repo (Docker) and Cloud SQL (Postgres). Put the DB password in Secret Manager as `DB_PASSWORD`.
+3. Configure Workload Identity Federation (OIDC) for GitHub; create service account `github-deployer` with the required roles.
+4. In GitHub → **Settings → Actions** configure:
+   - **Variables**: `PROJECT_ID`, `REGION=me-central2`, `AR_REPO`, `SERVICE`
+   - **Secrets**: `GCP_PROJECT_NUMBER`
+5. Merge this PR; pushes to `main` trigger the **Deploy to GCP** workflow.
+
+No secrets are committed. For production, switch the database to HA and add RBAC/SSO per the roadmap.  [oai_citation:5‡AI App Blueprint .docx](file-service://file-ALgZg1S1QWVEsFVxeedqkv)

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./.alembic_dummy.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,37 @@
+from logging.config import fileConfig
+
+from alembic import context
+
+from app.db.session import engine
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=str(engine.url),
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    with engine.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,16 @@
+"""initial"""
+
+from alembic import op
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("-- placeholder; add tables in later PRs")
+
+
+def downgrade() -> None:
+    op.execute("-- placeholder")

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Oaktree Estimator application package."""

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API routers for the Oaktree Estimator service."""

--- a/app/api/comps.py
+++ b/app/api/comps.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Query
+
+router = APIRouter(tags=["comps"])
+
+EXAMPLE_COMPS = [
+    {
+        "id": "C-001",
+        "date": "2025-06-15",
+        "city": "Riyadh",
+        "district": "Al Olaya",
+        "asset_type": "land",
+        "net_area_m2": 1500,
+        "price_per_m2": 2800,
+        "source": "rega_indicator",
+        "source_url": "https://example-rega",
+    }
+]
+
+
+@router.get("/comps")
+def get_comps(
+    city: str | None = Query(default=None),
+    type: str | None = Query(default=None),
+    since: str | None = Query(default=None),
+) -> dict[str, list[dict]]:
+    items = EXAMPLE_COMPS
+    if city:
+        items = [record for record in items if record["city"].lower() == city.lower()]
+    if type:
+        items = [record for record in items if record["asset_type"].lower() == type.lower()]
+    return {"items": items}

--- a/app/api/estimates.py
+++ b/app/api/estimates.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, List, Literal
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+router = APIRouter(tags=["estimates"])
+
+
+class UnitMix(BaseModel):
+    type: str
+    count: int
+
+
+class Timeline(BaseModel):
+    start: str
+    months: int
+
+
+class FinancingParams(BaseModel):
+    margin_bps: int = 250
+    ltv: float = 0.6
+
+
+class EstimateRequest(BaseModel):
+    geometry: Dict[str, Any]
+    asset_program: str
+    unit_mix: List[UnitMix] = Field(default_factory=list)
+    finish_level: Literal["low", "mid", "high"] = "mid"
+    timeline: Timeline
+    financing_params: FinancingParams
+    strategy: Literal["build_to_sell", "build_to_lease", "hotel"] = "build_to_sell"
+
+
+@router.post("/estimates")
+def create_estimate(req: EstimateRequest) -> dict[str, Any]:
+    land_value = 10_000_000
+    hard_costs = 25_000_000
+    soft_costs = 4_000_000
+    financing = 2_000_000
+    revenues = 45_000_000
+
+    total_cost = land_value + hard_costs + soft_costs + financing
+    p50_profit = revenues - total_cost
+    irr_guess = 0.18
+
+    return {
+        "totals": {
+            "land_value": land_value,
+            "hard_costs": hard_costs,
+            "soft_costs": soft_costs,
+            "financing": financing,
+            "revenues": revenues,
+            "p50_profit": p50_profit,
+            "irr_guess": irr_guess,
+        },
+        "confidence_bands": {
+            "p5": p50_profit * 0.6,
+            "p50": p50_profit,
+            "p95": p50_profit * 1.4,
+        },
+        "assumptions": [
+            {"key": "finish_level", "value": req.finish_level, "source_type": "Manual"},
+            {"key": "ltv", "value": req.financing_params.ltv, "source_type": "Manual"},
+        ],
+    }

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/app/api/indices.py
+++ b/app/api/indices.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Query
+
+router = APIRouter(tags=["indices"])
+
+CCI_SAMPLE = [
+    {
+        "month": "2025-06-01",
+        "sector": "construction",
+        "cci_index": 108.9,
+        "source_url": "https://example-cci",
+    }
+]
+
+RATES_SAMPLE = [
+    {
+        "date": "2025-06-01",
+        "tenor": "overnight",
+        "rate_type": "SAMA_base",
+        "value": 6.00,
+        "source_url": "https://example-sama",
+    },
+    {
+        "date": "2025-06-01",
+        "tenor": "1M",
+        "rate_type": "SAIBOR",
+        "value": 6.1,
+        "source_url": "https://example-sama",
+    },
+]
+
+
+@router.get("/indices/cci")
+def get_cci(month: str | None = Query(default=None)) -> dict[str, list[dict]]:
+    items = CCI_SAMPLE
+    if month:
+        items = [record for record in items if record["month"][0:7] == month[0:7]]
+    return {"items": items}
+
+
+@router.get("/indices/rates")
+def get_rates(date_str: str | None = Query(default=None)) -> dict[str, list[dict]]:
+    items = RATES_SAMPLE
+    if date_str:
+        items = [record for record in items if record["date"] == date_str]
+    return {"items": items}

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core configuration and utilities."""

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,18 @@
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Settings:
+    APP_ENV: str = os.getenv("APP_ENV", "local")
+    APP_NAME: str = os.getenv("APP_NAME", "oaktree-estimator")
+    DB_USER: str = os.getenv("POSTGRES_USER", "oaktree")
+    DB_PASSWORD: str = os.getenv("POSTGRES_PASSWORD", "devpass")
+    DB_NAME: str = os.getenv("POSTGRES_DB", "oaktree")
+    DB_HOST: str = os.getenv("POSTGRES_HOST", "localhost")
+    DB_PORT: int = int(os.getenv("POSTGRES_PORT", "5432"))
+
+
+settings = Settings()

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database session management."""

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+DATABASE_URL = (
+    f"postgresql+psycopg://{settings.DB_USER}:{settings.DB_PASSWORD}"
+    f"@{settings.DB_HOST}:{settings.DB_PORT}/{settings.DB_NAME}"
+)
+
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+from app.api.comps import router as comps_router
+from app.api.estimates import router as estimates_router
+from app.api.health import router as health_router
+from app.api.indices import router as indices_router
+
+app = FastAPI(title="Oaktree Estimator API", version="0.1.0")
+
+app.include_router(health_router, prefix="")
+app.include_router(indices_router, prefix="/v1")
+app.include_router(comps_router, prefix="/v1")
+app.include_router(estimates_router, prefix="/v1")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  api:
+    build: .
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    depends_on:
+      - db
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata: {}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+fastapi>=0.111.0
+uvicorn[standard]>=0.30.0
+pydantic>=2.7.0
+SQLAlchemy>=2.0.29
+psycopg[binary,pool]>=3.1.18
+alembic>=1.13.1
+httpx>=0.27.0
+python-dotenv>=1.0.1
+shapely>=2.0.4
+h3>=3.7.7
+numpy>=1.26.4
+pandas>=2.2.2
+mlflow>=2.14.3
+pytest>=8.2.0
+black>=24.4.2
+flake8>=7.0.0

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_health() -> None:
+    client = TestClient(app)
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- seed the FastAPI application with health, indices, comps, and estimates endpoints plus configuration scaffolding
- add Docker, docker-compose, Alembic boilerplate, pytest setup, and supporting Makefile/scripts
- document local setup and Cloud Run deployment process and configure CI + deploy workflows

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d41b036184832aa2f714a4a3031c0c