### PR TITLE
Add test covering estimate endpoint basic response

### DIFF
--- a/tests/test_estimates.py
+++ b/tests/test_estimates.py
@@ -1,0 +1,100 @@
+from contextlib import contextmanager
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db.deps import get_db
+from app.main import app
+
+
+class DummyQuery:
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+    def all(self):
+        return []
+
+    def limit(self, *args, **kwargs):
+        return self
+
+
+class DummySession:
+    def __init__(self):
+        self.added = []
+        self.committed = False
+        self.rolled_back = False
+
+    def query(self, *args, **kwargs):
+        return DummyQuery()
+
+    def add_all(self, entries):
+        self.added.extend(entries)
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        pass
+
+
+@contextmanager
+def dummy_session_scope():
+    session = DummySession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def override_get_db():
+    with dummy_session_scope() as session:
+        yield session
+
+
+@pytest.fixture(autouse=True)
+def override_db_dependency():
+    app.dependency_overrides[get_db] = override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+
+
+client = TestClient(app)
+
+
+def test_create_estimate_basic():
+    poly = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [46.675, 24.713],
+                [46.676, 24.713],
+                [46.676, 24.714],
+                [46.675, 24.714],
+                [46.675, 24.713],
+            ]
+        ],
+    }
+    payload = {
+        "geometry": poly,
+        "asset_program": "residential_midrise",
+        "unit_mix": [{"type": "1BR", "count": 10}],
+        "finish_level": "mid",
+        "timeline": {"start": "2025-10-01", "months": 18},
+        "financing_params": {"margin_bps": 250, "ltv": 0.6},
+        "strategy": "build_to_sell",
+    }
+    response = client.post("/v1/estimates", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    for key in ["totals", "confidence_bands", "assumptions"]:
+        assert key in data
+    assert data["totals"]["land_value"] > 0


### PR DESCRIPTION
## Summary
- add a FastAPI TestClient-based test that exercises the /v1/estimates endpoint
- stub database dependency with an in-memory dummy session so the estimate handler can run without Postgres

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d729395048832aa2da8f1912b1f1af