### PR TITLE
Support ArcGIS token query parameter

### DIFF
--- a/app/connectors/arcgis.py
+++ b/app/connectors/arcgis.py
@@ -35,6 +35,9 @@ def query_features(
         "returnGeometry": "true",
         "resultRecordCount": result_record_count,
     }
+    # Some ArcGIS servers require token as a query param instead of Authorization.
+    if token:
+        params["token"] = token
     with httpx.Client(timeout=30) as client:
         response = client.get(url, params=params, headers=_headers(token))
         response.raise_for_status()


### PR DESCRIPTION
## Summary
- allow ArcGIS connector queries to pass tokens via query parameters for servers that require it

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db04c94d9c832a91609a7da4a0b2fd