### PR TITLE
Add external source configuration settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,22 @@ POSTGRES_PORT=5432
 
 # Cloud SQL socket hints (set by deploy workflow)
 CLOUD_SQL_CONNECTION_NAME=
+
+# ---- External data sources (fill as available) ----
+# ArcGIS (FeatureServer base, e.g., https://<host>/arcgis/rest/services/Parcels)
+ARCGIS_BASE_URL=
+ARCGIS_PARCEL_LAYER=
+ARCGIS_TOKEN=
+
+# GASTAT CCI (CSV/Excel export URL)
+GASTAT_CCI_CSV_URL=
+
+# SAMA open-data JSON (rates)
+SAMA_OPEN_JSON=
+
+# REGA / SREM indicator CSV exports (comma-separated)
+REGA_CSV_URLS=
+
+# Suhail (licensed)
+SUHAIL_API_URL=
+SUHAIL_API_KEY=

--- a/app/connectors/gastat.py
+++ b/app/connectors/gastat.py
@@ -3,9 +3,9 @@ import csv
 import io
 
 from app.connectors.open_data import safe_get_bytes
+from app.core.config import settings
 
-# Placeholder: you will replace CSV_URL once you have the official open-data link
-CSV_URL = None  # e.g., https://dp.stats.gov.sa/.../cci.csv
+CSV_URL = settings.GASTAT_CCI_CSV_URL
 
 
 def fetch_cci_rows() -> Iterable[Dict]:

--- a/app/connectors/rega.py
+++ b/app/connectors/rega.py
@@ -1,7 +1,9 @@
 from typing import Iterable, Dict
 
-# Many indicator pages provide CSV/Excel exports; wire their direct file URLs once identified.
-CSV_URLS: list[str] = []  # add one or more allowed CSV export links
+from app.core.config import settings
+
+# Many indicator pages provide CSV/Excel exports; configured via env (comma-separated)
+CSV_URLS: list[str] = settings.REGA_CSV_URLS
 
 
 def fetch_market_indicators() -> Iterable[Dict]:

--- a/app/connectors/sama.py
+++ b/app/connectors/sama.py
@@ -1,9 +1,9 @@
 from typing import Iterable, Dict
 
 from app.connectors.open_data import safe_get_json
+from app.core.config import settings
 
-# Option A: if you adopt an open-data mirror that exposes JSON with date/value (e.g., Opendatasoft/KAPSARC)
-OPEN_JSON = None  # e.g., "https://data.kapsarc.org/api/records/1.0/search/?dataset=interest-rates-and-sama-average-bills&rows=5000"
+OPEN_JSON = settings.SAMA_OPEN_JSON
 
 
 def fetch_rates() -> Iterable[Dict]:

--- a/app/connectors/suhail.py
+++ b/app/connectors/suhail.py
@@ -1,7 +1,9 @@
 from typing import Iterable, Dict
 
-API_URL = None
-API_KEY = None
+from app.core.config import settings
+
+API_URL = settings.SUHAIL_API_URL
+API_KEY = settings.SUHAIL_API_KEY
 
 def fetch_comps(query: Dict) -> Iterable[Dict]:
     """

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,5 +14,28 @@ class Settings:
     DB_HOST: str = os.getenv("POSTGRES_HOST", "localhost")
     DB_PORT: int = int(os.getenv("POSTGRES_PORT", "5432"))
 
+    # --- External data & APIs (env-driven) ---
+    # ArcGIS (البوابة المكانية) parcels/zoning
+    ARCGIS_BASE_URL: str | None = os.getenv("ARCGIS_BASE_URL")
+    ARCGIS_PARCEL_LAYER: int | None = (
+        int(os.getenv("ARCGIS_PARCEL_LAYER")) if os.getenv("ARCGIS_PARCEL_LAYER") else None
+    )
+    ARCGIS_TOKEN: str | None = os.getenv("ARCGIS_TOKEN")
+
+    # GASTAT Construction Cost Index (CSV/Excel export)
+    GASTAT_CCI_CSV_URL: str | None = os.getenv("GASTAT_CCI_CSV_URL")
+
+    # SAMA rates (open-data JSON endpoint)
+    SAMA_OPEN_JSON: str | None = os.getenv("SAMA_OPEN_JSON")
+
+    # REGA / SREM indicators (one or more CSV URLs; comma-separated)
+    REGA_CSV_URLS: list[str] = [
+        u.strip() for u in os.getenv("REGA_CSV_URLS", "").split(",") if u.strip()
+    ]
+
+    # Suhail (licensed partner API)
+    SUHAIL_API_URL: str | None = os.getenv("SUHAIL_API_URL")
+    SUHAIL_API_KEY: str | None = os.getenv("SUHAIL_API_KEY")
+
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- add environment-driven settings for external data providers
- wire connectors to pull configuration values from the central settings module
- document new variables in the sample environment file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d9bd8e69f8832a95139041cec6449d