### PR TITLE
docs: add operator quickstart and sample ingest helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ pycache/
 .env
 node_modules/
 *.log
-data/
+# Ignore generated data but keep checked-in samples
+data/*
+!data/samples/
+!data/samples/**
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Oaktree Estimator – Starter (GCP / KSA)
 
+## Operator Quickstart (from a polygon to a memo)
+1. Start the API locally (or hit staging) and the React UI (Vite).
+2. In the UI, draw a site polygon (Riyadh default). Enter city/FAR/timeline.
+3. Click **Run Estimate** to compute land, costs, financing, revenues, and P5/P50/P95.
+4. Click **Open PDF Memo** to export.
+5. Use **Scenario** to test deltas (e.g., +x% price).
+
 FastAPI + PostgreSQL starter for Oaktree’s cost/revenue estimator app. Built to match the approved blueprint and phased plan. Runs locally via Docker and deploys to **Google Cloud Run** in **Dammam (me-central2)** using keyless GitHub OIDC.  [oai_citation:2‡AI App Blueprint .docx](file-service://file-ALgZg1S1QWVEsFVxeedqkv)  [oai_citation:3‡comprehensive, step‑by‑step, end‑to‑end build guide.docx](file-service://file-2mLQo2SYnT3iuikLqGJy8N)
 
 ## Quick start (local)
@@ -13,6 +20,12 @@ alembic upgrade head
 uvicorn app.main:app --reload --port 8000
 # open http://127.0.0.1:8000/docs
 pytest -q
+```
+
+### Load sample data (optional)
+```bash
+python scripts/ingest_samples.py
+curl -fsS 127.0.0.1:8000/v1/metadata/freshness
 ```
 
 ### Endpoints (MVP)
@@ -39,6 +52,13 @@ If you're using Codespaces, the FastAPI URL will look like:
 
 ```
 https://<your-codespace>-8000.app.github.dev
+```
+
+### Using the UI against staging (ACK)
+If the API is deployed on sccc/ACK, set:
+
+```
+VITE_API_BASE_URL=https://<your-loadbalancer-dns-or-ip>
 ```
 
 ## Deploy (sccc by stc / Alibaba Cloud Riyadh, me-central-1)

--- a/data/samples/cci_sample.csv
+++ b/data/samples/cci_sample.csv
@@ -1,0 +1,2 @@
+month,cci_index,source_url
+2025-06-01,108.9,https://example-cci

--- a/data/samples/comps_sale_sample.csv
+++ b/data/samples/comps_sale_sample.csv
@@ -1,0 +1,2 @@
+id,date,city,district,asset_type,net_area_m2,price_total,price_per_m2,source,source_url,asof_date
+C-001,2025-06-15,Riyadh,Al Olaya,land,1500,4200000,2800,rega_indicator,https://example-rega,2025-06-30

--- a/data/samples/indicators_sample.csv
+++ b/data/samples/indicators_sample.csv
@@ -1,0 +1,3 @@
+date,city,asset_type,indicator_type,value,unit,source_url
+2025-06-01,Riyadh,residential,sale_price_per_m2,6500,SAR/m2,https://example-rega
+2025-06-01,Riyadh,residential,rent_per_m2,230,SAR/m2/mo,https://example-rega

--- a/data/samples/rates_sample.csv
+++ b/data/samples/rates_sample.csv
@@ -1,0 +1,3 @@
+date,value,tenor,rate_type,source_url
+2025-06-01,6.00,overnight,SAMA_base,https://example-sama
+2025-06-01,6.10,1M,SAIBOR,https://example-sama

--- a/frontend/.env.development.example
+++ b/frontend/.env.development.example
@@ -1,3 +1,5 @@
 VITE_API_BASE_URL=http://127.0.0.1:8000
+# For staging, point to your ACK Service external URL, e.g.:
+# VITE_API_BASE_URL=https://<your-loadbalancer-dns-or-ip>
 # Public demo basemap good for dev/test (HTTPS, no key)
 VITE_MAP_STYLE=https://demotiles.maplibre.org/style.json

--- a/scripts/ingest_samples.py
+++ b/scripts/ingest_samples.py
@@ -1,0 +1,35 @@
+import os
+import pathlib
+
+import httpx
+
+BASE = os.environ.get("API_BASE", "http://127.0.0.1:8000")
+HERE = pathlib.Path(__file__).resolve().parents[1] / "data" / "samples"
+
+
+def _post_file(path: pathlib.Path, url: str, extra: dict | None = None) -> None:
+    with path.open("rb") as handle:
+        response = httpx.post(
+            url,
+            files={"file": (path.name, handle, "text/csv")},
+            params=extra or {},
+            timeout=httpx.Timeout(60.0),
+        )
+        response.raise_for_status()
+        print("OK:", url, "→", response.json())
+
+
+def main() -> None:
+    _post_file(HERE / "cci_sample.csv", f"{BASE}/v1/ingest/cci")
+    _post_file(HERE / "rates_sample.csv", f"{BASE}/v1/ingest/rates")
+    _post_file(HERE / "indicators_sample.csv", f"{BASE}/v1/ingest/indicators")
+    _post_file(
+        HERE / "comps_sale_sample.csv",
+        f"{BASE}/v1/ingest/comps",
+        {"comp_type": "sale"},
+    )
+    print("Sample ingest complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document an operator quickstart flow plus staging configuration hints
- add sample CSV data and an ingest helper script to seed the API
- note how to point the frontend at staging from the example env file

## Testing
- pytest -q
- npm install
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd9b125d30832a84a9892562b88244