### PR TITLE
Add CSV export link to estimator UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Polygon } from "geojson";
 import Map from "./Map";
-import { createEstimate, getFreshness, memoPdfUrl, runScenario, getComps } from "./api";
+import { createEstimate, getFreshness, memoPdfUrl, runScenario, getComps, exportCsvUrl } from "./api";
 
 const DEFAULT_POLY: Polygon = {
   type: "Polygon",
@@ -187,6 +187,9 @@ export default function App() {
             />
             <a href={memoPdfUrl(estimate.id)} target="_blank" rel="noreferrer" style={{ marginLeft: 4 }}>
               Open PDF Memo
+            </a>
+            <a href={exportCsvUrl(estimate.id)} target="_blank" rel="noreferrer" style={{ marginLeft: 8 }}>
+              Download CSV
             </a>
           </>
         )}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -43,6 +43,10 @@ export function memoPdfUrl(id: string) {
   return `${BASE}/v1/estimates/${id}/memo.pdf`;
 }
 
+export function exportCsvUrl(id: string) {
+  return `${BASE}/v1/estimates/${id}/export?format=csv`;
+}
+
 export async function getComps(params: { city?: string; type?: string; since?: string }) {
   const q = new URLSearchParams();
   if (params.city) q.set("city", params.city);


### PR DESCRIPTION
## Summary
- add an API helper to build the CSV export endpoint URL
- surface a "Download CSV" link next to the existing PDF memo link in the estimate view

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dda162ddec832ab8db989235deb742