### PR TITLE
Fix invalid image tag by normalizing namespace/service

### DIFF
--- a/.github/workflows/deploy-sccc.yml
+++ b/.github/workflows/deploy-sccc.yml
@@ -45,6 +45,17 @@ jobs:
           R="$(printf '%s' "$R" | tr -d '\r' | tr -d '\n' | sed 's:/*$::')"
           echo "host=$R" >> "$GITHUB_OUTPUT"
           echo "ACR_REG_HOST=$R" >> "$GITHUB_ENV"
+
+      # Normalize namespace and service (strip CR/LF, spaces, trailing slashes)
+      - name: Normalize image coordinates
+        id: imgmeta
+        run: |
+          NS="$(printf '%s' "${ACR_NAMESPACE}" | tr -d '\r\n' | tr -d ' ' | sed 's:/*$::')"
+          SVC="$(printf '%s' "${SERVICE_NAME}" | tr -d '\r\n' | tr -d ' ' | sed 's:/*$::')"
+          echo "ns=$NS"  >> "$GITHUB_OUTPUT"
+          echo "svc=$SVC" >> "$GITHUB_OUTPUT"
+          echo "ACR_NS=$NS" >> "$GITHUB_ENV"
+          echo "SVC_NAME=$SVC" >> "$GITHUB_ENV"
       # 2) Configure Alibaba Cloud credentials (AK/SK workaround until OIDC is enabled)
       - name: Configure Alibaba Cloud credentials
         run: |
@@ -78,7 +89,8 @@ jobs:
       - name: Build & push image
         id: img
         run: |
-          IMAGE="${ACR_REG_HOST}/${{ env.ACR_NAMESPACE }}/${{ env.SERVICE_NAME }}:${{ github.sha }}"
+          IMAGE="${ACR_REG_HOST}/${ACR_NS}/${SVC_NAME}:${{ github.sha }}"
+          echo "Using image: $IMAGE"
           docker build -t "$IMAGE" .
           docker push "$IMAGE"
           echo "image=$IMAGE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- sanitize the ACR namespace and service values to remove hidden whitespace and trailing slashes
- build the docker image using the normalized coordinates to avoid invalid reference formats

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6117693ec832a8e77ac871c9c6921