### PR TITLE
Add listings-aware confidence scoring for Aqar commercial units

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -1681,7 +1681,45 @@ def _competition_whitespace_score(competitor_count: int) -> float:
     return _clamp(max(15.0, raw))
 
 
-def _confidence_score(landuse_label: str | None, population_reach: float, delivery_listing_count: int) -> float:
+def _confidence_score(
+    *,
+    is_listing: bool = False,
+    rent_confidence: str | None = None,
+    area_confidence: str | None = None,
+    unit_street_width_m: float | None = None,
+    image_url: str | None = None,
+    landuse_label: str | None = None,
+    population_reach: float = 0.0,
+    delivery_listing_count: int = 0,
+) -> float:
+    """Confidence score on a 0-100 scale.
+
+    For listings: rewards measured ground truth from Aqar.
+    For parcels: legacy district-context formula, capped at 70.
+    """
+    if is_listing:
+        score = 30.0  # base for being a real listing
+
+        if rent_confidence == "actual":
+            score += 20.0
+
+        if area_confidence == "actual":
+            score += 15.0
+
+        if unit_street_width_m is not None and unit_street_width_m > 0:
+            score += 15.0
+
+        if image_url:
+            score += 10.0
+
+        if landuse_label:
+            score += 5.0
+        if population_reach > 0:
+            score += 5.0
+
+        return _clamp(score)
+
+    # Parcel path: legacy formula, capped at 70.
     score = 40.0
     if landuse_label:
         score += 25.0
