### PR TITLE
Fix area parsing for Saudi deed-registry decimal-comma convention

### DIFF
--- a/.github/workflows/repair-bad-areas.yml
+++ b/.github/workflows/repair-bad-areas.yml
@@ -1,0 +1,54 @@
+name: Repair Bad Areas
+
+# Manual trigger ONLY — this workflow re-fetches Aqar listing pages to
+# re-parse area tokens corrupted by the pre-Patch-14 parser.  It must
+# NOT be wired to a workflow_run / cron trigger because it places a
+# courtesy load on Aqar's servers.  Run it by hand after Patch 14 ships
+# and re-run on-demand if the health-check soft warning from
+# deploy-sccc.yml ever surfaces a fresh regression.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (don't write to DB)"
+        required: false
+        default: "true"
+      limit:
+        description: "Max rows to process (hard ceiling is 100)"
+        required: false
+        default: ""
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Run repair script
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_SSLMODE: ${{ secrets.POSTGRES_SSLMODE }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ -n "${{ inputs.limit }}" ]; then
+            ARGS="$ARGS --limit ${{ inputs.limit }}"
+          fi
+          python scripts/repair_bad_areas.py $ARGS

--- a/scripts/repair_bad_areas.py
+++ b/scripts/repair_bad_areas.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Repair commercial_unit rows whose area_sqm was corrupted by the
+pre-Patch-14 Aqar area parser.
+
+Selects active store/showroom rows with implausible area_sqm, re-fetches
+each listing's HTML from the stored ``listing_url``, re-parses the area
+with the new disambiguator, and updates ``area_sqm`` in place if the new
+value is plausible AND different from the stored value.
+
+Marks repaired rows for selective LLM re-classification by clearing
+``llm_classified_at``, so the existing auto-backfill path picks them up
+on the next deploy and re-scores them with correct area context.
+
+Safety guardrails:
+
+  - Hard ceiling of 100 rows per invocation (``_HARD_ROW_CEILING``).
+  - 1-second delay between HTTP requests (``_REQUEST_DELAY_SEC``).
+  - ``--dry-run`` prints the planned repairs without touching the DB.
+  - Manual trigger only (no auto-fire on deploy) — this script re-fetches
+    Aqar pages and must not become a recurring load on their servers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+import requests
+from bs4 import BeautifulSoup
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from scripts.scrape_aqar import _AREA_RE, _parse_area_token
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+_HARD_ROW_CEILING = 100
+_REQUEST_DELAY_SEC = 1.0  # be polite to Aqar
+
+_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 "
+    "OaktreeAtlas-AreaRepair/1.0"
+)
+
+
+def _build_engine():
+    return create_engine(
+        f"postgresql://{os.environ['POSTGRES_USER']}:{os.environ['POSTGRES_PASSWORD']}"
+        f"@{os.environ['POSTGRES_HOST']}:{os.environ['POSTGRES_PORT']}"
+        f"/{os.environ['POSTGRES_DB']}",
+        connect_args={"sslmode": os.environ.get("POSTGRES_SSLMODE") or "require"},
+    )
+
+
+def _fetch_listing_html(url: str) -> str | None:
+    try:
+        r = requests.get(url, timeout=15, headers={"User-Agent": _USER_AGENT})
+        if r.status_code != 200:
+            logger.warning("Non-200 (%s) for %s", r.status_code, url)
+            return None
+        return r.text
+    except Exception as exc:  # pragma: no cover - network error path
+        logger.warning("Fetch failed for %s: %s", url, exc)
+        return None
+
+
+def _extract_detail_page_area_text(html: str) -> str | None:
+    """Pull a raw area token from an Aqar detail page.
+
+    The Aqar card DOM (which the scraper's ``_parse_listing_from_card``
+    already understands) reappears on the detail page in the Listing
+    Details panel: an ``<img src=".../area.svg">`` followed by a sibling
+    ``<span>`` containing a token like ``"120,205 m²"``.  We look for that
+    first, since the "Area" label also appears in the Info panel where
+    the value is rendered without the decimal separator (un-disambiguable).
+
+    Returns the raw token with the ``m²`` unit still attached, or None
+    if no area element was found.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Strategy 1: reuse the scraper's area.svg + sibling span convention.
+    for img_el in soup.find_all("img", src=True):
+        src = img_el.get("src", "")
+        if "area.svg" not in src:
+            continue
+        sibling = img_el.find_next("span")
+        if not sibling:
+            continue
+        span_text = sibling.get_text(strip=True)
+        if _AREA_RE.search(span_text):
+            return span_text
+
+    # Strategy 2: regex-scan the full page text for an "m²" token that
+    # looks like an area.  Last resort if the DOM structure shifted.
+    page_text = soup.get_text(" ", strip=True)
+    match = _AREA_RE.search(page_text)
+    if match:
+        return match.group(0)
+
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Repair commercial_unit rows with corrupted area_sqm values. "
+            "Re-fetches each listing's HTML and re-parses the area token "
+            "with the Patch-14 disambiguator."
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned repairs without writing to the DB.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of rows processed (still subject to hard ceiling).",
+    )
+    args = parser.parse_args()
+
+    engine = _build_engine()
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    rows = session.execute(
+        text(
+            """
+            SELECT aqar_id, listing_type, neighborhood, area_sqm, listing_url
+            FROM commercial_unit
+            WHERE status = 'active'
+              AND listing_type IN ('store', 'showroom')
+              AND (area_sqm > 1000 OR area_sqm < 5)
+              AND listing_url IS NOT NULL
+            ORDER BY area_sqm DESC NULLS LAST
+            """
+        )
+    ).mappings().all()
+
+    if args.limit is not None:
+        rows = rows[: args.limit]
+
+    if len(rows) > _HARD_ROW_CEILING:
+        logger.error(
+            "Refusing to process %d rows (ceiling %d). Use --limit to shrink the batch.",
+            len(rows),
+            _HARD_ROW_CEILING,
+        )
+        return 1
+
+    logger.info("Repairing %d rows (dry_run=%s)", len(rows), args.dry_run)
+
+    repaired = 0
+    skipped = 0
+    failed = 0
+
+    for row in rows:
+        aqar_id = row["aqar_id"]
+        old_area = float(row["area_sqm"]) if row["area_sqm"] is not None else None
+        url = row["listing_url"]
+        listing_type = row["listing_type"]
+
+        html = _fetch_listing_html(url)
+        if not html:
+            failed += 1
+            time.sleep(_REQUEST_DELAY_SEC)
+            continue
+
+        area_text = _extract_detail_page_area_text(html)
+        new_area = _parse_area_token(area_text, listing_type=listing_type)
+
+        if new_area is None:
+            logger.info(
+                "aqar_id=%s: parse returned None for raw=%r — skipping",
+                aqar_id,
+                area_text,
+            )
+            skipped += 1
+            time.sleep(_REQUEST_DELAY_SEC)
+            continue
+
+        if old_area is not None and abs(new_area - old_area) < 0.5:
+            logger.info(
+                "aqar_id=%s: new area %.3f matches existing — skipping",
+                aqar_id,
+                new_area,
+            )
+            skipped += 1
+            time.sleep(_REQUEST_DELAY_SEC)
+            continue
+
+        logger.info(
+            "aqar_id=%s: REPAIR area_sqm %.2f → %.3f (raw=%r, district=%s)",
+            aqar_id,
+            old_area if old_area is not None else 0.0,
+            new_area,
+            area_text,
+            row["neighborhood"],
+        )
+
+        if not args.dry_run:
+            session.execute(
+                text(
+                    """
+                    UPDATE commercial_unit
+                    SET area_sqm = :new_area,
+                        llm_classified_at = NULL,
+                        last_seen_at = now()
+                    WHERE aqar_id = :aqar_id
+                    """
+                ),
+                {"new_area": new_area, "aqar_id": aqar_id},
+            )
+            session.commit()
+
+        repaired += 1
+        time.sleep(_REQUEST_DELAY_SEC)
+
+    logger.info(
+        "Repair complete. repaired=%d skipped=%d failed=%d",
+        repaired,
+        skipped,
+        failed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scrape_aqar.py
+++ b/scripts/scrape_aqar.py
@@ -92,8 +92,94 @@ _CARD_HREF_RE = re.compile(r"(?:store|showroom|warehouse|building)-for-rent-(\d+
 _AREA_RE = re.compile(r"(\d+(?:[.,]\d+)?)\s*m²")
 _STREET_RE = re.compile(r"(\d+(?:[.,]\d+)?)\s*m\b")
 
+# Arabic-Indic to ASCII digit translation table, shared by helpers below.
+_ARABIC_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
 
-def _parse_listing_from_card(card_link, neighborhood: str) -> dict | None:
+# Plausibility bounds applied to store/showroom listings only. Real commercial
+# stores/showrooms on Aqar essentially never fall outside this range; anything
+# outside is almost certainly a parse corruption or a category miscoding.
+_AREA_MIN_SQM = 5.0
+_AREA_MAX_SQM = 5000.0
+
+
+def _parse_area_token(text: str | None, listing_type: str | None = None) -> float | None:
+    """Parse an Aqar area token like ``'120,205 m²'`` or ``'85.5 m²'``.
+
+    Aqar inherits the Saudi deed-registry convention where area is recorded
+    with millimeter precision (3 digits after the decimal) and rendered with
+    a comma as the decimal separator.  Plain comma-as-thousands parsing
+    produces 1000× area inflation on those rows.  Confirmed against listing
+    6294239: the page shows ``Area: 120,205 m²`` which is 120.205 m².
+
+    Disambiguation rules for store/showroom (and unknown types):
+
+      - Both ``','`` and ``'.'`` present → comma is thousands, period is decimal
+      - Comma only                      → comma is decimal separator (deed convention)
+      - Period only                     → period is decimal separator
+      - Neither                         → plain integer
+
+    For ``listing_type in ('building', 'warehouse')`` the population
+    legitimately contains real large-area listings with comma-as-thousands
+    separators, so this branch keeps the legacy behavior and skips the
+    plausibility guardrail (real buildings can be 8 000+ m²).  Those listing
+    types are enrichment-only per the listings-only architecture and not in
+    the F&B candidate pool, so this conservative branch carries no risk for
+    the Expansion Advisor.
+
+    For store/showroom, the parsed value is validated against
+    ``[_AREA_MIN_SQM, _AREA_MAX_SQM]``; out-of-range values are logged and
+    rejected (returns ``None``) so junk does not land in the DB.  Unknown
+    listing types get the new disambiguator but no plausibility guard.
+    """
+    if not text:
+        return None
+    text = text.translate(_ARABIC_DIGITS)
+    cleaned = re.sub(r"[^\d.,]", "", text)
+    if not cleaned:
+        return None
+
+    # building / warehouse → legacy thousands-separator behavior, no guard
+    if listing_type in ("building", "warehouse"):
+        try:
+            return float(cleaned.replace(",", ""))
+        except ValueError:
+            return None
+
+    has_comma = "," in cleaned
+    has_period = "." in cleaned
+    try:
+        if has_comma and has_period:
+            # Both present: comma is thousands, period is decimal (e.g., "1,200.50")
+            value = float(cleaned.replace(",", ""))
+        elif has_comma:
+            # Comma only: treat as decimal separator (Saudi deed convention)
+            value = float(cleaned.replace(",", "."))
+        else:
+            value = float(cleaned)
+    except ValueError:
+        return None
+
+    # Plausibility guardrail for store/showroom only.  Keeps junk out of the
+    # DB even if a future parser bug slips through; rejected values show up
+    # in the scraper logs so false rejections are recoverable.
+    if listing_type in ("store", "showroom"):
+        if value < _AREA_MIN_SQM or value > _AREA_MAX_SQM:
+            logger.warning(
+                "Rejected implausible area value %.3f for listing_type=%s (raw=%r)",
+                value,
+                listing_type,
+                text,
+            )
+            return None
+
+    return value
+
+
+def _parse_listing_from_card(
+    card_link,
+    neighborhood: str,
+    listing_type: str | None = None,
+) -> dict | None:
     """Parse a listing from an <a> card link matching the Aqar HTML structure.
 
     ``card_link`` is an <a> tag whose href contains ``store-for-rent-NNNN``.
