### PR TITLE
Patch 14b: Stricter area parsing with telemetry and legacy cleanup

### DIFF
--- a/.github/workflows/quarantine-legacy-areas.yml
+++ b/.github/workflows/quarantine-legacy-areas.yml
@@ -1,0 +1,44 @@
+name: Quarantine Legacy Bad Areas
+
+# Manual trigger ONLY. This is a one-time cleanup for pre-Patch-14
+# corrupted areas. Future contamination is prevented by Patch 14b's
+# parser changes, not by this workflow.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (don't write to DB)"
+        required: false
+        default: "true"
+      restore:
+        description: "Restore: flip quarantined_area rows back to active"
+        required: false
+        default: "false"
+
+jobs:
+  quarantine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - name: Run quarantine script
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_SSLMODE: ${{ secrets.POSTGRES_SSLMODE }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "false" ]; then
+            ARGS="$ARGS --no-dry-run"
+          fi
+          if [ "${{ inputs.restore }}" = "true" ]; then
+            ARGS="$ARGS --restore"
+          fi
+          python scripts/quarantine_legacy_corrupt_areas.py $ARGS

--- a/scripts/quarantine_legacy_corrupt_areas.py
+++ b/scripts/quarantine_legacy_corrupt_areas.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""One-time quarantine of legacy area-corrupted commercial_unit rows.
+
+Identifies rows in the active pool whose area_sqm is implausible for
+a store/showroom listing — almost certainly the result of pre-Patch-14
+decimal-comma parser corruption — and flips their status from 'active'
+to 'quarantined_area'. The Expansion Advisor JOIN clause already
+filters status = 'active' so quarantined rows disappear from the
+candidate pool automatically.
+
+This script does NOT re-fetch any pages. It does NOT try to guess the
+correct area. It only removes rows from the active pool so the LLM
+stops reasoning about hallucinated values.
+
+Quarantine criteria (store/showroom only):
+  - area_sqm > 10000 (16 rows expected based on Q32 audit)
+  - area_sqm < 5     (1 row expected based on Q32 audit)
+
+Total expected: ~17 rows touched.
+
+Reversible: re-running with --restore flips quarantined_area rows back
+to active. Use this if a future investigation shows a quarantined row
+was actually correct.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+_HARD_ROW_CEILING = 100  # Safety guard — never quarantine more than this in one run
+
+_QUARANTINE_STATUS = "quarantined_area"
+
+
+def _build_engine():
+    return create_engine(
+        f"postgresql://{os.environ['POSTGRES_USER']}:{os.environ['POSTGRES_PASSWORD']}"
+        f"@{os.environ['POSTGRES_HOST']}:{os.environ['POSTGRES_PORT']}"
+        f"/{os.environ['POSTGRES_DB']}",
+        connect_args={"sslmode": os.environ.get("POSTGRES_SSLMODE") or "require"},
+    )
+
+
+def _quarantine(session, dry_run: bool) -> int:
+    rows = session.execute(text(
+        """
+        SELECT aqar_id, listing_type, neighborhood, area_sqm
+        FROM commercial_unit
+        WHERE status = 'active'
+          AND listing_type IN ('store', 'showroom')
+          AND (area_sqm > 10000 OR area_sqm < 5)
+        ORDER BY area_sqm DESC NULLS LAST
+        """
+    )).mappings().all()
+
+    if len(rows) > _HARD_ROW_CEILING:
+        logger.error(
+            "Refusing to quarantine %d rows (ceiling %d)", len(rows), _HARD_ROW_CEILING
+        )
+        return 1
+
+    logger.info("Quarantining %d rows (dry_run=%s)", len(rows), dry_run)
+    for row in rows:
+        logger.info(
+            "QUARANTINE aqar_id=%s area_sqm=%s listing_type=%s neighborhood=%s",
+            row["aqar_id"], row["area_sqm"], row["listing_type"], row["neighborhood"],
+        )
+
+    if not dry_run:
+        session.execute(text(
+            f"""
+            UPDATE commercial_unit
+            SET status = '{_QUARANTINE_STATUS}',
+                last_seen_at = now()
+            WHERE status = 'active'
+              AND listing_type IN ('store', 'showroom')
+              AND (area_sqm > 10000 OR area_sqm < 5)
+            """
+        ))
+        session.commit()
+        logger.info("Committed %d quarantine flips", len(rows))
+    return 0
+
+
+def _restore(session, dry_run: bool) -> int:
+    rows = session.execute(text(
+        f"""
+        SELECT aqar_id, listing_type, neighborhood, area_sqm
+        FROM commercial_unit
+        WHERE status = '{_QUARANTINE_STATUS}'
+        """
+    )).mappings().all()
+    logger.info("Restoring %d quarantined rows (dry_run=%s)", len(rows), dry_run)
+    for row in rows:
+        logger.info(
+            "RESTORE aqar_id=%s area_sqm=%s",
+            row["aqar_id"], row["area_sqm"],
+        )
+    if not dry_run:
+        session.execute(text(
+            f"""
+            UPDATE commercial_unit
+            SET status = 'active', last_seen_at = now()
+            WHERE status = '{_QUARANTINE_STATUS}'
+            """
+        ))
+        session.commit()
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", default=True,
+                        help="Print planned changes without writing (default)")
+    parser.add_argument("--no-dry-run", dest="dry_run", action="store_false",
+                        help="Actually write changes to the DB")
+    parser.add_argument("--restore", action="store_true",
+                        help="Reverse: flip quarantined_area back to active")
+    args = parser.parse_args()
+
+    engine = _build_engine()
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    if args.restore:
+        return _restore(session, args.dry_run)
+    return _quarantine(session, args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scrape_aqar.py
+++ b/scripts/scrape_aqar.py
@@ -100,6 +100,63 @@ _ARABIC_DIGITS = str.maketrans("٠١٢٣٤٥٦٧٨٩", "0123456789")
 # outside is almost certainly a parse corruption or a category miscoding.
 _AREA_MIN_SQM = 5.0
 _AREA_MAX_SQM = 5000.0
+# Stricter floor applied ONLY on the decimal-fallback path. The general
+# _AREA_MIN_SQM stays at 5.0 because real Aqar listings can legitimately
+# show very small areas (souk kiosks, market stalls) when not coming
+# through the comma disambiguator. The fallback path is different — by
+# the time we land there, we already know the source token had a comma
+# AND the thousands interpretation was too large, which is strong
+# evidence of decimal-comma corruption. A stricter floor catches the
+# 14-class decimal results from sources like "14,285 m²" without
+# affecting any non-fallback parsing.
+_AREA_FALLBACK_MIN_SQM = 20.0
+
+
+# Telemetry counters for area parsing reliability. Reset at the start
+# of each scrape via _reset_area_parse_telemetry().
+_area_parse_stats = {
+    "attempted": 0,
+    "succeeded": 0,
+    "rejected_multi_separator": 0,
+    "rejected_decimal_fallback_too_small": 0,
+    "rejected_plausibility_floor": 0,
+    "rejected_plausibility_ceiling": 0,
+    "rejected_unparseable": 0,
+}
+
+
+def _reset_area_parse_telemetry() -> None:
+    for k in _area_parse_stats:
+        _area_parse_stats[k] = 0
+
+
+def _log_area_parse_telemetry() -> None:
+    """Log the area parser's success/failure counts and emit a WARNING
+    if the rejection rate exceeds 5% of attempted parses.
+    """
+    attempted = _area_parse_stats["attempted"]
+    if attempted == 0:
+        logger.info("Area parser telemetry: no parses attempted")
+        return
+    succeeded = _area_parse_stats["succeeded"]
+    rejected = attempted - succeeded
+    rejection_rate = (rejected / attempted) * 100.0
+    summary = (
+        "Area parser telemetry: attempted=%d succeeded=%d rejected=%d "
+        "(%.1f%%) — multi_separator=%d fallback_too_small=%d "
+        "plausibility_floor=%d plausibility_ceiling=%d unparseable=%d"
+    ) % (
+        attempted, succeeded, rejected, rejection_rate,
+        _area_parse_stats["rejected_multi_separator"],
+        _area_parse_stats["rejected_decimal_fallback_too_small"],
+        _area_parse_stats["rejected_plausibility_floor"],
+        _area_parse_stats["rejected_plausibility_ceiling"],
+        _area_parse_stats["rejected_unparseable"],
+    )
+    if rejection_rate > 5.0:
+        logger.warning("HIGH AREA PARSE REJECTION RATE: %s", summary)
+    else:
+        logger.info(summary)
 
 
 def _parse_area_token(text: str | None, listing_type: str | None = None) -> float | None:
@@ -158,12 +215,43 @@ def _parse_area_token(text: str | None, listing_type: str | None = None) -> floa
     if not cleaned:
         return None
 
+    # Count as an attempted parse once we know we have something to parse.
+    _area_parse_stats["attempted"] += 1
+
+    # Multi-separator reject: catches source-data corruption like
+    # "5,028,580 m²" (real case from listing 6550938) where the area token
+    # has multiple commas glued together in a way that's neither a clean
+    # thousands separator nor a clean decimal-comma. The only legitimate
+    # multi-separator pattern is the international thousands+decimal form
+    # (exactly one comma, exactly one period, in that order), which the
+    # disambiguator already handles correctly downstream.
+    comma_count = cleaned.count(",")
+    period_count = cleaned.count(".")
+    total_separators = comma_count + period_count
+    if total_separators > 1:
+        legit_thousands_decimal = (
+            comma_count == 1
+            and period_count == 1
+            and cleaned.index(",") < cleaned.index(".")
+        )
+        if not legit_thousands_decimal:
+            _area_parse_stats["rejected_multi_separator"] += 1
+            logger.warning(
+                "Rejected multi-separator area %r for listing_type=%s "
+                "(commas=%d, periods=%d)",
+                text, listing_type, comma_count, period_count,
+            )
+            return None
+
     # building / warehouse → legacy thousands-separator behavior, no guard
     if listing_type in ("building", "warehouse"):
         try:
-            return float(cleaned.replace(",", ""))
+            result = float(cleaned.replace(",", ""))
         except ValueError:
+            _area_parse_stats["rejected_unparseable"] += 1
             return None
+        _area_parse_stats["succeeded"] += 1
+        return result
 
     has_comma = "," in cleaned
     has_period = "." in cleaned
@@ -182,17 +270,44 @@ def _parse_area_token(text: str | None, listing_type: str | None = None) -> floa
             if thousands_value <= _AREA_MAX_SQM:
                 value = thousands_value
             else:
-                value = float(cleaned.replace(",", "."))
+                # Decimal-fallback path. Apply a STRICTER floor than the
+                # general _AREA_MIN_SQM because anything reaching this
+                # branch is an interpretation we have lower confidence
+                # in (the thousands reading was implausibly large,
+                # suggesting deed-convention decimal-comma — but a
+                # 14.285 m² store is still nonsense and almost certainly
+                # contamination, not a real kiosk).
+                decimal_value = float(cleaned.replace(",", "."))
+                if decimal_value < _AREA_FALLBACK_MIN_SQM:
+                    _area_parse_stats["rejected_decimal_fallback_too_small"] += 1
+                    logger.warning(
+                        "Rejected implausible decimal-fallback area %.3f "
+                        "for listing_type=%s (raw=%r, thousands=%.0f)",
+                        decimal_value, listing_type, text, thousands_value,
+                    )
+                    return None
+                value = decimal_value
         else:
             value = float(cleaned)
     except ValueError:
+        _area_parse_stats["rejected_unparseable"] += 1
         return None
 
     # Plausibility guardrail for store/showroom only.  Keeps junk out of the
     # DB even if a future parser bug slips through; rejected values show up
     # in the scraper logs so false rejections are recoverable.
     if listing_type in ("store", "showroom"):
-        if value < _AREA_MIN_SQM or value > _AREA_MAX_SQM:
+        if value < _AREA_MIN_SQM:
+            _area_parse_stats["rejected_plausibility_floor"] += 1
+            logger.warning(
+                "Rejected implausible area value %.3f for listing_type=%s (raw=%r)",
+                value,
+                listing_type,
+                text,
+            )
+            return None
+        if value > _AREA_MAX_SQM:
+            _area_parse_stats["rejected_plausibility_ceiling"] += 1
             logger.warning(
                 "Rejected implausible area value %.3f for listing_type=%s (raw=%r)",
                 value,
@@ -201,6 +316,7 @@ def _parse_area_token(text: str | None, listing_type: str | None = None) -> floa
             )
             return None
 
+    _area_parse_stats["succeeded"] += 1
     return value
 
 
@@ -1395,6 +1511,10 @@ def main():
     )
     args = parser.parse_args()
 
