### PR TITLE
Change Aqar scraper to run daily with staggered timing

### DIFF
--- a/.github/workflows/aqar-scraper.yml
+++ b/.github/workflows/aqar-scraper.yml
@@ -1,4 +1,4 @@
-name: Aqar Scraper (Manual)
+name: Aqar Scraper
 
 on:
   workflow_dispatch:
@@ -27,8 +27,10 @@ on:
           - warehouse
           - building
   schedule:
-    # Every Monday at 02:00 UTC (05:00 Riyadh time) — off-peak
-    - cron: '0 2 * * 1'
+    # Daily at 02:17 UTC (05:17 Riyadh time) — off-peak, with a 17-minute
+    # offset from the top of the hour to stagger against other cron jobs
+    # and avoid hammering Aqar at a predictable moment.
+    - cron: '17 2 * * *'
 
 concurrency:
   group: aqar-scraper

--- a/.github/workflows/candidate-locations-refresh.yml
+++ b/.github/workflows/candidate-locations-refresh.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
         default: true
   workflow_run:
-    workflows: ["Aqar Scraper (Manual)"]
+    workflows: ["Aqar Scraper"]
     types:
       - completed
     branches:


### PR DESCRIPTION
## Summary
Updated the Aqar scraper workflow to run daily instead of weekly, with a staggered start time to avoid predictable load spikes on the target service.

## Key Changes
- **Schedule frequency**: Changed from weekly (Mondays at 02:00 UTC) to daily at 02:17 UTC
- **Timing offset**: Added a 17-minute offset from the top of the hour to stagger execution against other cron jobs and avoid hammering Aqar at predictable moments
- **Workflow naming**: Removed "(Manual)" suffix from the workflow name for clarity
- **Dependent workflow**: Updated the candidate-locations-refresh workflow to reference the renamed Aqar scraper workflow

## Implementation Details
The new cron expression `17 2 * * *` runs the scraper daily at 02:17 UTC (05:17 Riyadh time), maintaining the off-peak execution window while distributing load more evenly across the day and reducing the likelihood of concurrent requests to the Aqar service.

https://claude.ai/code/session_01BwiBjHwEsYgTELZ4GYxDnA