### PR TITLE
Add psycopg2-binary dependency for SQLAlchemy PostgreSQL support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]>=0.30.0
 pydantic>=2.7.0
 SQLAlchemy>=2.0.29
 psycopg[binary,pool]>=3.1.18
+psycopg2-binary>=2.9  # required by SQLAlchemy postgresql:// dialect (used by backfill scripts in CI)
 alembic>=1.13.1
 httpx>=0.27.0
 python-dotenv>=1.0.1


### PR DESCRIPTION
## Summary
Added `psycopg2-binary>=2.9` to project dependencies to support SQLAlchemy's PostgreSQL dialect, which is required by backfill scripts used in CI.

## Changes
- Added `psycopg2-binary>=2.9` to `requirements.txt` with a comment explaining its purpose for CI backfill scripts

## Details
The `psycopg2-binary` package is required to enable SQLAlchemy's `postgresql://` URI scheme support. This dependency is specifically needed for backfill scripts that run in the CI/CD pipeline. While `psycopg` (the modern PostgreSQL adapter) is already included in the requirements, `psycopg2-binary` provides compatibility for the legacy PostgreSQL dialect URI scheme used by these scripts.

https://claude.ai/code/session_016fibK1uw4HoHLP11dPfrhp