@@ -133,9 +219,13 @@ def _parse_listing_from_card(card_link, neighborhood: str) -> dict | None:
         span_text = sibling.get_text(strip=True)
 
         if "area.svg" in src:
+            # Route the raw token through the decimal/thousands disambiguator
+            # so Saudi deed-convention rows like "120,205 m²" land as 120.205
+            # instead of 120 205.  Passing the known listing_type lets the
+            # helper keep legacy thousands behavior for building/warehouse.
             am = _AREA_RE.search(span_text)
             if am:
-                area_sqm = float(am.group(1).replace(",", ""))
+                area_sqm = _parse_area_token(am.group(0), listing_type=listing_type)
         elif "street.svg" in src:
             sm = _STREET_RE.search(span_text)
             if sm:
@@ -217,8 +307,20 @@ def _find_next_page_url(soup: BeautifulSoup, current_url: str) -> str | None:
     return href if href.startswith("http") else f"https://sa.aqar.fm{href}"
 
 
-def fetch_neighborhood_listings(neighborhood_url: str, neighborhood_name: str, max_pages: int = 10) -> list[dict]:
-    """Fetch all listing cards from a neighborhood page, following pagination."""
+def fetch_neighborhood_listings(
+    neighborhood_url: str,
+    neighborhood_name: str,
+    max_pages: int = 10,
+    listing_type: str | None = None,
+) -> list[dict]:
+    """Fetch all listing cards from a neighborhood page, following pagination.
+
+    ``listing_type`` is the canonical type key (``store`` / ``showroom`` /
+    ``building`` / ``warehouse``) from the caller's crawl configuration.  It
+    is threaded through so the card parser can branch the area token
+    disambiguator correctly — store/showroom use the decimal-comma rule,
+    building/warehouse keep the legacy thousands-separator behavior.
+    """
     all_listings = []
     url = neighborhood_url
     seen_ids: set[str] = set()
