### PR TITLE
Add app environment secret to deployment manifest

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -21,6 +21,8 @@ spec:
           envFrom:
             - secretRef:
                 name: oaktree-db-env
+            - secretRef:
+                name: oaktree-app-env
           readinessProbe:
             httpGet: { path: /health, port: 8000 }
             initialDelaySeconds: 5


### PR DESCRIPTION
## Summary
- load the oaktree-app-env secret alongside the existing database secret in the API deployment manifest

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e16cb1a900832a8995529c696d7807