+    # Reset area-parser telemetry at the start of each run so the
+    # end-of-run summary reflects only this scrape's counts.
+    _reset_area_parse_telemetry()
+
     api_key = os.environ.get("GOOGLE_MAPS_API_KEY", "")
     do_geocode = not args.skip_geocode and bool(api_key)
     if not args.skip_geocode and not api_key:
@@ -1501,6 +1621,20 @@ def main():
                         # Compute price_per_sqm
                         listing["price_per_sqm"] = _compute_price_per_sqm(listing)
 
+                        # Skip rows where the area parser rejected the
+                        # token (returned None). Letting these through
+                        # would insert an area_sqm=NULL row that the LLM
+                        # classifier can't reason about and that would
+                        # still appear in the active pool — exactly the
+                        # contamination path Patch 14b is trying to
+                        # close.
+                        if listing.get("area_sqm") is None:
+                            logger.info(
+                                "Skipping listing %s: area_sqm could not be parsed",
+                                aqar_id,
+                            )
+                            continue
+
                         stats["total"] += 1
                         stats["scraped"] += 1
 
@@ -1564,6 +1698,16 @@ def main():
                     listing["listing_type"] = type_key
                     classify_restaurant_suitability(listing)
                     listing["price_per_sqm"] = _compute_price_per_sqm(listing)
