### PR TITLE
Add placeholder Suhail connector

### DIFF
--- a/app/connectors/suhail.py
+++ b/app/connectors/suhail.py
@@ -1,0 +1,10 @@
+from typing import Iterable, Dict
+
+API_URL = None
+API_KEY = None
+
+def fetch_comps(query: Dict) -> Iterable[Dict]:
+    """
+    Placeholder for licensed Suhail feed. Return rows conforming to sale_comp or rent_comp schema.
+    """
+    return []


### PR DESCRIPTION
## Summary
- add a stub Suhail connector module with placeholders for configuration
- implement a no-op `fetch_comps` that returns an empty list until licensed access is configured

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d97115db64832aa7fcb845d0253c49