### PR TITLE
Add ingestion endpoint for sale and rent comps

### DIFF
--- a/app/api/ingest.py
+++ b/app/api/ingest.py
@@ -7,7 +7,13 @@ from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_db
-from app.models.tables import CostIndexMonthly, Rate, MarketIndicator
+from app.models.tables import (
+    CostIndexMonthly,
+    Rate,
+    MarketIndicator,
+    RentComp,
+    SaleComp,
+)
 
 router = APIRouter(prefix="/v1/ingest", tags=["ingest"])
 
@@ -19,6 +25,17 @@ def _read_table(upload: UploadFile) -> pd.DataFrame:
     if name.endswith(".xlsx") or name.endswith(".xls"):
         return pd.read_excel(buf)
     return pd.read_csv(io.StringIO(raw.decode("utf-8")), encoding_errors="ignore")
+
+
+def _clean_optional(value):
+    if value is None:
+        return None
+    if pd.isna(value):
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return value
 
 
 @router.post("/cci")
@@ -56,6 +73,87 @@ def ingest_cci(
                 )
             )
         upserted += 1
+    db.commit()
+    return {"status": "ok", "rows": int(upserted)}
+
+
+@router.post("/comps")
+def ingest_comps(
+    file: UploadFile = File(...),
+    comp_type: str = "sale",
+    db: Session = Depends(get_db),
+):
+    """
+    Columns (sale): id,date,city,district,asset_type,net_area_m2,price_total,price_per_m2,source,source_url,asof_date
+    Columns (rent): id,date,city,district,asset_type,unit_type,lease_term_months,rent_per_unit,rent_per_m2,source,source_url,asof_date
+    """
+
+    df = _read_table(file)
+    df.columns = [c.lower() for c in df.columns]
+
+    required_sale = {"id", "date", "city", "asset_type", "price_per_m2"}
+    required_rent = {"id", "date", "city", "asset_type", "rent_per_m2"}
+
+    is_sale = comp_type.lower() == "sale"
+    required = required_sale if is_sale else required_rent
+    missing = required - set(df.columns)
+    if missing:
+        raise HTTPException(400, f"Missing columns: {sorted(missing)}")
+
+    upserted = 0
+    for _, r in df.iterrows():
+        comp_id = str(r["id"])
+        comp_date = date.fromisoformat(str(r["date"])[:10])
+        city = str(r["city"])
+        asset_type = str(r["asset_type"])
+        asof_value = _clean_optional(r.get("asof_date"))
+        asof_date = (
+            date.fromisoformat(str(asof_value)[:10]) if asof_value is not None else None
+        )
+
+        if is_sale:
+            obj = db.get(SaleComp, comp_id)
+            data = dict(
+                id=comp_id,
+                date=comp_date,
+                city=city,
+                district=_clean_optional(r.get("district")),
+                asset_type=asset_type,
+                net_area_m2=_clean_optional(r.get("net_area_m2")),
+                price_total=_clean_optional(r.get("price_total")),
+                price_per_m2=_clean_optional(r.get("price_per_m2")),
+                source=_clean_optional(r.get("source")),
+                source_url=_clean_optional(r.get("source_url")),
+                asof_date=asof_date,
+            )
+            if obj:
+                for key, value in data.items():
+                    setattr(obj, key, value)
+            else:
+                db.add(SaleComp(**data))
+        else:
+            obj = db.get(RentComp, comp_id)
+            data = dict(
+                id=comp_id,
+                date=comp_date,
+                city=city,
+                district=_clean_optional(r.get("district")),
+                asset_type=asset_type,
+                unit_type=_clean_optional(r.get("unit_type")),
+                lease_term_months=_clean_optional(r.get("lease_term_months")),
+                rent_per_unit=_clean_optional(r.get("rent_per_unit")),
+                rent_per_m2=_clean_optional(r.get("rent_per_m2")),
+                source=_clean_optional(r.get("source")),
+                source_url=_clean_optional(r.get("source_url")),
+                asof_date=asof_date,
+            )
+            if obj:
+                for key, value in data.items():
+                    setattr(obj, key, value)
+            else:
+                db.add(RentComp(**data))
+        upserted += 1
+
     db.commit()
     return {"status": "ok", "rows": int(upserted)}
 


### PR DESCRIPTION
## Summary
- add an ingest endpoint for sale and rent comps that upserts into SaleComp and RentComp tables
- normalize optional values before persisting and validate required columns based on comp type

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d96becb510832abdd1ae63bf5d7807