### PR TITLE
fix: ensure alembic imports app in ci

### DIFF
--- a/.github/workflows/train-hedonic.yml
+++ b/.github/workflows/train-hedonic.yml
@@ -64,9 +64,13 @@ jobs:
 
       - name: Prepare schema (alembic) + seed (only for ephemeral)
         if: ${{ inputs.use_ephemeral_db == 'true' }}
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           alembic upgrade head
           python -m app.ingest.seed
+          python -m app.ingest.seed_boq
+          python -m app.ingest.seed_indicators
 
       - name: Train and save model
         run: |

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,4 +1,7 @@
 from logging.config import fileConfig
+import sys, pathlib
+# add repo root to sys.path so `import app` works when alembic runs in CI
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 from alembic import context
 


### PR DESCRIPTION
## Summary
- set PYTHONPATH for the training workflow's alembic + seed step so app modules resolve
- ensure seeding runs all relevant scripts in CI
- make alembic/env.py prepend the repo root to sys.path so imports work regardless of CWD

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d878aee5b4832ab02e7dbf76f8b15f