### PR TITLE
Fix area parsing to disambiguate comma usage in Aqar listings

### DIFF
--- a/scripts/scrape_aqar.py
+++ b/scripts/scrape_aqar.py
@@ -103,20 +103,38 @@ _AREA_MAX_SQM = 5000.0
 
 
 def _parse_area_token(text: str | None, listing_type: str | None = None) -> float | None:
-    """Parse an Aqar area token like ``'120,205 m²'`` or ``'85.5 m²'``.
+    """Parse an Aqar area token like ``'120,205 m²'`` or ``'5,000 m²'``.
 
-    Aqar inherits the Saudi deed-registry convention where area is recorded
-    with millimeter precision (3 digits after the decimal) and rendered with
-    a comma as the decimal separator.  Plain comma-as-thousands parsing
-    produces 1000× area inflation on those rows.  Confirmed against listing
-    6294239: the page shows ``Area: 120,205 m²`` which is 120.205 m².
+    Aqar uses commas in area tokens in **two mutually incompatible ways**
+    with identical syntax:
 
-    Disambiguation rules for store/showroom (and unknown types):
+      1. **Thousands separator** — e.g. ``"5,000 m²"`` = 5000 m² (a real
+         large store).
+      2. **Decimal separator** (Saudi deed-registry convention, 3 digits
+         after the decimal) — e.g. ``"120,205 m²"`` = 120.205 m². Confirmed
+         against listing 6294239.
+
+    Punctuation alone cannot distinguish the two. The Patch-14 dry-run
+    proved the earlier "comma only → decimal" rule was wrong: it correctly
+    fixed the 120,205-class rows but then corrupted the 5,000-class rows
+    (real large stores) into 5.0 m² entries.
+
+    Disambiguation rule for store/showroom (and unknown types):
 
       - Both ``','`` and ``'.'`` present → comma is thousands, period is decimal
-      - Comma only                      → comma is decimal separator (deed convention)
-      - Period only                     → period is decimal separator
-      - Neither                         → plain integer
+      - Comma only → **prefer thousands**; fall back to decimal **only** if
+        the thousands interpretation is implausibly large for the listing
+        type (i.e. > ``_AREA_MAX_SQM``)
+      - Period only → period is decimal separator
+      - Neither → plain integer
+
+    Worked examples under the new rule:
+
+      - ``"5,000 m²"``   → thousands=5000 (≤5000) → **5000.0** ✓ real store
+      - ``"4,500 m²"``   → thousands=4500 (≤5000) → **4500.0** ✓ real store
+      - ``"1,200 m²"``   → thousands=1200 (≤5000) → **1200.0** ✓ real store
+      - ``"120,205 m²"`` → thousands=120205 (>5000) → decimal=**120.205** ✓ deed
+      - ``"28,580 m²"``  → thousands=28580  (>5000) → decimal=**28.580**  ✓ deed
 
     For ``listing_type in ('building', 'warehouse')`` the population
     legitimately contains real large-area listings with comma-as-thousands
@@ -129,7 +147,9 @@ def _parse_area_token(text: str | None, listing_type: str | None = None) -> floa
     For store/showroom, the parsed value is validated against
     ``[_AREA_MIN_SQM, _AREA_MAX_SQM]``; out-of-range values are logged and
     rejected (returns ``None``) so junk does not land in the DB.  Unknown
-    listing types get the new disambiguator but no plausibility guard.
+    listing types get the same disambiguator (using the store/showroom
+    ceiling as a heuristic, since that's Aqar's dominant comma-token
+    population) but no final plausibility guard.
     """
     if not text:
         return None
@@ -152,8 +172,17 @@ def _parse_area_token(text: str | None, listing_type: str | None = None) -> floa
             # Both present: comma is thousands, period is decimal (e.g., "1,200.50")
             value = float(cleaned.replace(",", ""))
         elif has_comma:
-            # Comma only: treat as decimal separator (Saudi deed convention)
-            value = float(cleaned.replace(",", "."))
+            # Comma-only is ambiguous: the same "N,NNN m²" syntax is used
+            # both for plain thousands ("5,000 m²" = 5000) and for the
+            # Saudi deed-registry decimal-comma convention ("120,205 m²"
+            # = 120.205). Disambiguate by plausibility — prefer the
+            # thousands interpretation, fall back to decimal only if
+            # thousands is implausibly large for a store/showroom.
+            thousands_value = float(cleaned.replace(",", ""))
+            if thousands_value <= _AREA_MAX_SQM:
+                value = thousands_value
+            else:
+                value = float(cleaned.replace(",", "."))
         else:
             value = float(cleaned)
     except ValueError:

--- a/tests/test_scrape_aqar.py
+++ b/tests/test_scrape_aqar.py
@@ -1,8 +1,15 @@
 """Tests for scripts/scrape_aqar.py parser helpers.
 
