### PR TITLE
Add optional OpenTelemetry instrumentation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,11 @@ from app.api.health import router as health_router
 from app.api.indices import router as indices_router
 from app.api.ingest import router as ingest_router
 from app.api.metadata import router as metadata_router
+from app.telemetry import setup_otel_if_configured
 from app.security.auth import require as auth_require
 
 app = FastAPI(title="Oaktree Estimator API", version="0.1.0")
+setup_otel_if_configured(app)
 
 # Allow cross-origin requests for the API (tighten in production as needed).
 app.add_middleware(

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,0 +1,22 @@
+import os
+
+
+def setup_otel_if_configured(app):
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        return
+
+    # Lazy import to avoid impacting local runs
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+    provider = TracerProvider()
+    processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+    FastAPIInstrumentor.instrument_app(app)
+    HTTPXClientInstrumentor().instrument()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,7 @@ fpdf2>=2.7.8
 openpyxl>=3.1.5   # enables Excel uploads for /ingest endpoints
 scikit-learn>=1.5.1
 joblib>=1.4.2
+opentelemetry-sdk>=1.25.0
+opentelemetry-exporter-otlp>=1.25.0
+opentelemetry-instrumentation-fastapi>=0.46b0
+opentelemetry-instrumentation-httpx>=0.46b0


### PR DESCRIPTION
## Summary
- add optional OpenTelemetry setup that activates when OTLP endpoint is provided
- instrument FastAPI app and HTTPX client when telemetry is enabled
- include required OpenTelemetry dependencies in requirements

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db0c962770832a9071e650e33cc6d4