### PR TITLE
Add Postgres configuration env vars to API deployment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,6 +18,16 @@ spec:
           env:
             - name: APP_ENV
               value: "prod"
+            - name: POSTGRES_HOST
+              value: "YOUR_PG_HOST"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_DB
+              value: "oaktree"
+            - name: POSTGRES_USER
+              value: "oaktree"
+            - name: POSTGRES_PASSWORD
+              value: "CHANGEME"
           readinessProbe:
             httpGet: { path: /health, port: 8000 }
             initialDelaySeconds: 5


### PR DESCRIPTION
## Summary
- add temporary Postgres connection environment variables to the API deployment manifest so staging can target the real database

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd951c1008832a964598117d1f313c