+
+                    # Same None-area skip as the area-level loop — see
+                    # comment above.
+                    if listing.get("area_sqm") is None:
+                        logger.info(
+                            "Skipping listing %s: area_sqm could not be parsed",
+                            aqar_id,
+                        )
+                        continue
+
                     stats["total"] += 1
                     stats["scraped"] += 1
 
@@ -1590,6 +1734,13 @@ def main():
             db.commit()
             if stale_count:
                 print(f"\nMarked {stale_count} listings as stale (not seen in {_STALE_DAYS}+ days)")
+
+        # Surface parser reliability on every run. If the rejection
+        # rate spikes (e.g. Aqar changes their HTML layout and tokens
+        # stop matching the disambiguator), this emits a WARNING line
+        # so we catch it in the next scrape log instead of waiting
+        # for a user complaint.
+        _log_area_parse_telemetry()
 
         print(f"\n=== Done ===")
     finally:

--- a/tests/test_scrape_aqar.py
+++ b/tests/test_scrape_aqar.py
@@ -36,21 +36,25 @@ class TestParseAreaTokenDecimalComma:
         )
 
     def test_all_failing_rows_from_diagnostic(self):
-        # Every row from the production diagnostic query gets pinned here.
-        # Each thousands reading (28580, 22376, ...) is > _AREA_MAX_SQM
-        # so the disambiguator falls back to decimal.
-        cases = [
+        """Diagnostic rows from production. Some now correctly return None
+        after the Patch-14b decimal-fallback floor (anything < 20 m²)."""
+        accepted_cases = [
             ("28,580 m²", 28.580),
             ("22,376 m²", 22.376),
             ("22,108 m²", 22.108),
-            ("16,446 m²", 16.446),
-            ("16,205 m²", 16.205),
-            ("14,285 m²", 14.285),
         ]
-        for raw, expected in cases:
+        for raw, expected in accepted_cases:
             assert _parse_area_token(raw, listing_type="store") == pytest.approx(
                 expected
             ), f"{raw!r} did not parse to {expected}"
+
+        # These now correctly return None: their decimal-fallback values
+        # (16.446, 16.205, 14.285) all fall below the 20 m² fallback floor
+        # and are treated as contamination rather than tiny kiosks.
+        rejected_cases = ["16,446 m²", "16,205 m²", "14,285 m²"]
+        for raw in rejected_cases:
+            assert _parse_area_token(raw, listing_type="store") is None, \
+                f"{raw!r} should be rejected by the decimal-fallback floor"
 
 
 class TestParseAreaTokenThousandsComma:
@@ -84,9 +88,13 @@ class TestParseAreaTokenThousandsComma:
         # Exactly at the ceiling stays as thousands.
         assert _parse_area_token("5,000 m²", listing_type="store") == 5000.0
 
-    def test_just_over_ceiling_falls_back_to_decimal(self):
-        # "5,500 m²" thousands=5500 > 5000 → decimal=5.5 (plausible for store).
-        assert _parse_area_token("5,500 m²", listing_type="store") == pytest.approx(5.5)
+    def test_just_over_ceiling_falls_back_to_decimal_rejected(self):
+        # "5,500 m²" thousands=5500 > 5000 → decimal=5.5 → now rejected
+        # by the Patch-14b decimal-fallback floor (5.5 < 20.0). The old
+        # behavior accepted 5.5 as a plausible-looking kiosk value, but
+        # no real F&B store in Riyadh is 5.5 m², and the fallback path
+        # is low-confidence by construction — treat as contamination.
+        assert _parse_area_token("5,500 m²", listing_type="store") is None
 
 
 class TestParseAreaTokenPeriodDecimal:
@@ -186,3 +194,91 @@ class TestParseAreaTokenEmptyOrGarbage:
 
     def test_only_unit_with_whitespace(self):
         assert _parse_area_token("  m²  ") is None
+
+
+class TestParseAreaTokenMultiSeparatorReject:
+    """Multi-separator garbage like '5,028,580 m²' must be rejected."""
+
+    def test_rejects_three_commas(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="scripts.scrape_aqar"):
+            assert _parse_area_token("5,028,580 m²", listing_type="store") is None
+        assert any("multi-separator" in rec.message.lower() for rec in caplog.records)
+
+    def test_rejects_two_commas(self):
+        assert _parse_area_token("1,234,567 m²", listing_type="store") is None
+
+    def test_rejects_two_periods(self):
+        assert _parse_area_token("12.345.678 m²", listing_type="store") is None
+
+    def test_rejects_for_building_too(self):
+        # Multi-separator garbage is invalid for ALL listing types, not
+        # just store/showroom. A 1.2 million sqm building is nonsense.
+        assert _parse_area_token("1,200,500 m²", listing_type="building") is None
+
+    def test_accepts_legit_thousands_decimal(self):
+        # Exactly one comma followed by exactly one period, in order, is the
+        # international thousands+decimal form and stays valid.
+        assert _parse_area_token("1,200.50 m²", listing_type="building") == pytest.approx(1200.50)
+
+    def test_rejects_period_then_comma(self):
+        # period-then-comma is invalid (would be European decimal-with-thousands,
+        # which Aqar doesn't use, and is too risky to disambiguate)
+        assert _parse_area_token("1.200,50 m²", listing_type="store") is None
+
+
+class TestParseAreaTokenDecimalFallbackFloor:
+    """Stricter floor on decimal-fallback path to catch contamination
+    like '12,500 m²' falling back to 12.5 m²."""
+
+    def test_rejects_fallback_below_20(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="scripts.scrape_aqar"):
+            # 12,500 → thousands=12500 > 5000 → fallback decimal=12.5 → < 20 → reject
+            assert _parse_area_token("12,500 m²", listing_type="store") is None
+        assert any("decimal-fallback" in rec.message.lower() for rec in caplog.records)
+
+    def test_rejects_fallback_14_class(self):
+        # 14,285 → thousands=14285 > 5000 → fallback decimal=14.285 → < 20 → reject
+        assert _parse_area_token("14,285 m²", listing_type="store") is None
+
+    def test_accepts_fallback_above_20(self):
+        # 28,580 → thousands=28580 > 5000 → fallback decimal=28.580 → ≥ 20 → accept
+        assert _parse_area_token("28,580 m²", listing_type="store") == pytest.approx(28.580)
+
+    def test_accepts_fallback_120_class(self):
+        # The original Patch 14 canary case still works
+        assert _parse_area_token("120,205 m²", listing_type="store") == pytest.approx(120.205)
+
+    def test_general_floor_unchanged_for_non_fallback(self):
+        # A direct "10 m²" (no comma, no fallback) still passes the
+        # general floor of 5.0 because it didn't come through fallback.
+        assert _parse_area_token("10 m²", listing_type="store") == 10.0
+
+    def test_general_floor_still_rejects_below_5(self):
+        # The general floor is unchanged.
+        assert _parse_area_token("3 m²", listing_type="store") is None
+
+
+class TestParseAreaTelemetryCounters:
+    """Verify the telemetry counters increment on each return path."""
+
+    def test_counters_increment_on_success(self):
+        from scripts.scrape_aqar import _area_parse_stats, _reset_area_parse_telemetry
+        _reset_area_parse_telemetry()
+        _parse_area_token("100 m²", listing_type="store")
+        assert _area_parse_stats["attempted"] == 1
+        assert _area_parse_stats["succeeded"] == 1
+
+    def test_counters_increment_on_multi_separator_reject(self):
+        from scripts.scrape_aqar import _area_parse_stats, _reset_area_parse_telemetry
+        _reset_area_parse_telemetry()
+        _parse_area_token("5,028,580 m²", listing_type="store")
+        assert _area_parse_stats["attempted"] == 1
+        assert _area_parse_stats["succeeded"] == 0
+        assert _area_parse_stats["rejected_multi_separator"] == 1
+
+    def test_counters_increment_on_fallback_too_small(self):
+        from scripts.scrape_aqar import _area_parse_stats, _reset_area_parse_telemetry
+        _reset_area_parse_telemetry()
+        _parse_area_token("14,285 m²", listing_type="store")
+        assert _area_parse_stats["attempted"] == 1
+        assert _area_parse_stats["rejected_decimal_fallback_too_small"] == 1


### PR DESCRIPTION
## Summary
This patch hardens the area parser against decimal-comma corruption by introducing stricter validation rules, comprehensive telemetry tracking, and a one-time cleanup script for legacy corrupted data.

## Key Changes

### Area Parser Hardening (`scripts/scrape_aqar.py`)
- **Multi-separator rejection**: Rejects malformed area tokens with multiple commas/periods (e.g., "5,028,580 m²") unless they match the legitimate international thousands+decimal format (comma then period)
- **Decimal-fallback floor**: Introduces `_AREA_FALLBACK_MIN_SQM = 20.0` for the fallback path when thousands interpretation exceeds the ceiling. This catches contamination like "14,285 m²" → 14.285 m² (below 20 m²) while preserving legitimate cases like "28,580 m²" → 28.580 m²
- **Separate floor tracking**: Keeps the general `_AREA_MIN_SQM = 5.0` unchanged for non-fallback paths (real souk kiosks can be legitimately small)
- **Plausibility checks split**: Separates floor and ceiling rejection logging for better diagnostics

### Telemetry System
- **Counters**: Tracks attempted parses, successes, and six rejection categories (multi-separator, decimal-fallback-too-small, plausibility-floor, plausibility-ceiling, unparseable)
- **Logging functions**: `_reset_area_parse_telemetry()` and `_log_area_parse_telemetry()` provide per-run statistics
- **Alerting**: Emits a WARNING if rejection rate exceeds 5%, enabling early detection of parser degradation from HTML layout changes
- **Integration**: Resets telemetry at scrape start, logs summary at end

### Data Quality Gates
- **Null-area skipping**: Both area-level and type-level loops now skip listings where `area_sqm` is None, preventing NULL rows from entering the active pool where the LLM classifier cannot reason about them

### Legacy Cleanup (`scripts/quarantine_legacy_corrupt_areas.py`)
- One-time script to quarantine pre-Patch-14 corrupted rows (store/showroom with area_sqm > 10000 or < 5)
- Flips status from 'active' to 'quarantined_area', removing them from the candidate pool
- Supports dry-run mode and reversible restore operation
- Safety guard: refuses to quarantine more than 100 rows in a single run

### CI/CD (`workflows/quarantine-legacy-areas.yml`)
- Manual-trigger workflow for the quarantine script with configurable dry-run and restore flags

## Test Coverage
- Updated existing tests to reflect new rejection behavior (e.g., "5,500 m²" now returns None instead of 5.5)
- Added comprehensive test suites for multi-separator rejection, decimal-fallback floor, and telemetry counters
- Diagnostic cases from production now correctly split into accepted and rejected groups

## Notable Implementation Details
- The fallback floor is intentionally stricter than the general floor because the fallback path represents lower-confidence interpretations (thousands reading was implausibly large, suggesting deed-convention decimal-comma)
- Multi-separator validation allows exactly one comma + one period in that order (international format) but rejects all other multi-separator patterns
- Telemetry is reset per-run to reflect only the current scrape's reliability metrics

https://claude.ai/code/session_01UirGSt3a9itsqUUHTs4ULb