### PR TITLE
Add manifest dry-run validation to deploy workflow

### DIFF
--- a/.github/workflows/deploy-sccc.yml
+++ b/.github/workflows/deploy-sccc.yml
@@ -115,6 +115,10 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       # 7) Deploy to ACK (patch image and apply)
+      - name: Validate manifests (dry-run)
+        run: |
+          kubectl apply --dry-run=client -f k8s/
+
       - name: Deploy manifests
         run: |
           sed -i "s|IMAGE_PLACEHOLDER|${{ steps.img.outputs.image }}|g" k8s/deployment.yaml

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ VITE_API_BASE_URL=https://<your-loadbalancer-dns-or-ip>
 2. Until GitHub OIDC is enabled in the region, the workflow authenticates with AK/SK credentials. In GitHub → **Settings → Actions** configure:
    - **Variables**: `ALIBABA_REGION=me-central-1`, `ACR_NAMESPACE`, `SERVICE_NAME`, `ACK_CLUSTER_ID`, `ACR_LOGIN_SERVER=<enterprise-acr-domain>`
    - **Secrets**: `ALIBABA_CLOUD_ACR_INSTANCE_ID`, `ALIBABA_ACCESS_KEY_ID`, `ALIBABA_ACCESS_KEY_SECRET`
-3. Pushes to `main` trigger `.github/workflows/deploy-sccc.yml`. The workflow builds the Docker image, pushes it to the Enterprise ACR domain specified in `ACR_LOGIN_SERVER`, then applies the manifests in `k8s/` to update the ACK deployment.
+3. Pushes to `main` trigger `.github/workflows/deploy-sccc.yml`. The workflow builds the Docker image, pushes it to the Enterprise ACR domain specified in `ACR_LOGIN_SERVER`, validates the Kubernetes manifests with `kubectl apply --dry-run=client -f k8s/`, then applies the manifests in `k8s/` to update the ACK deployment. (If you edit the manifests manually, keep `spec.template.spec.containers` as a YAML list — each container needs its own leading hyphen.)
 4. (Preferred, once available) Switch back to GitHub OIDC by providing `ALIBABA_CLOUD_RAM_ROLE_ARN` and `ALIBABA_CLOUD_RAM_OIDC_ARN` secrets and removing the AK/SK credentials.
 
 No secrets are committed. For production, switch the database to HA and add RBAC/SSO per the roadmap.  [oai_citation:5‡AI App Blueprint .docx](file-service://file-ALgZg1S1QWVEsFVxeedqkv)


### PR DESCRIPTION
## Summary
- add a dry-run validation step for Kubernetes manifests to the ACK deployment workflow
- document the new validation step and remind contributors to keep the containers list properly formatted

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de9c692d9c832abbf7fbf75934f054