### PR TITLE
Add ML and Excel dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ pytest>=8.2.0
 black>=24.4.2
 flake8>=7.0.0
 fpdf2>=2.7.8
+scikit-learn>=1.5.1
+joblib>=1.4.2
+openpyxl>=3.1.5   # enables Excel uploads for /ingest endpoints


### PR DESCRIPTION
## Summary
- add scikit-learn and joblib packages for machine learning workloads
- include openpyxl to support Excel uploads on ingest endpoints

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8648d73ec832a89db11da4cce2aff