### PR TITLE
Shorten Alembic revision identifier

### DIFF
--- a/alembic/versions/0003_market_indicators_and_estimates.py
+++ b/alembic/versions/0003_market_indicators_and_estimates.py
@@ -3,7 +3,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "0003_market_indicators_and_estimates"
+revision = "0003_market_ind_est"
 down_revision = "0002_boq"  # or "0001_initial" if you skipped 0002
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- shorten the Alembic revision identifier for the market indicators and estimates migration to 32 characters

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d87b762504832ab2d80fab8ac3b027