### PR TITLE
Add metadata freshness API endpoint

### DIFF
--- a/app/api/metadata.py
+++ b/app/api/metadata.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from app.db.deps import get_db
+from app.models.tables import CostIndexMonthly, Rate, MarketIndicator, SaleComp, RentComp
+
+router = APIRouter(tags=["metadata"])
+
+def _max_date(db: Session, col):
+    val = db.query(func.max(col)).scalar()
+    return val.isoformat() if val else None
+
+@router.get("/metadata/freshness")
+def freshness(db: Session = Depends(get_db)):
+    return {
+        "cost_index_monthly": _max_date(db, CostIndexMonthly.month),
+        "rates": _max_date(db, Rate.date),
+        "market_indicator": _max_date(db, MarketIndicator.date),
+        "sale_comp": _max_date(db, SaleComp.date),
+        "rent_comp": _max_date(db, RentComp.date),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from app.api.comps import router as comps_router
 from app.api.estimates import router as estimates_router
 from app.api.health import router as health_router
 from app.api.indices import router as indices_router
+from app.api.metadata import router as metadata_router
 
 app = FastAPI(title="Oaktree Estimator API", version="0.1.0")
 
@@ -11,3 +12,4 @@ app.include_router(health_router, prefix="")
 app.include_router(indices_router, prefix="/v1")
 app.include_router(comps_router, prefix="/v1")
 app.include_router(estimates_router, prefix="/v1")
+app.include_router(metadata_router, prefix="/v1")


### PR DESCRIPTION
## Summary
- add a metadata router that reports the latest available dates for ingested data sources
- wire the metadata router into the FastAPI application under the /v1 prefix

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d866e04a50832aaf47681a6265252e