### PR TITLE
Add fpdf2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ mlflow>=2.14.3
 pytest>=8.2.0
 black>=24.4.2
 flake8>=7.0.0
+fpdf2>=2.7.8


### PR DESCRIPTION
## Summary
- add the fpdf2 library to the Python requirements list for PDF generation support

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8576ac4dc832ab957fe95f58bb6eb