### PR TITLE
Expose land model metadata in estimate notes

### DIFF
--- a/app/api/estimates.py
+++ b/app/api/estimates.py
@@ -147,6 +147,7 @@ def create_estimate(req: EstimateRequest, db: Session = Depends(get_db)) -> dict
         "cci_scalar": hard.get("cci_scalar"),
         "financing_apr": fin["apr"],
         "revenue_lines": rev.get("lines", []),
+        "land_model": meta.get("model"),  # shows {"model_used": true/false, mape, n_rows}
     }
     result["assumptions"] = [
         {"key": "ppm2", "value": ppm2, "unit": "SAR/m2", "source_type": "Model" if meta.get("n_comps", 0) > 0 else "Manual"},


### PR DESCRIPTION
## Summary
- include land model metadata in the estimate notes payload so clients can see model usage details

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d86ff4bb80832aa5cfc6dcf05912b5