### PR TITLE
Add PDF memo export route for estimates

### DIFF
--- a/app/services/pdf.py
+++ b/app/services/pdf.py
@@ -1,5 +1,9 @@
 from typing import List, Dict, Any
-from fpdf import FPDF
+
+try:  # pragma: no cover - dependency availability handled at runtime
+    from fpdf import FPDF
+except ModuleNotFoundError:  # pragma: no cover
+    FPDF = None  # type: ignore[assignment]
 
 
 def _fmt_money(x: float | None) -> str:
@@ -15,6 +19,8 @@ def build_memo_pdf(
     assumptions: List[Dict[str, Any]],
     top_comps: List[Dict[str, Any]],
 ) -> bytes:
+    if FPDF is None:
+        raise RuntimeError("fpdf library is not installed")
     pdf = FPDF(orientation="P", unit="mm", format="A4")
     pdf.add_page()
     pdf.set_title(title)


### PR DESCRIPTION
## Summary
- add a memo PDF export endpoint for estimates that streams a generated PDF
- ensure PDF generation gracefully handles missing fpdf dependency

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8596cb184832a9818ce383329346c