### PR TITLE
Use first_seen_at instead of last_seen_at for listing freshness

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -1734,13 +1734,19 @@ def _confidence_score(
 def _listing_quality_score(
     *,
     is_listing: bool,
-    last_seen_at: datetime | None,
+    first_seen_at: datetime | None,
     is_furnished: bool | None,
     unit_restaurant_score: float | None,
     has_image: bool,
     has_drive_thru: bool | None = None,
 ) -> float:
     """Pure listing-quality score on a 0-100 scale.
+
+    Freshness is measured from first_seen_at — the date the listing
+    first appeared on Aqar. This is the listing's true age, not the
+    last time the scraper confirmed it was still live. A listing that
+    has been on Aqar for 9 months and is still being re-confirmed is
+    exactly the case we want to deprioritize.
 
     Distinct from _confidence_score (which measures whether the data is
     trustworthy). This measures whether the listing itself is a good
@@ -1751,7 +1757,8 @@ def _listing_quality_score(
     returns a neutral 50.
 
     Components:
-      - Freshness (40%): how recently seen on Aqar
+      - Freshness from first_seen_at (40%): how recently the listing
+        first appeared on Aqar (measures listing age, not scrape recency)
       - Aqar suitability (35%): the classifier's assessment
       - Image presence (15%): operator can visually verify
       - Furnished (10%): faster open, lower risk, lower fitout
@@ -1760,12 +1767,12 @@ def _listing_quality_score(
     if not is_listing:
         return 50.0
 
-    # Freshness band
-    if last_seen_at is None:
+    # Freshness band (based on listing age from first_seen_at)
+    if first_seen_at is None:
         freshness = 50.0
     else:
         try:
-            days = (datetime.utcnow() - last_seen_at).days
+            days = (datetime.utcnow() - first_seen_at).days
         except Exception:
             days = 30
         if days <= 14:
@@ -3626,6 +3633,7 @@ def _query_candidate_location_pool(
                 cl.profitability_score::float AS profitability_score,
                 -- Commercial unit signals (Tier 1 only, via LEFT JOIN)
                 cu.is_furnished AS unit_is_furnished,
+                cu.first_seen_at AS unit_first_seen_at,
                 cu.last_seen_at AS unit_last_seen_at,
                 cu.restaurant_score AS unit_restaurant_score,
                 cu.has_drive_thru AS unit_has_drive_thru,
@@ -3679,6 +3687,7 @@ def _query_candidate_location_pool(
             cl_platform_count,
             profitability_score,
             unit_is_furnished,
+            unit_first_seen_at,
             unit_last_seen_at,
             unit_restaurant_score,
             unit_has_drive_thru,
@@ -5112,7 +5121,7 @@ def run_expansion_search(
 
         listing_quality = _listing_quality_score(
             is_listing=_is_listing,
-            last_seen_at=row.get("unit_last_seen_at"),
+            first_seen_at=row.get("unit_first_seen_at"),
             is_furnished=row.get("unit_is_furnished"),
             unit_restaurant_score=_safe_float(row.get("unit_restaurant_score")) if row.get("unit_restaurant_score") is not None else None,
             has_image=bool(row.get("image_url")),
@@ -5743,7 +5752,7 @@ def run_expansion_search(
         )
         listing_quality = _listing_quality_score(
             is_listing=_is_listing,
-            last_seen_at=row.get("unit_last_seen_at"),
+            first_seen_at=row.get("unit_first_seen_at"),
             is_furnished=row.get("unit_is_furnished"),
             unit_restaurant_score=_safe_float(row.get("unit_restaurant_score")) if row.get("unit_restaurant_score") is not None else None,
             has_image=bool(row.get("image_url")),

--- a/tests/test_expansion_advisor_regression.py
+++ b/tests/test_expansion_advisor_regression.py
@@ -1030,7 +1030,7 @@ def test_listing_quality_parcel_returns_neutral_50():
     """Parcels (non-listings) should return a neutral 50."""
     score = _listing_quality_score(
         is_listing=False,
-        last_seen_at=None,
+        first_seen_at=None,
         is_furnished=None,
         unit_restaurant_score=None,
         has_image=False,
@@ -1042,7 +1042,7 @@ def test_listing_quality_fresh_full_data_high_score():
     """A fresh listing with full data should score close to 100."""
     score = _listing_quality_score(
         is_listing=True,
-        last_seen_at=datetime.utcnow() - timedelta(days=3),
+        first_seen_at=datetime.utcnow() - timedelta(days=3),
         is_furnished=True,
         unit_restaurant_score=90.0,
         has_image=True,
@@ -1056,7 +1056,7 @@ def test_listing_quality_stale_no_image_low_score():
     """A very stale listing without image should score below 50."""
     score = _listing_quality_score(
         is_listing=True,
-        last_seen_at=datetime.utcnow() - timedelta(days=400),
+        first_seen_at=datetime.utcnow() - timedelta(days=400),
         is_furnished=False,
         unit_restaurant_score=None,
         has_image=False,
@@ -1069,7 +1069,7 @@ def test_listing_quality_drive_thru_adds_5():
     """Drive-thru bonus should add exactly 5 points."""
     base = _listing_quality_score(
         is_listing=True,
-        last_seen_at=datetime.utcnow() - timedelta(days=10),
+        first_seen_at=datetime.utcnow() - timedelta(days=10),
         is_furnished=False,
         unit_restaurant_score=50.0,
         has_image=True,
@@ -1077,7 +1077,7 @@ def test_listing_quality_drive_thru_adds_5():
     )
     with_dt = _listing_quality_score(
         is_listing=True,
-        last_seen_at=datetime.utcnow() - timedelta(days=10),
+        first_seen_at=datetime.utcnow() - timedelta(days=10),
         is_furnished=False,
         unit_restaurant_score=50.0,
         has_image=True,


### PR DESCRIPTION
## Summary
Changed the listing quality scoring logic to measure freshness based on `first_seen_at` (when a listing first appeared on Aqar) instead of `last_seen_at` (when the scraper last confirmed it was live). This ensures that old listings being continuously re-confirmed are properly deprioritized.

## Key Changes
- **Function signature update**: `_listing_quality_score()` now accepts `first_seen_at` parameter instead of `last_seen_at`
- **SQL query changes**: Added `cu.first_seen_at AS unit_first_seen_at` to the candidate location pool query and included it in result mapping
- **Scoring logic**: Freshness calculation now uses `first_seen_at` to determine listing age rather than scrape recency
- **Documentation**: Updated docstring to clarify that freshness measures true listing age, not how recently the scraper confirmed it was still live
- **Test updates**: Updated all test cases to use `first_seen_at` parameter

## Implementation Details
The change addresses a key insight: a listing that has been on Aqar for 9 months but is still being re-confirmed by the scraper should be deprioritized as a stale opportunity, not treated as fresh. By using `first_seen_at`, the scoring now correctly reflects the actual age of the listing opportunity, making the freshness component (40% of the quality score) more meaningful for identifying genuinely new market opportunities.

https://claude.ai/code/session_012Hi3kGjNgC2KwAGDM3AnyA