### PR TITLE
Add revenue service and stochastic simulation utilities

### DIFF
--- a/app/services/revenue.py
+++ b/app/services/revenue.py
@@ -1,0 +1,95 @@
+from datetime import date
+from typing import Dict, Any, Optional
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from app.models.tables import MarketIndicator
+
+
+def _indicator(
+    db: Session, indicator_type: str, city: Optional[str], asset_type: str
+) -> Optional[float]:
+    q = (
+        db.query(MarketIndicator)
+        .filter(MarketIndicator.indicator_type == indicator_type)
+        .filter(MarketIndicator.asset_type == asset_type)
+        .order_by(MarketIndicator.date.desc())
+    )
+    if city:
+        q = q.filter(func.lower(MarketIndicator.city) == city.lower())
+    row = q.first()
+    return float(row.value) if row else None
+
+
+def build_to_sell_revenue(
+    db: Session,
+    net_floor_area_m2: float,
+    city: Optional[str],
+    asset_type: str = "residential",
+    fallback_price_per_m2: float = 5500.0,
+) -> Dict[str, Any]:
+    indicator_price = _indicator(db, "sale_price_per_m2", city, asset_type)
+    if indicator_price is None:
+        price = fallback_price_per_m2
+        source_type = "Manual"
+    else:
+        price = indicator_price
+        source_type = "Observed"
+    gdv = net_floor_area_m2 * price
+    return {
+        "gdv": gdv,
+        "price_per_m2": price,
+        "lines": [
+            {
+                "key": "sale_price_per_m2",
+                "value": price,
+                "unit": "SAR/m2",
+                "source_type": source_type,
+            }
+        ],
+    }
+
+
+def build_to_lease_revenue(
+    db: Session,
+    net_floor_area_m2: float,
+    city: Optional[str],
+    asset_type: str = "residential",
+    occ: float = 0.92,
+    op_ex_ratio: float = 0.30,
+    cap_rate: float = 0.075,
+    fallback_rent_per_m2: float = 220.0,
+) -> Dict[str, Any]:
+    indicator_rent = _indicator(db, "rent_per_m2", city, asset_type)
+    if indicator_rent is None:
+        rent = fallback_rent_per_m2
+        rent_source_type = "Manual"
+    else:
+        rent = indicator_rent
+        rent_source_type = "Observed"
+    # SAR/m2/month
+    annual_rent = rent * net_floor_area_m2 * 12.0 * occ
+    noi = annual_rent * (1.0 - op_ex_ratio)
+    exit_value = noi / cap_rate
+    return {
+        "gdv": exit_value,
+        "rent_per_m2": rent,
+        "annual_rent": annual_rent,
+        "noi": noi,
+        "cap_rate": cap_rate,
+        "lines": [
+            {
+                "key": "rent_per_m2",
+                "value": rent,
+                "unit": "SAR/m2/mo",
+                "source_type": rent_source_type,
+            },
+            {"key": "occ", "value": occ, "unit": "ratio", "source_type": "Manual"},
+            {
+                "key": "op_ex_ratio",
+                "value": op_ex_ratio,
+                "unit": "ratio",
+                "source_type": "Manual",
+            },
+            {"key": "cap_rate", "value": cap_rate, "unit": "ratio", "source_type": "Manual"},
+        ],
+    }

--- a/app/services/simulate.py
+++ b/app/services/simulate.py
@@ -1,0 +1,36 @@
+import math
+import random
+from typing import Dict, Any, Tuple, List
+
+
+def percentile(xs: List[float], p: float) -> float:
+    xs = sorted(xs)
+    k = (len(xs) - 1) * p
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return xs[int(k)]
+    return xs[f] + (xs[c] - xs[f]) * (k - f)
+
+
+def p_bands(p50_profit: float, drivers: Dict[str, Tuple[float, float]], runs: int = 1000) -> Dict[str, float]:
+    """
+    drivers: { "land_ppm2": (mu, sigma), "unit_cost": (mu, sigma), "gdv_m2_price": (mu, sigma) }
+    Simple lognormal-ish perturbation: x' = mu * exp(N(0, sigma))
+    """
+    outcomes = []
+    mu_land, s_land = drivers.get("land_ppm2", (1.0, 0.10))
+    mu_unit, s_unit = drivers.get("unit_cost", (1.0, 0.08))
+    mu_price, s_price = drivers.get("gdv_m2_price", (1.0, 0.10))
+    for _ in range(runs):
+        land_f = mu_land * math.exp(random.gauss(0.0, s_land))
+        unit_f = mu_unit * math.exp(random.gauss(0.0, s_unit))
+        price_f = mu_price * math.exp(random.gauss(0.0, s_price))
+        # approximate profit scaling: price ↑ helps, unit cost ↑ hurts, land ↑ hurts
+        profit = p50_profit * (price_f / (unit_f * land_f))
+        outcomes.append(profit)
+    return {
+        "p5": percentile(outcomes, 0.05),
+        "p50": percentile(outcomes, 0.50),
+        "p95": percentile(outcomes, 0.95),
+    }

--- a/tests/test_revenue.py
+++ b/tests/test_revenue.py
@@ -1,0 +1,49 @@
+from app.services import revenue
+
+
+class DummySession:
+    pass
+
+
+def _run_and_get_line(monkeypatch, indicator_value):
+    monkeypatch.setattr(
+        revenue,
+        "_indicator",
+        lambda db, indicator_type, city, asset_type: indicator_value,
+    )
+    result = revenue.build_to_sell_revenue(DummySession(), 100.0, city=None)
+    return result["price_per_m2"], result["lines"][0]["source_type"]
+
+
+def test_build_to_sell_revenue_zero_indicator(monkeypatch):
+    price, source = _run_and_get_line(monkeypatch, 0.0)
+    assert price == 0.0
+    assert source == "Observed"
+
+
+def test_build_to_sell_revenue_fallback_when_none(monkeypatch):
+    price, source = _run_and_get_line(monkeypatch, None)
+    assert price == 5500.0
+    assert source == "Manual"
+
+
+def test_build_to_lease_revenue_zero_indicator(monkeypatch):
+    monkeypatch.setattr(
+        revenue,
+        "_indicator",
+        lambda db, indicator_type, city, asset_type: 0.0,
+    )
+    result = revenue.build_to_lease_revenue(DummySession(), 100.0, city=None)
+    assert result["rent_per_m2"] == 0.0
+    assert result["lines"][0]["source_type"] == "Observed"
+
+
+def test_build_to_lease_revenue_fallback_when_none(monkeypatch):
+    monkeypatch.setattr(
+        revenue,
+        "_indicator",
+        lambda db, indicator_type, city, asset_type: None,
+    )
+    result = revenue.build_to_lease_revenue(DummySession(), 100.0, city=None)
+    assert result["rent_per_m2"] == 220.0
+    assert result["lines"][0]["source_type"] == "Manual"


### PR DESCRIPTION
## Summary
- add a revenue service for build-to-sell and build-to-lease strategies with indicator-aware fallbacks
- provide a simulation utility to derive profit confidence bands from driver distributions
- cover revenue fallbacks with unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d80f21f470832ab3f8268ba9988f6f