### PR TITLE
Refine candidate location filtering for restaurant suitability

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -3708,9 +3708,11 @@ def _query_candidate_location_pool(
                         cl.id ASC
                 ) AS district_rank
             FROM candidate_location cl
-            LEFT JOIN commercial_unit cu
+            INNER JOIN commercial_unit cu
                    ON cl.source_tier = 1
                   AND cl.source_id = cu.aqar_id
+                  AND cu.restaurant_suitable = TRUE
+                  AND cu.listing_type IN ('store', 'showroom')
             WHERE cl.is_cluster_primary = TRUE
               AND cl.source_tier = 1
               AND cl.geom IS NOT NULL


### PR DESCRIPTION
## Summary
Updated the candidate location pool query to enforce stricter filtering criteria for commercial units, ensuring only restaurant-suitable locations with appropriate listing types are considered for expansion.

## Key Changes
- Changed `LEFT JOIN` to `INNER JOIN` for `commercial_unit` table to exclude locations without matching commercial unit records
- Added filter for `cu.restaurant_suitable = TRUE` to only include locations marked as suitable for restaurant operations
- Added filter for `cu.listing_type IN ('store', 'showroom')` to restrict results to relevant commercial property types

## Implementation Details
These additional join conditions ensure that the expansion advisor only evaluates candidate locations that meet both operational suitability requirements and property type criteria, improving the quality and relevance of location recommendations.

https://claude.ai/code/session_01C4Z81GYRcAB2oxi13MxAh3