@@ -237,7 +339,9 @@ def fetch_neighborhood_listings(neighborhood_url: str, neighborhood_name: str, m
         soup = BeautifulSoup(html, "html.parser")
         card_links = soup.find_all("a", href=_CARD_HREF_RE)
         for card_link in card_links:
-            parsed = _parse_listing_from_card(card_link, neighborhood_name)
+            parsed = _parse_listing_from_card(
+                card_link, neighborhood_name, listing_type=listing_type
+            )
             if parsed and parsed["aqar_id"] not in seen_ids:
                 seen_ids.add(parsed["aqar_id"])
                 listings_on_page.append(parsed)
@@ -1332,7 +1436,12 @@ def main():
                     if j > 0 or i > 0:
                         time.sleep(2)
                     print(f"\n  --- Crawling: {nbr['neighborhood']} ---")
-                    listings = fetch_neighborhood_listings(nbr["url"], nbr["neighborhood"], max_pages=args.max_pages)
+                    listings = fetch_neighborhood_listings(
+                        nbr["url"],
+                        nbr["neighborhood"],
+                        max_pages=args.max_pages,
+                        listing_type=type_key,
+                    )
                     print(f"  Found {len(listings)} listings")
 
                     geo = geo_cache.get(nbr["neighborhood"])
@@ -1393,7 +1502,12 @@ def main():
                     listing_type, type_total_from_areas, city_url,
                 )
                 try:
