### PR TITLE
Add hedonic model training workflow

### DIFF
--- a/.github/workflows/train-hedonic.yml
+++ b/.github/workflows/train-hedonic.yml
@@ -1,0 +1,82 @@
+name: Train Hedonic v0
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_ephemeral_db:
+        description: "Use an ephemeral Postgres (seeds minimal data) instead of your real DB?"
+        required: true
+        default: "true"
+        type: choice
+        options: ["true", "false"]
+  schedule:
+    - cron: "0 2 * * 1"   # Mondays 02:00 UTC (optional)
+
+permissions:
+  contents: write
+
+jobs:
+  train:
+    runs-on: ubuntu-latest
+
+    services:
+      # Ephemeral Postgres (used when inputs.use_ephemeral_db == 'true')
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: oaktree
+          POSTGRES_PASSWORD: devpass
+          POSTGRES_DB: oaktree
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd="pg_isready -U oaktree"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Configure DB env (ephemeral)
+        if: ${{ inputs.use_ephemeral_db == 'true' }}
+        run: |
+          echo "POSTGRES_USER=oaktree" >> $GITHUB_ENV
+          echo "POSTGRES_PASSWORD=devpass" >> $GITHUB_ENV
+          echo "POSTGRES_DB=oaktree" >> $GITHUB_ENV
+          echo "POSTGRES_HOST=127.0.0.1" >> $GITHUB_ENV
+          echo "POSTGRES_PORT=5432" >> $GITHUB_ENV
+
+      - name: Configure DB env (real DB via secrets)
+        if: ${{ inputs.use_ephemeral_db == 'false' }}
+        run: |
+          echo "POSTGRES_USER=${{ secrets.POSTGRES_USER }}" >> $GITHUB_ENV
+          echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> $GITHUB_ENV
+          echo "POSTGRES_DB=${{ secrets.POSTGRES_DB }}" >> $GITHUB_ENV
+          echo "POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}" >> $GITHUB_ENV
+          echo "POSTGRES_PORT=${{ secrets.POSTGRES_PORT }}" >> $GITHUB_ENV
+
+      - name: Prepare schema (alembic) + seed (only for ephemeral)
+        if: ${{ inputs.use_ephemeral_db == 'true' }}
+        run: |
+          alembic upgrade head
+          python -m app.ingest.seed
+
+      - name: Train and save model
+        run: |
+          python -m app.ml.hedonic_train
+          ls -lh models/
+
+      - name: Commit model artifact to repo
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git add models/hedonic_v0.pkl models/hedonic_v0.meta.json
+          git commit -m "chore(model): update hedonic_v0" || echo "No changes"
+          git push


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to train the Hedonic v0 model on demand or on schedule
- support toggling between an ephemeral Postgres instance and a real database via secrets
- seed data and commit the trained artifact back to the repository when changes occur

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d870d45200832abe6276bebdff8d48