### PR TITLE
Add foundational service layer modules

### DIFF
--- a/app/services/comps.py
+++ b/app/services/comps.py
@@ -1,0 +1,26 @@
+from datetime import date
+from typing import List, Optional, Dict, Any
+from sqlalchemy.orm import Session
+from app.models.tables import SaleComp
+
+
+def fetch_sale_comps(
+    db: Session,
+    city: Optional[str] = None,
+    since: Optional[date] = None,
+    limit: int = 200,
+) -> List[SaleComp]:
+    q = db.query(SaleComp)
+    if city:
+        q = q.filter(SaleComp.city.ilike(city))
+    if since:
+        q = q.filter(SaleComp.date >= since)
+    return q.order_by(SaleComp.date.desc()).limit(limit).all()
+
+
+def summarize_ppm2(comps: List[SaleComp]) -> Optional[float]:
+    ppm2 = [float(c.price_per_m2) for c in comps if c.price_per_m2 is not None]
+    if not ppm2:
+        return None
+    ppm2.sort()
+    return ppm2[len(ppm2) // 2]  # median

--- a/app/services/costs.py
+++ b/app/services/costs.py
@@ -1,0 +1,49 @@
+from datetime import date
+from typing import Dict, Any
+from sqlalchemy.orm import Session
+from app.models.tables import CostIndexMonthly, BoqItem
+
+
+def _latest_cci(db: Session, for_month: date, sector: str = "construction") -> float:
+    row = (
+        db.query(CostIndexMonthly)
+        .filter(CostIndexMonthly.sector == sector)
+        .order_by(CostIndexMonthly.month.desc())
+        .first()
+    )
+    idx = float(row.cci_index) if row and row.cci_index is not None else 100.0
+    return idx  # base 2023=100 in GASTAT; scale = idx/100
+
+
+def compute_hard_costs(db: Session, area_m2: float, month: date) -> Dict[str, Any]:
+    items = db.query(BoqItem).all()
+    if not items:
+        # conservative defaults if BoQ not yet seeded
+        return {
+            "cci_scalar": _latest_cci(db, month) / 100.0,
+            "total": area_m2 * 1800.0 * (_latest_cci(db, month) / 100.0),
+            "lines": [],
+            "note": "fallback: 1800 SAR/m² baseline (no BoQ rows present)"
+        }
+
+    cci_scalar = _latest_cci(db, month) / 100.0
+    total = 0.0
+    lines = []
+    for it in items:
+        qty = area_m2 * float(it.quantity_per_m2)
+        unit = float(it.baseline_unit_cost)
+        factor = float(it.city_factor) * cci_scalar
+        cost = qty * unit * factor
+        lines.append({
+            "code": it.code,
+            "uom": it.uom,
+            "qty": qty,
+            "unit_cost": unit,
+            "city_factor": float(it.city_factor),
+            "cci_scalar": cci_scalar,
+            "extended_cost": cost,
+            "source_type": "Model",
+            "url": it.source_url,
+        })
+        total += cost
+    return {"cci_scalar": cci_scalar, "total": total, "lines": lines}

--- a/app/services/financing.py
+++ b/app/services/financing.py
@@ -1,0 +1,53 @@
+from datetime import date
+from typing import Dict, Any, List
+from sqlalchemy.orm import Session
+from app.models.tables import Rate
+
+
+def _sama_base_rate(db: Session, on_date: date) -> float:
+    row = (
+        db.query(Rate)
+        .filter(Rate.rate_type == "SAMA_base")
+        .order_by(Rate.date.desc())
+        .first()
+    )
+    return float(row.value) if row and row.value is not None else 6.0  # % p.a.
+
+
+def compute_financing(
+    db: Session,
+    hard_plus_soft: float,
+    months: int,
+    margin_bps: int = 250,
+    ltv: float = 0.6,
+    asof: date | None = None,
+) -> Dict[str, Any]:
+    base = _sama_base_rate(db, asof or date.today()) / 100.0  # decimal p.a.
+    apr = base + (margin_bps / 10000.0)
+    mr = apr / 12.0
+
+    # simple S-curve (front/mid/back): 15% / 50% / 35%
+    seg = max(1, months // 3)
+    profile: List[float] = []
+    profile += [0.15 / seg] * seg
+    profile += [0.50 / seg] * seg
+    profile += [0.35 / (months - 2 * seg)] * (months - 2 * seg)
+    # normalize (guard integers)
+    s = sum(profile)
+    profile = [p / s for p in profile]
+
+    principal = hard_plus_soft * ltv
+    balance = 0.0
+    interest = 0.0
+    for p in profile:
+        draw = principal * p
+        balance += draw
+        interest += balance * mr
+    return {
+        "apr": apr,
+        "monthly_rate": mr,
+        "ltv": ltv,
+        "months": months,
+        "interest": interest,
+        "principal": principal,
+    }

--- a/app/services/geo.py
+++ b/app/services/geo.py
@@ -1,0 +1,33 @@
+from typing import Tuple, Dict, Any
+from shapely.geometry import shape, mapping
+import math
+
+
+def parse_geojson(gj: Dict[str, Any]):
+    return shape(gj)
+
+
+def project_to_xy_meters(lon: float, lat: float, lat0: float) -> Tuple[float, float]:
+    R = 6371000.0
+    x = math.radians(lon) * R * math.cos(math.radians(lat0))
+    y = math.radians(lat) * R
+    return x, y
+
+
+def area_m2(geom) -> float:
+    # Equirectangular approximation around centroid latitude (good enough for MVP)
+    c = geom.centroid
+    lat0 = c.y
+    coords = list(geom.exterior.coords)
+    XY = [project_to_xy_meters(lon, lat, lat0) for lon, lat in coords]
+    # Shoelace
+    area = 0.0
+    for i in range(len(XY) - 1):
+        x1, y1 = XY[i]
+        x2, y2 = XY[i + 1]
+        area += (x1 * y2 - x2 * y1)
+    return abs(area) / 2.0
+
+
+def to_geojson(geom):
+    return mapping(geom)

--- a/app/services/hedonic.py
+++ b/app/services/hedonic.py
@@ -1,0 +1,13 @@
+from datetime import date
+from typing import Optional, Tuple, Dict, Any
+from sqlalchemy.orm import Session
+from app.services.comps import fetch_sale_comps, summarize_ppm2
+
+
+def land_price_per_m2(
+    db: Session, city: Optional[str], since: Optional[date]
+) -> Tuple[Optional[float], Dict[str, Any]]:
+    comps = fetch_sale_comps(db, city=city, since=since)
+    median_ppm2 = summarize_ppm2(comps)
+    meta = {"n_comps": len(comps), "city": city, "since": since.isoformat() if since else None}
+    return median_ppm2, meta

--- a/app/services/proforma.py
+++ b/app/services/proforma.py
@@ -1,0 +1,30 @@
+from datetime import date
+from typing import Dict, Any
+
+
+def assemble(
+    land_value: float,
+    hard_costs: float,
+    soft_costs: float,
+    financing_interest: float,
+    revenues: float,
+) -> Dict[str, Any]:
+    total_cost = land_value + hard_costs + soft_costs + financing_interest
+    p50_profit = revenues - total_cost
+    # light bands: widen when profit close to zero
+    band = max(abs(p50_profit) * 0.4, total_cost * 0.05)
+    return {
+        "totals": {
+            "land_value": land_value,
+            "hard_costs": hard_costs,
+            "soft_costs": soft_costs,
+            "financing": financing_interest,
+            "revenues": revenues,
+            "p50_profit": p50_profit,
+        },
+        "confidence_bands": {
+            "p5": p50_profit - band,
+            "p50": p50_profit,
+            "p95": p50_profit + band,
+        },
+    }


### PR DESCRIPTION
## Summary
- add geo service helpers for GeoJSON parsing and area estimation
- add comps and hedonic services to retrieve comps and compute land pricing
- add costs, financing, and proforma services to assemble project cost models

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d71a48496c832ab68838d94b60e35c