### PR TITLE
Add lightweight ORM models and DB dependency

### DIFF
--- a/app/db/deps.py
+++ b/app/db/deps.py
@@ -1,0 +1,13 @@
+from typing import Generator
+
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -1,0 +1,90 @@
+from sqlalchemy import Column, Integer, String, Date, Numeric, DateTime
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.models.base import Base
+
+
+class CostIndexMonthly(Base):
+    __tablename__ = "cost_index_monthly"
+
+    id = Column(Integer, primary_key=True)
+    month = Column(Date, nullable=False)
+    sector = Column(String(64), nullable=False)
+    cci_index = Column(Numeric(8, 2), nullable=False)
+    source_url = Column(String(512))
+    asof_date = Column(Date)
+
+
+class Rate(Base):
+    __tablename__ = "rates"
+
+    id = Column(Integer, primary_key=True)
+    date = Column(Date, nullable=False)
+    tenor = Column(String(16), nullable=False)
+    rate_type = Column(String(32), nullable=False)
+    value = Column(Numeric(6, 3), nullable=False)
+    source_url = Column(String(512))
+
+
+class SaleComp(Base):
+    __tablename__ = "sale_comp"
+
+    id = Column(String(64), primary_key=True)
+    date = Column(Date, nullable=False)
+    city = Column(String(64), nullable=False)
+    district = Column(String(128))
+    asset_type = Column(String(32), nullable=False)
+    net_area_m2 = Column(Numeric(14, 2))
+    price_total = Column(Numeric(14, 2))
+    price_per_m2 = Column(Numeric(12, 2))
+    source = Column(String(64))
+    source_url = Column(String(512))
+    asof_date = Column(Date)
+
+
+class RentComp(Base):
+    __tablename__ = "rent_comp"
+
+    id = Column(String(64), primary_key=True)
+    date = Column(Date, nullable=False)
+    city = Column(String(64), nullable=False)
+    district = Column(String(128))
+    asset_type = Column(String(32), nullable=False)
+    unit_type = Column(String(32))
+    lease_term_months = Column(Integer)
+    rent_per_unit = Column(Numeric(12, 2))
+    rent_per_m2 = Column(Numeric(12, 2))
+    source = Column(String(64))
+    source_url = Column(String(512))
+    asof_date = Column(Date)
+
+
+class Parcel(Base):
+    __tablename__ = "parcel"
+
+    id = Column(String(64), primary_key=True)
+    gis_polygon = Column(JSONB)
+    municipality = Column(String(64))
+    district = Column(String(128))
+    zoning = Column(String(64))
+    far = Column(Numeric(6, 3))
+    frontage_m = Column(Numeric(10, 2))
+    road_class = Column(String(32))
+    setbacks = Column(JSONB)
+    source_url = Column(String(512))
+    asof_date = Column(Date)
+
+
+class AssumptionLedger(Base):
+    __tablename__ = "assumption_ledger"
+
+    id = Column(Integer, primary_key=True)
+    estimate_id = Column(String(64), nullable=False)
+    line_id = Column(String(64))
+    source_type = Column(String(16), nullable=False)
+    source_ref = Column(String(128))
+    url = Column(String(512))
+    value = Column(Numeric(18, 4))
+    unit = Column(String(16))
+    owner = Column(String(64))
+    created_at = Column(DateTime)


### PR DESCRIPTION
## Summary
- add a reusable SQLAlchemy session dependency helper for FastAPI routes
- introduce a declarative base for ORM models
- define lightweight ORM models for cost indices, rates, comps, parcels, and assumption ledger

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6f2e64684832ab960991e913483e6