### PR TITLE
k8s: pass DB envs via Secret for staging

### DIFF
--- a/.github/workflows/deploy-sccc.yml
+++ b/.github/workflows/deploy-sccc.yml
@@ -103,7 +103,18 @@ jobs:
           aliyun cs DescribeClusterUserKubeconfig --RegionId "$ALIBABA_REGION" --ClusterId "$ACK_CLUSTER_ID" | jq -r '.config' > kubeconfig
           echo "KUBECONFIG=$PWD/kubeconfig" >> $GITHUB_ENV
 
-      # 6) Deploy to ACK (patch image and apply)
+      # 6) Create/Update DB Secret (oaktree-db-env)
+      - name: Create/Update DB Secret (oaktree-db-env)
+        run: |
+          kubectl create secret generic oaktree-db-env \
+            --from-literal=POSTGRES_USER="${{ secrets.POSTGRES_USER }}" \
+            --from-literal=POSTGRES_PASSWORD="${{ secrets.POSTGRES_PASSWORD }}" \
+            --from-literal=POSTGRES_DB="${{ secrets.POSTGRES_DB }}" \
+            --from-literal=POSTGRES_HOST="${{ secrets.POSTGRES_HOST }}" \
+            --from-literal=POSTGRES_PORT="${{ secrets.POSTGRES_PORT }}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      # 7) Deploy to ACK (patch image and apply)
       - name: Deploy manifests
         run: |
           sed -i "s|IMAGE_PLACEHOLDER|${{ steps.img.outputs.image }}|g" k8s/deployment.yaml

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,16 +18,9 @@ spec:
           env:
             - name: APP_ENV
               value: "prod"
-            - name: POSTGRES_HOST
-              value: "YOUR_PG_HOST"
-            - name: POSTGRES_PORT
-              value: "5432"
-            - name: POSTGRES_DB
-              value: "oaktree"
-            - name: POSTGRES_USER
-              value: "oaktree"
-            - name: POSTGRES_PASSWORD
-              value: "CHANGEME"
+          envFrom:
+            - secretRef:
+                name: oaktree-db-env
           readinessProbe:
             httpGet: { path: /health, port: 8000 }
             initialDelaySeconds: 5


### PR DESCRIPTION
## Summary
- mount database connection settings from the oaktree-db-env Secret in the API deployment
- ensure deploy workflow creates or updates the oaktree-db-env Secret using repository secrets before applying manifests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd99c83d8c832aa3d9ca571957cd90