-Focused on the area-token disambiguator that handles Aqar's Saudi
-deed-registry decimal-comma convention. Every previously-failing input
-from the production diagnostic query becomes a test case here.
+Focused on the area-token disambiguator that handles Aqar's ambiguous
+comma usage. Aqar renders areas with commas in two mutually incompatible
+ways using identical syntax:
+
+  - Thousands separator: ``"5,000 m²"`` = 5000 m² (real large store)
+  - Saudi deed-registry decimal-comma: ``"120,205 m²"`` = 120.205 m²
+
+The disambiguator uses plausibility to pick the right interpretation:
+prefer thousands; fall back to decimal only when the thousands value is
+implausibly large for a store/showroom.
 """
 
 import logging
@@ -17,7 +24,9 @@ class TestParseAreaTokenDecimalComma:
 
     Listings render areas like ``120,205 m²`` — that is **120.205 m²**,
     not 120 205 m². Pre-Patch-14 parsing treated comma as thousands and
-    produced 1000× inflated values.
+    produced 1000× inflated values. The disambiguator falls back to the
+    decimal interpretation here because the thousands reading (120205)
+    is far outside the store/showroom plausibility ceiling.
     """
 
     def test_listing_6294239_real_failing_case(self):
@@ -28,6 +37,8 @@ class TestParseAreaTokenDecimalComma:
 
     def test_all_failing_rows_from_diagnostic(self):
         # Every row from the production diagnostic query gets pinned here.
+        # Each thousands reading (28580, 22376, ...) is > _AREA_MAX_SQM
+        # so the disambiguator falls back to decimal.
         cases = [
             ("28,580 m²", 28.580),
             ("22,376 m²", 22.376),
@@ -40,6 +51,42 @@ class TestParseAreaTokenDecimalComma:
             assert _parse_area_token(raw, listing_type="store") == pytest.approx(
                 expected
             ), f"{raw!r} did not parse to {expected}"
+
+
+class TestParseAreaTokenThousandsComma:
+    """Plain thousands separator: comma groups the integer part.
+
+    These inputs have the same ``N,NNN m²`` shape as the deed-convention
+    cases above, but the thousands reading is plausible for a real large
+    store, so the disambiguator sticks with thousands. This is the
+    regression guard for the bug the Patch-14 dry-run surfaced: the
+    earlier "comma only → decimal" rule corrupted these into 5.0-class
+    values.
+    """
+
+    def test_store_five_thousand(self):
+        # "5,000 m²" is a real large store, not 5.0 m². thousands=5000 is
+        # exactly at the plausibility ceiling → use thousands.
+        assert _parse_area_token("5,000 m²", listing_type="store") == 5000.0
+
+    def test_store_forty_five_hundred(self):
+        assert _parse_area_token("4,500 m²", listing_type="store") == 4500.0
+
+    def test_store_twelve_hundred(self):
+        assert _parse_area_token("1,200 m²", listing_type="store") == 1200.0
+
+    def test_showroom_thousands_separator(self):
+        # Same rule applies to showrooms.
+        assert _parse_area_token("3,000 m²", listing_type="showroom") == 3000.0
+        assert _parse_area_token("2,500 m²", listing_type="showroom") == 2500.0
+
+    def test_thousands_boundary_exact_ceiling(self):
+        # Exactly at the ceiling stays as thousands.
+        assert _parse_area_token("5,000 m²", listing_type="store") == 5000.0
+
+    def test_just_over_ceiling_falls_back_to_decimal(self):
+        # "5,500 m²" thousands=5500 > 5000 → decimal=5.5 (plausible for store).
+        assert _parse_area_token("5,500 m²", listing_type="store") == pytest.approx(5.5)
 
 
 class TestParseAreaTokenPeriodDecimal:


### PR DESCRIPTION
## Summary

Fix a critical bug in area token parsing that was corrupting real large store listings. Aqar uses commas in area tokens in two mutually incompatible ways with identical syntax: as thousands separators (e.g., "5,000 m²" = 5000 m²) and as decimal separators per Saudi deed-registry convention (e.g., "120,205 m²" = 120.205 m²). The previous implementation treated all comma-only cases as decimals, which correctly handled deed-convention cases but corrupted real large stores into implausibly small values (e.g., "5,000 m²" → 5.0 m²).

## Key Changes

- **Implemented plausibility-based disambiguation**: For comma-only area tokens, prefer the thousands interpretation but fall back to decimal only when the thousands value exceeds `_AREA_MAX_SQM` (5000 m² for stores/showrooms), which is implausibly large for those listing types.

- **Updated parsing logic**: Modified `_parse_area_token()` to evaluate both interpretations and select based on plausibility rather than syntax alone.

- **Comprehensive documentation**: Expanded docstring with detailed explanation of the ambiguity, the new rule, and worked examples showing both cases (deed-convention and thousands-separator).

- **Added regression tests**: Created `TestParseAreaTokenThousandsComma` class with test cases covering the thousands-separator cases that were being corrupted (5,000 m², 4,500 m², 1,200 m², etc.) and boundary conditions.

- **Updated test documentation**: Clarified test module docstring to explain the dual-interpretation problem and the plausibility-based solution.

## Implementation Details

The disambiguator now:
1. Checks if both comma and period are present → comma is thousands, period is decimal
2. If comma only → tries thousands interpretation first; if result ≤ `_AREA_MAX_SQM`, uses it; otherwise falls back to decimal interpretation
3. If period only → uses period as decimal
4. If neither → parses as plain integer

This approach preserves the fix for deed-convention cases (120,205 → 120.205) while restoring correct parsing for real large stores (5,000 → 5000.0).

https://claude.ai/code/session_01HgfErsezK2BxDVEqjXh2ro