@@ -1689,7 +1727,7 @@ def _confidence_score(landuse_label: str | None, population_reach: float, delive
         score += 20.0
     if delivery_listing_count > 0:
         score += 15.0
-    return _clamp(score)
+    return min(70.0, _clamp(score))
 
 
 def _candidate_gate_status(
@@ -2077,7 +2115,17 @@ def _confidence_grade(
     zoning_available: bool = True,
     delivery_observed: bool = True,
     data_completeness_score: int | float = 0,
+    is_listing: bool = False,
 ) -> str:
+    """Map a 0-100 confidence score to an A/B/C/D grade.
+
+    For listings, the score already encodes data quality (measured rent,
+    area, street width, image) — parcel-era critical-missing checks are
+    irrelevant. Use the score directly.
+
+    For parcels, the score is from district-context enrichment, so the
+    critical-missing flags meaningfully indicate thin context.
+    """
     adjusted = _safe_float(confidence_score)
     if district:
         adjusted += 2.5
@@ -2087,9 +2135,18 @@ def _confidence_grade(
     if rent_source != "conservative_default":
         adjusted += 3.0
 
-    # Cap grade when critical observed context is missing.
-    # Missing zoning, delivery observation, road or parking context
-    # should prevent inflated A/B grades.
+    if is_listing:
+        # Listings: score is grounded in unit-level ground truth.
+        # Trust the score directly without parcel-context demotions.
+        if adjusted >= 85.0:
+            return "A"
+        if adjusted >= 70.0:
+            return "B"
+        if adjusted >= 50.0:
+            return "C"
+        return "D"
+
+    # Parcel path: legacy logic, unchanged.
     critical_missing = 0
     if not zoning_available:
         critical_missing += 1
@@ -3402,6 +3459,7 @@ def _query_candidate_location_pool(
                 cl.current_tenant,
                 cl.current_category,
                 cl.rent_confidence,
+                cl.area_confidence,
                 cl.rent_sar_m2_month::float AS cl_rent_m2_month,
                 cl.rent_sar_annual::float AS cl_rent_annual,
                 cl.avg_rating::float AS cl_avg_rating,
@@ -3447,6 +3505,7 @@ def _query_candidate_location_pool(
             current_tenant,
             current_category,
             rent_confidence,
+            area_confidence,
             cl_rent_m2_month,
             cl_rent_annual,
             cl_avg_rating,
@@ -4761,7 +4820,17 @@ def run_expansion_search(
         delivery_score = _delivery_score(delivery_listing_count)
         demand_score = _clamp(pop_score * _pop_w + delivery_score * _del_w)
 
-        confidence_score = _confidence_score(landuse_label, population_reach, delivery_listing_count)
+        _is_listing = bool(row.get("commercial_unit_id"))
+        confidence_score = _confidence_score(
+            is_listing=_is_listing,
+            rent_confidence=row.get("rent_confidence"),
+            area_confidence=row.get("area_confidence"),
+            unit_street_width_m=_safe_float(row.get("unit_street_width_m")) if row.get("unit_street_width_m") else None,
+            image_url=row.get("image_url"),
+            landuse_label=landuse_label,
+            population_reach=population_reach,
+            delivery_listing_count=delivery_listing_count,
+        )
         distance_to_nearest_branch_m = _nearest_branch_distance_m(
             _safe_float(row.get("lat")),
             _safe_float(row.get("lon")),
@@ -4808,7 +4877,6 @@ def run_expansion_search(
             category=category,
             price_tier=effective_brand_profile.get("price_tier"),
         )
-        _is_listing = bool(row.get("commercial_unit_id"))
         economics_score, economics_meta = _economics_score(
             estimated_revenue_index=estimated_revenue_index,
             estimated_annual_rent_sar=estimated_annual_rent_sar,
@@ -5555,6 +5623,7 @@ def run_expansion_search(
             zoning_available=bool(landuse_label or landuse_code),
             delivery_observed=provider_listing_count > 0,
             data_completeness_score=feature_snapshot_json.get("data_completeness_score", 0),
+            is_listing=_is_listing,
         )
         demand_thesis = _build_demand_thesis(
             demand_score=demand_score,

--- a/tests/test_expansion_advisor.py
+++ b/tests/test_expansion_advisor.py
@@ -2,6 +2,7 @@ from app.services.expansion_advisor import (
     _candidate_feature_snapshot,
     _candidate_gate_status,
     _confidence_grade,
+    _confidence_score,
     _context_checked,
     _dedupe_candidates,
     _build_demand_thesis,
@@ -425,6 +426,157 @@ def test_confidence_grade_b_with_one_missing():
         data_completeness_score=85,
     )
     assert grade == "B"
+
+
+# ---------------------------------------------------------------------------
+# Listings-aware confidence score tests (Patch 04)
+# ---------------------------------------------------------------------------
+
+def test_confidence_score_listing_full_ground_truth():
+    """Listing with all measured fields scores ~95."""
+    score = _confidence_score(
+        is_listing=True,
+        rent_confidence="actual",
+        area_confidence="actual",
+        unit_street_width_m=12.0,
+        image_url="https://example.com/img.jpg",
+        landuse_label="commercial",
+        population_reach=5000.0,
+    )
+    assert score == 100.0  # 30+20+15+15+10+5+5 = 100
+
+
+def test_confidence_score_listing_no_image():
+    """Missing image costs exactly 10 points."""
+    with_image = _confidence_score(
+        is_listing=True,
+        rent_confidence="actual",
+        area_confidence="actual",
+        unit_street_width_m=12.0,
+        image_url="https://example.com/img.jpg",
+        landuse_label="commercial",
+        population_reach=5000.0,
+    )
+    without_image = _confidence_score(
+        is_listing=True,
+        rent_confidence="actual",
+        area_confidence="actual",
+        unit_street_width_m=12.0,
+        image_url=None,
+        landuse_label="commercial",
+        population_reach=5000.0,
+    )
+    assert with_image - without_image == 10.0
+
+
+def test_confidence_score_listing_no_measured_rent():
+    """Listing without actual rent scores lower."""
+    score = _confidence_score(
+        is_listing=True,
+        rent_confidence="interpolated",
+        area_confidence="actual",
+        unit_street_width_m=12.0,
+        image_url="https://example.com/img.jpg",
+        landuse_label="commercial",
+        population_reach=5000.0,
+    )
+    assert score == 80.0  # 30+0+15+15+10+5+5
+
+
+def test_confidence_score_listing_minimal():
+    """Listing with no measured fields gets base 30."""
+    score = _confidence_score(
+        is_listing=True,
+        rent_confidence=None,
+        area_confidence=None,
+        unit_street_width_m=None,
+        image_url=None,
+        landuse_label=None,
+        population_reach=0.0,
+    )
+    assert score == 30.0
+
+
+def test_confidence_score_parcel_capped_at_70():
+    """Parcel path is capped at 70 regardless of context richness."""
+    score = _confidence_score(
+        is_listing=False,
+        landuse_label="commercial",
+        population_reach=5000.0,
+        delivery_listing_count=10,
+    )
+    assert score == 70.0  # 40+25+20+15=100 but capped at 70
+
+
+def test_confidence_score_parcel_legacy_base():
+    """Parcel with no context gets base 40."""
+    score = _confidence_score(
+        is_listing=False,
+        landuse_label=None,
+        population_reach=0.0,
+        delivery_listing_count=0,
+    )
+    assert score == 40.0
+
+
+def test_confidence_grade_listing_a():
+    """Listing with high score grades A without needing parcel context."""
+    grade = _confidence_grade(
+        confidence_score=85.0,
+        district="Al Olaya",
+        provider_platform_count=3,
+        multi_platform_presence_score=20.0,
+        rent_source="commercial_unit_actual",
+        road_context_available=False,
+        parking_context_available=False,
+        zoning_available=False,
+        delivery_observed=False,
+        data_completeness_score=0,
+        is_listing=True,
+    )
+    assert grade == "A"
+
+
+def test_confidence_grade_listing_not_demoted_by_missing_context():
+    """Listing grade is NOT demoted by missing parcel-era context flags."""
+    grade_with_context = _confidence_grade(
+        confidence_score=75.0,
+        district="Al Olaya",
+        provider_platform_count=2,
+        multi_platform_presence_score=10.0,
+        rent_source="commercial_unit_actual",
+        road_context_available=True,
+        parking_context_available=True,
+        zoning_available=True,
+        delivery_observed=True,
+        is_listing=True,
+    )
+    grade_without_context = _confidence_grade(
+        confidence_score=75.0,
+        district="Al Olaya",
+        provider_platform_count=2,
+        multi_platform_presence_score=10.0,
+        rent_source="commercial_unit_actual",
+        road_context_available=False,
+        parking_context_available=False,
+        zoning_available=False,
+        delivery_observed=False,
+        is_listing=True,
+    )
+    assert grade_with_context == grade_without_context
+
+
+def test_confidence_grade_listing_d_for_low_score():
+    """Listing with very low score still gets D."""
+    grade = _confidence_grade(
+        confidence_score=20.0,
+        district=None,
+        provider_platform_count=0,
+        multi_platform_presence_score=0.0,
+        rent_source="conservative_default",
+        is_listing=True,
+    )
+    assert grade == "D"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Extends the confidence scoring system to differentiate between listing-based candidates (from Aqar) and parcel-based candidates. Listings now receive scores based on measured ground truth (rent, area, street width, images), while parcels continue using the legacy district-context formula capped at 70.

## Key Changes

- **New `_confidence_score` signature**: Added `is_listing` flag and listing-specific parameters (`rent_confidence`, `area_confidence`, `unit_street_width_m`, `image_url`)
  - Listings: Base 30 points + bonuses for actual rent (20), actual area (15), street width (15), image (10), landuse (5), population (5) = up to 100
  - Parcels: Legacy formula (40 base + context bonuses) capped at 70

- **Updated `_confidence_grade` logic**: 
  - Listings now trust the confidence score directly without parcel-era context demotions (zoning, delivery, road/parking availability)
  - Parcels retain original critical-missing checks
  - Added docstring clarifying the two paths

- **Database query enhancements**:
  - Added `area_confidence` field to candidate location pool query
  - Moved `_is_listing` determination earlier to pass to confidence scoring

- **Test coverage**: Added 8 new tests covering:
  - Listing scoring with full/partial ground truth
  - Parcel scoring cap at 70
  - Grade assignment for both paths
  - Verification that listings aren't demoted by missing parcel context

## Implementation Details

The listing path rewards measured data from Aqar (actual rent/area measurements, street width, images) while the parcel path remains conservative, capped at 70 to reflect inherent uncertainty in district-level enrichment. This allows high-confidence listings to achieve A grades based on data quality alone, independent of parcel-era context availability.

https://claude.ai/code/session_01Xg6wEJJ5ArfgXhZV8bok7J