-                    city_listings = fetch_neighborhood_listings(city_url, "Riyadh", max_pages=args.max_pages)
+                    city_listings = fetch_neighborhood_listings(
+                        city_url,
+                        "Riyadh",
+                        max_pages=args.max_pages,
+                        listing_type=type_key,
+                    )
                 except Exception as e:
                     logger.warning(
                         "City-level fallback failed for %s (%s): %s — skipping",

--- a/tests/test_scrape_aqar.py
+++ b/tests/test_scrape_aqar.py
@@ -1,0 +1,141 @@
+"""Tests for scripts/scrape_aqar.py parser helpers.
+
+Focused on the area-token disambiguator that handles Aqar's Saudi
+deed-registry decimal-comma convention. Every previously-failing input
+from the production diagnostic query becomes a test case here.
+"""
+
+import logging
+
+import pytest
+
+from scripts.scrape_aqar import _parse_area_token
+
+
+class TestParseAreaTokenDecimalComma:
+    """Saudi deed-registry convention: comma is the decimal separator.
+
+    Listings render areas like ``120,205 m²`` — that is **120.205 m²**,
+    not 120 205 m². Pre-Patch-14 parsing treated comma as thousands and
+    produced 1000× inflated values.
+    """
+
+    def test_listing_6294239_real_failing_case(self):
+        # Listing 6294239 page: "Area: 120,205 m²" → 120.205 m²
+        assert _parse_area_token("120,205 m²", listing_type="store") == pytest.approx(
+            120.205
+        )
+
+    def test_all_failing_rows_from_diagnostic(self):
+        # Every row from the production diagnostic query gets pinned here.
+        cases = [
+            ("28,580 m²", 28.580),
+            ("22,376 m²", 22.376),
+            ("22,108 m²", 22.108),
+            ("16,446 m²", 16.446),
+            ("16,205 m²", 16.205),
+            ("14,285 m²", 14.285),
+        ]
+        for raw, expected in cases:
+            assert _parse_area_token(raw, listing_type="store") == pytest.approx(
+                expected
+            ), f"{raw!r} did not parse to {expected}"
+
+
+class TestParseAreaTokenPeriodDecimal:
+    def test_simple_period_decimal(self):
+        assert _parse_area_token("85.5 m²", listing_type="store") == pytest.approx(85.5)
+
+    def test_period_decimal_three_digits(self):
+        assert _parse_area_token("120.205 m²", listing_type="store") == pytest.approx(
+            120.205
+        )
+
+
+class TestParseAreaTokenPlainInteger:
+    def test_plain_integers(self):
+        assert _parse_area_token("60 m²", listing_type="store") == 60.0
+        assert _parse_area_token("200 m²", listing_type="store") == 200.0
+        assert _parse_area_token("450 m²", listing_type="showroom") == 450.0
+
+
+class TestParseAreaTokenArabicNumerals:
+    def test_plain_arabic_integer(self):
+        # ٦٠ متر مربع → 60 m²
+        assert _parse_area_token("٦٠ متر مربع", listing_type="store") == 60.0
+
+    def test_arabic_decimal_comma(self):
+        # Mixed Arabic decimal-comma: ١٢٠,٢٠٥
+        assert _parse_area_token(
+            "١٢٠,٢٠٥ متر مربع", listing_type="store"
+        ) == pytest.approx(120.205)
+
+    def test_arabic_decimal_period(self):
+        # ٨٥.٥ → 85.5
+        assert _parse_area_token(
+            "٨٥.٥ متر مربع", listing_type="store"
+        ) == pytest.approx(85.5)
+
+
+class TestParseAreaTokenBuildingWarehouseLegacy:
+    """For building/warehouse the population legitimately uses
+    comma-as-thousands, so the parser keeps the legacy behavior AND
+    skips the plausibility guardrail (real buildings can be 8 000+ m²).
+    """
+
+    def test_building_comma_is_thousands(self):
+        assert _parse_area_token("1,200 m²", listing_type="building") == 1200.0
+
+    def test_warehouse_comma_is_thousands(self):
+        assert _parse_area_token("2,500 m²", listing_type="warehouse") == 2500.0
+
+    def test_building_large_area_passes(self):
+        # Real buildings can exceed the store/showroom plausibility ceiling.
+        assert _parse_area_token("8,000 m²", listing_type="building") == 8000.0
+        assert _parse_area_token("12,500 m²", listing_type="warehouse") == 12500.0
+
+    def test_building_both_comma_and_period(self):
+        # "1,200.50 m²" on a building = 1200.50 m² (comma thousands, period decimal).
+        assert _parse_area_token(
+            "1,200.50 m²", listing_type="building"
+        ) == pytest.approx(1200.50)
+
+
+class TestParseAreaTokenPlausibilityGuard:
+    """Plausibility guardrail rejects junk values for store/showroom.
+
+    Rejected values emit a warning log line and return None so the caller
+    leaves ``area_sqm`` NULL rather than corrupting the DB.
+    """
+
+    def test_implausibly_large_store(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="scripts.scrape_aqar"):
+            assert _parse_area_token("99999 m²", listing_type="store") is None
+        assert any("Rejected implausible area" in rec.message for rec in caplog.records)
+
+    def test_implausibly_small_store(self):
+        assert _parse_area_token("2 m²", listing_type="store") is None
+
+    def test_implausibly_large_showroom(self):
+        assert _parse_area_token("8000 m²", listing_type="showroom") is None
+
+    def test_building_bypasses_plausibility(self):
+        # Same literal value that's rejected for store is accepted for building.
+        assert _parse_area_token("8000 m²", listing_type="building") == 8000.0
+
+
+class TestParseAreaTokenEmptyOrGarbage:
+    def test_none_input(self):
+        assert _parse_area_token(None) is None
+
+    def test_empty_string(self):
+        assert _parse_area_token("") is None
+
+    def test_non_numeric_garbage(self):
+        assert _parse_area_token("not a number") is None
+
+    def test_only_unit(self):
+        assert _parse_area_token("m²") is None
+
+    def test_only_unit_with_whitespace(self):
+        assert _parse_area_token("  m²  ") is None


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the Aqar area parser that was inflating area values by ~1000× for listings using Saudi deed-registry convention (comma as decimal separator). It introduces a new disambiguator function, a repair script for corrupted historical data, and comprehensive test coverage.

## Key Changes

- **New `_parse_area_token()` helper** in `scripts/scrape_aqar.py`:
  - Disambiguates between comma-as-decimal (Saudi deed convention) and comma-as-thousands separators
  - Handles Arabic-Indic numerals via translation table
  - Applies plausibility guardrails for store/showroom (5–5000 m²) to prevent junk from entering the DB
  - Preserves legacy thousands-separator behavior for building/warehouse types (which legitimately have large areas)
  - Returns `None` for out-of-range values so they don't corrupt the database

- **Updated `_parse_listing_from_card()` and `fetch_neighborhood_listings()`**:
  - Thread `listing_type` parameter through the call chain so the parser can apply type-specific rules
  - Route area tokens through the new disambiguator instead of naive `replace(",", "")`

- **New repair script** (`scripts/repair_bad_areas.py`):
  - Identifies active store/showroom rows with implausible area values (>1000 or <5 m²)
  - Re-fetches each listing's HTML from stored `listing_url`
  - Re-parses area with the new disambiguator
  - Updates `area_sqm` and clears `llm_classified_at` to trigger LLM re-classification on next deploy
  - Safety guardrails: hard ceiling of 100 rows, 1-second request delay, `--dry-run` mode, manual trigger only

- **GitHub Actions workflow** (`repair-bad-areas.yml`):
  - Manual dispatch only (no auto-fire) to avoid recurring load on Aqar servers
  - Configurable `--dry-run` and `--limit` parameters

- **Comprehensive test suite** (`tests/test_scrape_aqar.py`):
  - Pins all failing cases from production diagnostic query (e.g., "120,205 m²" → 120.205 m²)
  - Tests decimal-comma, period-decimal, plain integer, and Arabic-numeral variants
  - Validates plausibility guardrails and legacy building/warehouse behavior
  - Tests edge cases (None, empty string, garbage input)

## Implementation Details

- **Decimal/thousands disambiguation logic**: If both comma and period are present, comma is thousands and period is decimal (e.g., "1,200.50" → 1200.50). If only comma, it's treated as decimal (deed convention). If only period or neither, standard parsing applies.
- **Plausibility bounds**: Store/showroom listings outside [5, 5000] m² are rejected with a warning log; building/warehouse bypass this check entirely.
- **Repair workflow**: Marks repaired rows by clearing `llm_classified_at` so the existing auto-backfill path picks them up and re-scores them with correct area context.
- **Request politeness**: 1-second delay between HTTP fetches and explicit User-Agent header to respect Aqar's servers.

https://claude.ai/code/session_011LBsjGEpEA1pjZTEjem8Cv