### PR TITLE
SCCC: AK/SK deploy auth + ACR instance domain

### DIFF
--- a/.github/workflows/deploy-sccc.yml
+++ b/.github/workflows/deploy-sccc.yml
@@ -11,7 +11,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write   # required for OIDC
   contents: read
 
 env:
@@ -20,6 +19,7 @@ env:
   ACR_NAMESPACE: ${{ vars.ACR_NAMESPACE }}              # e.g., oaktree
   SERVICE_NAME: ${{ vars.SERVICE_NAME }}                # e.g., oaktree-estimator
   ACK_CLUSTER_ID: ${{ vars.ACK_CLUSTER_ID }}            # e.g., c5b5e80b0b64a4bf...
+  ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}        # e.g., oaktree-ai-estimator-registry.me-central-1.cr.aliyuncs.com
 
 jobs:
   deploy:
@@ -27,15 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # 1) OIDC -> Alibaba Cloud STS credentials
-      - name: Authenticate to Alibaba Cloud (OIDC)
-        uses: mozillazg/alibabacloud-oidc-auth@v1
-        with:
-          role-arn-to-assume: ${{ secrets.ALIBABA_CLOUD_RAM_ROLE_ARN }}
-          oidc-provider-arn: ${{ secrets.ALIBABA_CLOUD_RAM_OIDC_ARN }}
-          export-environment-variables: 'true'
-
-      # 2) Tooling
+      # 1) Tooling
       - name: Install CLI tooling (aliyun, kubectl, jq)
         run: |
           sudo apt-get update && sudo apt-get install -y jq
@@ -43,24 +35,31 @@ jobs:
           tar -xzf aliyun.tgz && sudo mv aliyun /usr/local/bin/aliyun
           curl -L -o kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
           chmod +x kubectl && sudo mv kubectl /usr/local/bin/kubectl
+      # 2) Configure Alibaba Cloud credentials (AK/SK workaround until OIDC is enabled)
+      - name: Configure Alibaba Cloud credentials
+        run: |
+          aliyun configure set \
+            --mode AK \
+            --access-key-id "${{ secrets.ALIBABA_ACCESS_KEY_ID }}" \
+            --access-key-secret "${{ secrets.ALIBABA_ACCESS_KEY_SECRET }}" \
+            --region "${{ env.ALIBABA_REGION }}"
 
-      # 3) Ephemeral ACR login (no static secrets)
+      # 3) Ephemeral ACR login (token from ACR API)
       - name: Get temporary ACR login (STS)
         id: acr
         run: |
           JSON=$(aliyun cr GetAuthorizationToken --RegionId "$ALIBABA_REGION" --InstanceId "$ACR_INSTANCE_ID" --Output json)
           echo "acr_username=$(echo "$JSON" | jq -r '.TempUsername')" >> "$GITHUB_OUTPUT"
           echo "acr_password=$(echo "$JSON" | jq -r '.AuthorizationToken')" >> "$GITHUB_OUTPUT"
-          echo "login_server=cr.${ALIBABA_REGION}.aliyuncs.com" >> "$GITHUB_OUTPUT"
 
       - name: Docker login to ACR
-        run: echo "${{ steps.acr.outputs.acr_password }}" | docker login ${{ steps.acr.outputs.login_server }} -u "${{ steps.acr.outputs.acr_username }}" --password-stdin
+        run: echo "${{ steps.acr.outputs.acr_password }}" | docker login "${{ env.ACR_LOGIN_SERVER }}" -u "${{ steps.acr.outputs.acr_username }}" --password-stdin
 
       # 4) Build & push Docker image to ACR
       - name: Build & push image
         id: img
         run: |
-          IMAGE="${{ steps.acr.outputs.login_server }}/${{ env.ACR_NAMESPACE }}/${{ env.SERVICE_NAME }}:${{ github.sha }}"
+          IMAGE="${{ env.ACR_LOGIN_SERVER }}/${{ env.ACR_NAMESPACE }}/${{ env.SERVICE_NAME }}:${{ github.sha }}"
           docker build -t "$IMAGE" .
           docker push "$IMAGE"
           echo "image=$IMAGE" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ pytest -q
 
 ## Deploy (sccc by stc / Alibaba Cloud Riyadh, me-central-1)
 
-1. In sccc by stc (Alibaba Cloud Riyadh), provision an ACK cluster in `me-central-1` and an ACR instance reachable at `cr.me-central-1.aliyuncs.com`. Create a RAM role that trusts GitHub’s OIDC provider so the workflow can exchange its short-lived token for STS credentials—no long-lived secrets are required.
-2. In GitHub → **Settings → Actions** configure:
-   - **Variables**: `ALIBABA_REGION=me-central-1`, `ACR_NAMESPACE`, `SERVICE_NAME`, `ACK_CLUSTER_ID`
-   - **Secrets**: `ALIBABA_CLOUD_ACR_INSTANCE_ID`, `ALIBABA_CLOUD_RAM_ROLE_ARN`, `ALIBABA_CLOUD_RAM_OIDC_ARN`
-3. Pushes to `main` trigger `.github/workflows/deploy-sccc.yml`. The workflow builds the Docker image, pushes it to ACR at `cr.me-central-1.aliyuncs.com`, then applies the manifests in `k8s/` to update the ACK deployment.
+1. In sccc by stc (Alibaba Cloud Riyadh), provision an ACK cluster in `me-central-1` and an **Enterprise ACR instance** (the registry should expose a domain such as `oaktree-ai-estimator-registry.me-central-1.cr.aliyuncs.com`).
+2. Until GitHub OIDC is enabled in the region, the workflow authenticates with AK/SK credentials. In GitHub → **Settings → Actions** configure:
+   - **Variables**: `ALIBABA_REGION=me-central-1`, `ACR_NAMESPACE`, `SERVICE_NAME`, `ACK_CLUSTER_ID`, `ACR_LOGIN_SERVER=<enterprise-acr-domain>`
+   - **Secrets**: `ALIBABA_CLOUD_ACR_INSTANCE_ID`, `ALIBABA_ACCESS_KEY_ID`, `ALIBABA_ACCESS_KEY_SECRET`
+3. Pushes to `main` trigger `.github/workflows/deploy-sccc.yml`. The workflow builds the Docker image, pushes it to the Enterprise ACR domain specified in `ACR_LOGIN_SERVER`, then applies the manifests in `k8s/` to update the ACK deployment.
+4. (Preferred, once available) Switch back to GitHub OIDC by providing `ALIBABA_CLOUD_RAM_ROLE_ARN` and `ALIBABA_CLOUD_RAM_OIDC_ARN` secrets and removing the AK/SK credentials.
 
 No secrets are committed. For production, switch the database to HA and add RBAC/SSO per the roadmap.  [oai_citation:5‡AI App Blueprint .docx](file-service://file-ALgZg1S1QWVEsFVxeedqkv)


### PR DESCRIPTION
## Summary
- update the SCCC deploy workflow to configure the Alibaba CLI with AK/SK credentials until OIDC is available in the region
- add support for supplying the Enterprise ACR instance domain via `ACR_LOGIN_SERVER` when logging in and tagging images
- document the temporary AK/SK fallback, the new GitHub secrets/variables, and the preferred OIDC flow in the SCCC deploy section of the README

## Testing
- pytest -q
- python - <<'PY' ... yaml.safe_load('.github/workflows/deploy-sccc.yml')


------
https://chatgpt.com/codex/tasks/task_e_68d6025ef140832a81bb9a8bbec22651