### PR TITLE
Add open data harvesters for Saudi indicators

### DIFF
--- a/app/connectors/gastat.py
+++ b/app/connectors/gastat.py
@@ -1,0 +1,18 @@
+from typing import Iterable, Dict
+import csv
+import io
+
+from app.connectors.open_data import safe_get_bytes
+
+# Placeholder: you will replace CSV_URL once you have the official open-data link
+CSV_URL = None  # e.g., https://dp.stats.gov.sa/.../cci.csv
+
+
+def fetch_cci_rows() -> Iterable[Dict]:
+    if not CSV_URL:
+        return []
+    raw = safe_get_bytes(CSV_URL)
+    text = raw.decode("utf-8", errors="ignore")
+    rd = csv.DictReader(io.StringIO(text))
+    for r in rd:
+        yield {"month": r.get("month"), "cci_index": r.get("cci_index"), "source_url": CSV_URL}

--- a/app/connectors/open_data.py
+++ b/app/connectors/open_data.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import httpx
+import urllib.robotparser as rp
+from urllib.parse import urlparse
+
+
+def robots_allows(url: str, user_agent: str = "oaktree-estimator") -> bool:
+    parts = urlparse(url)
+    robots = f"{parts.scheme}://{parts.netloc}/robots.txt"
+    try:
+        r = httpx.get(robots, timeout=5)
+        r.raise_for_status()
+    except Exception:
+        return True  # if no robots, default allow (still honor ToS)
+    p = rp.RobotFileParser()
+    p.parse(r.text.splitlines())
+    return p.can_fetch(user_agent, url)
+
+
+def safe_get_json(url: str) -> dict:
+    if not robots_allows(url):
+        raise RuntimeError(f"robots.txt disallows: {url}")
+    r = httpx.get(url, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def safe_get_bytes(url: str) -> bytes:
+    if not robots_allows(url):
+        raise RuntimeError(f"robots.txt disallows: {url}")
+    r = httpx.get(url, timeout=30)
+    r.raise_for_status()
+    return r.content

--- a/app/connectors/rega.py
+++ b/app/connectors/rega.py
@@ -1,0 +1,26 @@
+from typing import Iterable, Dict
+
+# Many indicator pages provide CSV/Excel exports; wire their direct file URLs once identified.
+CSV_URLS: list[str] = []  # add one or more allowed CSV export links
+
+
+def fetch_market_indicators() -> Iterable[Dict]:
+    from app.connectors.open_data import safe_get_bytes
+    import csv
+    import io
+
+    for url in CSV_URLS:
+        raw = safe_get_bytes(url)
+        text = raw.decode("utf-8", errors="ignore")
+        rd = csv.DictReader(io.StringIO(text))
+        for r in rd:
+            # normalize your chosen schema
+            yield {
+                "date": r.get("date") or r.get("month") or r.get("period"),
+                "city": r.get("city") or r.get("region"),
+                "asset_type": r.get("asset_type") or "residential",
+                "indicator_type": r.get("indicator_type") or "sale_price_per_m2",
+                "value": r.get("value"),
+                "unit": r.get("unit") or "SAR/m2",
+                "source_url": url,
+            }

--- a/app/connectors/sama.py
+++ b/app/connectors/sama.py
@@ -1,0 +1,22 @@
+from typing import Iterable, Dict
+
+from app.connectors.open_data import safe_get_json
+
+# Option A: if you adopt an open-data mirror that exposes JSON with date/value (e.g., Opendatasoft/KAPSARC)
+OPEN_JSON = None  # e.g., "https://data.kapsarc.org/api/records/1.0/search/?dataset=interest-rates-and-sama-average-bills&rows=5000"
+
+
+def fetch_rates() -> Iterable[Dict]:
+    if not OPEN_JSON:
+        return []
+    data = safe_get_json(OPEN_JSON)
+    for r in data.get("records", []):
+        fields = r.get("fields", {})
+        if "date" in fields and "rr" in fields:  # adapt to schema
+            yield {
+                "date": str(fields["date"])[:10],
+                "tenor": "overnight",
+                "rate_type": "SAMA_base",
+                "value": float(fields["rr"]),
+                "source_url": OPEN_JSON,
+            }

--- a/app/ingest/harvest_open.py
+++ b/app/ingest/harvest_open.py
@@ -1,0 +1,90 @@
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.models.tables import CostIndexMonthly, Rate, MarketIndicator
+from app.connectors.gastat import fetch_cci_rows
+from app.connectors.sama import fetch_rates
+from app.connectors.rega import fetch_market_indicators
+
+
+def upsert_cci(db: Session) -> int:
+    n = 0
+    for r in fetch_cci_rows():
+        d = date.fromisoformat(str(r["month"])[:7] + "-01")
+        row = db.query(CostIndexMonthly).filter_by(month=d, sector="construction").first()
+        if row:
+            row.cci_index = float(r["cci_index"])
+            row.source_url = r.get("source_url")
+        else:
+            db.add(
+                CostIndexMonthly(
+                    month=d,
+                    sector="construction",
+                    cci_index=float(r["cci_index"]),
+                    source_url=r.get("source_url"),
+                )
+            )
+        n += 1
+    db.commit()
+    return n
+
+
+def upsert_rates(db: Session) -> int:
+    n = 0
+    for r in fetch_rates():
+        d = date.fromisoformat(str(r["date"])[:10])
+        t = str(r["tenor"])
+        rt = str(r["rate_type"])
+        row = db.query(Rate).filter_by(date=d, tenor=t, rate_type=rt).first()
+        if row:
+            row.value = float(r["value"])
+            row.source_url = r.get("source_url")
+        else:
+            db.add(
+                Rate(
+                    date=d,
+                    tenor=t,
+                    rate_type=rt,
+                    value=float(r["value"]),
+                    source_url=r.get("source_url"),
+                )
+            )
+        n += 1
+    db.commit()
+    return n
+
+
+def upsert_indicators(db: Session) -> int:
+    n = 0
+    for r in fetch_market_indicators():
+        d = date.fromisoformat(str(r["date"])[:10])
+        row = (
+            db.query(MarketIndicator)
+            .filter_by(
+                date=d,
+                city=r["city"],
+                asset_type=r["asset_type"],
+                indicator_type=r["indicator_type"],
+            )
+            .first()
+        )
+        if row:
+            row.value = float(r["value"])
+            row.unit = r["unit"]
+            row.source_url = r.get("source_url")
+        else:
+            db.add(
+                MarketIndicator(
+                    date=d,
+                    city=r["city"],
+                    asset_type=r["asset_type"],
+                    indicator_type=r["indicator_type"],
+                    value=float(r["value"]),
+                    unit=r["unit"],
+                    source_url=r.get("source_url"),
+                )
+            )
+        n += 1
+    db.commit()
+    return n


### PR DESCRIPTION
## Summary
- add a shared open-data helper that respects robots.txt before downloading files
- scaffold connectors for GASTAT CCI, SAMA rates, and REGA market indicators with placeholder URLs
- provide ingestion upsert routines for populating CostIndexMonthly, Rate, and MarketIndicator tables from the new connectors

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d96ea39224832aba79eeeb8960dd97