### PR TITLE
Add script to seed baseline BoQ items

### DIFF
--- a/app/ingest/seed_boq.py
+++ b/app/ingest/seed_boq.py
@@ -1,0 +1,28 @@
+from app.db.session import SessionLocal
+from app.models.tables import BoqItem
+
+SEED = [
+    {"code": "STRUC", "description": "Structure & frame", "uom": "m2", "quantity_per_m2": 1.0, "baseline_unit_cost": 850.0, "city_factor": 1.00},
+    {"code": "ENVEL", "description": "Envelope & finishes", "uom": "m2", "quantity_per_m2": 1.0, "baseline_unit_cost": 1200.0, "city_factor": 1.00},
+    {"code": "MEP",   "description": "MEP core",           "uom": "m2", "quantity_per_m2": 1.0, "baseline_unit_cost": 700.0, "city_factor": 1.00},
+    {"code": "SITE",  "description": "Site works",         "uom": "m2", "quantity_per_m2": 0.15,"baseline_unit_cost": 500.0, "city_factor": 1.00},
+]
+
+
+def main():
+    db = SessionLocal()
+    try:
+        for r in SEED:
+            if not db.get(BoqItem, r["code"]):
+                db.add(BoqItem(**r))
+        db.commit()
+        print("Seeded BoQ items.")
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a standalone seeding script for baseline Bill of Quantities items
- ensure new BoQ items are inserted only when missing to keep idempotency

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d728277b84832a9fd5e2ea8fc39e78