### PR TITLE
Add residual land value service

### DIFF
--- a/app/services/residual.py
+++ b/app/services/residual.py
@@ -1,0 +1,14 @@
+def residual_land_value(
+    gdv: float,
+    hard_costs: float,
+    soft_costs: float,
+    financing_interest: float,
+    dev_margin_pct: float = 0.15,
+) -> float:
+    """
+    Residual land = GDV - (Hard + Soft + Financing + Developer margin).
+    Returns 0 if negative (guard for early MVP).
+    """
+    required_profit = dev_margin_pct * gdv
+    rlv = gdv - (hard_costs + soft_costs + financing_interest + required_profit)
+    return max(0.0, rlv)


### PR DESCRIPTION
## Summary
- add a residual land value helper in the services layer
- implement simple guard to prevent negative residual values for the MVP

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d824564000832aa6945a02b026f01d