### PR TITLE
Add LLM-powered decision memo narrative to expansion advisor

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -35,6 +35,7 @@ from app.services.expansion_advisor import (
 )
 
 
+from app.services.llm_decision_memo import generate_decision_memo
 from app.services.aqar_district_match import normalize_district_key
 from app.api.search import normalize_search_text
 
@@ -971,3 +972,27 @@ def delete_expansion_saved_search(saved_id: str, db: Session = Depends(get_db)) 
     except Exception:
         db.rollback()
         raise
+
+
+# ── LLM Decision Memo ───────────────────────────────────────────────
+
+
+class DecisionMemoRequest(BaseModel):
+    candidate: dict[str, Any]
+    brief: dict[str, Any]
+    lang: str = "en"
+
+
+@router.post("/decision-memo")
+def post_decision_memo(req: DecisionMemoRequest):
+    """Generate an LLM decision memo for a candidate site."""
+    try:
+        memo = generate_decision_memo(
+            candidate=req.candidate,
+            brief=req.brief,
+            lang=req.lang if req.lang in ("en", "ar") else "en",
+        )
+        return {"memo": memo}
+    except RuntimeError as exc:
+        logger.warning("Decision memo generation failed: %s", exc)
+        raise HTTPException(status_code=503, detail=str(exc))

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -1,0 +1,344 @@
+"""LLM-powered decision memo generator for Expansion Advisor candidates.
+
+Generates a 200-300 word narrative on click of "Decision Memo", explaining
+whether a candidate site is a fit for the operator's specific brand brief.
+
+Uses the same OpenAI client pattern as llm_suitability.py. Model and cost
+ceiling are configurable via environment variables.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ── Model & cost configuration ──────────────────────────────────────
+
+MODEL_ID = os.environ.get("DECISION_MEMO_MODEL", "gpt-4o-mini-2024-07-18")
+MAX_TOKENS = 800
+TEMPERATURE = 0.3
+
+# Soft daily ceiling in USD.  Raises RuntimeError before calling OpenAI
+# if the running total for today exceeds this value.
+DAILY_CEILING_USD = float(
+    os.environ.get("DECISION_MEMO_DAILY_CEILING_USD", "1.00")
+)
+
+# Per-token costs for gpt-4o-mini (as of 2024-07).  Used for cost
+# tracking only — not billing.
+_INPUT_COST_PER_TOKEN = 0.15 / 1_000_000   # $0.15 per 1M input tokens
+_OUTPUT_COST_PER_TOKEN = 0.60 / 1_000_000  # $0.60 per 1M output tokens
+
+# ── Daily cost tracker (in-process, resets on restart) ──────────────
+
+_daily_cost_tracker: dict[str, float] = {}
+
+
+def _today_key() -> str:
+    return date.today().isoformat()
+
+
+def _check_daily_ceiling() -> None:
+    today = _today_key()
+    spent = _daily_cost_tracker.get(today, 0.0)
+    if spent >= DAILY_CEILING_USD:
+        raise RuntimeError(
+            f"Decision memo daily cost ceiling reached "
+            f"(${spent:.4f} / ${DAILY_CEILING_USD:.2f}). "
+            f"Try again tomorrow or raise DECISION_MEMO_DAILY_CEILING_USD."
+        )
+
+
+def _record_cost(input_tokens: int, output_tokens: int) -> float:
+    cost = (input_tokens * _INPUT_COST_PER_TOKEN
+            + output_tokens * _OUTPUT_COST_PER_TOKEN)
+    today = _today_key()
+    _daily_cost_tracker[today] = _daily_cost_tracker.get(today, 0.0) + cost
+    return cost
+
+
+# ── OpenAI client (lazy) ────────────────────────────────────────────
+
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY is not set. Decision memo generation "
+                "requires an OpenAI API key."
+            )
+        from openai import OpenAI
+        _client = OpenAI(api_key=api_key)
+    return _client
+
+
+# ── Rent-vs-median helper ───────────────────────────────────────────
+
+def _format_rent_vs_median(
+    candidate_rent: float | None,
+    district_median: float | None,
+    lang: str = "en",
+) -> str:
+    if candidate_rent is None or district_median is None or district_median <= 0:
+        return "غير معروف" if lang == "ar" else "unknown"
+
+    pct = ((candidate_rent - district_median) / district_median) * 100
+
+    if abs(pct) < 5:
+        return "متوافق مع المتوسط" if lang == "ar" else "in line with median"
+    elif pct > 0:
+        rounded = round(pct)
+        if lang == "ar":
+            return f"أعلى من المتوسط بنسبة {rounded}%"
+        return f"{rounded}% above median"
+    else:
+        rounded = round(abs(pct))
+        if lang == "ar":
+            return f"أقل من المتوسط بنسبة {rounded}%"
+        return f"{rounded}% below median"
+
+
+# ── Prompt templates ────────────────────────────────────────────────
+
+_PROMPT_TEMPLATE_EN = """You are a real estate advisor evaluating a commercial site in Riyadh, Saudi Arabia for a specific restaurant/retail operator.
+
+OPERATOR'S BRAND BRIEF:
+- Brand: {brand_name}
+- Category: {category}
+- Service model: {service_model}
+- Target area: {target_area} m²  (acceptable range: {min_area}–{max_area} m²)
+- Existing branches: {existing_branches}
+- Primary channel: {primary_channel}
+
+CANDIDATE SITE:
+- District: {district}
+- Area: {area} m²
+- Annual rent: SAR {annual_rent}
+- Rent per m²/year: SAR {rent_per_sqm}
+- Street width: {street_width} m
+- Final score: {final_score}/100
+- Economics score: {economics_score}/100
+- Brand fit score: {brand_fit_score}/100
+- Demand score: {demand_score}/100
+- Whitespace score: {whitespace_score}/100
+- Listing quality score: {listing_quality_score}/100
+- District median rent: SAR {district_median_rent}
+- Rent vs median: {rent_vs_median}
+- LLM site assessment: {llm_reasoning}
+
+Return a JSON object with exactly these fields:
+{{
+  "headline": "<≤15 words: GO/CONSIDER/CAUTION verdict + key reason>",
+  "fit_summary": "<2-3 sentences explaining fit for {brand_name} as a {category} operator. Reference the brand and category by name.>",
+  "top_reasons_to_pursue": ["<reason 1>", "<reason 2>", "<reason 3>"],
+  "top_risks": ["<risk 1>", "<risk 2>", "<risk 3>"],
+  "recommended_next_action": "<1 concrete, actionable next step>",
+  "rent_context": "<1 sentence comparing this site's rent to the district median>"
+}}
+
+RULES:
+- Do not invent facts. If you don't know something, omit it or say "data not available".
+- Reference the operator's brand name ({brand_name}) and category ({category}) explicitly.
+- Keep the total response under 300 words.
+- Return ONLY the JSON object."""
+
+_PROMPT_TEMPLATE_AR = """أنت مستشار عقاري تُقيّم موقعاً تجارياً في الرياض، المملكة العربية السعودية لصالح مُشغّل مطاعم/تجزئة محدد.
+
+موجز العلامة التجارية للمشغّل:
+- العلامة التجارية: {brand_name}
+- الفئة: {category}
+- نموذج الخدمة: {service_model}
+- المساحة المستهدفة: {target_area} م² (النطاق المقبول: {min_area}–{max_area} م²)
+- الفروع الحالية: {existing_branches}
+- القناة الرئيسية: {primary_channel}
+
+الموقع المرشح:
+- الحي: {district}
+- المساحة: {area} م²
+- الإيجار السنوي: {annual_rent} ريال
+- الإيجار لكل م²/سنة: {rent_per_sqm} ريال
+- عرض الشارع: {street_width} م
+- الدرجة النهائية: {final_score}/100
+- درجة الجدوى: {economics_score}/100
+- درجة ملاءمة العلامة: {brand_fit_score}/100
+- درجة الطلب: {demand_score}/100
+- درجة الفراغ السوقي: {whitespace_score}/100
+- درجة جودة الإعلان: {listing_quality_score}/100
+- متوسط إيجار الحي: {district_median_rent} ريال
+- الإيجار مقارنة بالمتوسط: {rent_vs_median}
+- تقييم الموقع: {llm_reasoning}
+
+أعد كائن JSON يحتوي على هذه الحقول بالضبط:
+{{
+  "headline": "<≤15 كلمة: حكم انطلق/تأمّل/احذر + السبب الرئيسي>",
+  "fit_summary": "<2-3 جمل توضح مدى ملاءمة الموقع لـ {brand_name} كمُشغّل {category}. اذكر العلامة التجارية والفئة بالاسم.>",
+  "top_reasons_to_pursue": ["<سبب 1>", "<سبب 2>", "<سبب 3>"],
+  "top_risks": ["<خطر 1>", "<خطر 2>", "<خطر 3>"],
+  "recommended_next_action": "<خطوة عملية واحدة قابلة للتنفيذ>",
+  "rent_context": "<جملة واحدة تقارن إيجار هذا الموقع بمتوسط الحي>"
+}}
+
+القواعد:
+- لا تختلق حقائق. إذا لم تعرف شيئاً، احذفه أو قل "البيانات غير متوفرة".
+- اذكر اسم العلامة التجارية ({brand_name}) والفئة ({category}) صراحةً.
+- اجعل الرد أقل من 300 كلمة.
+- أعد كائن JSON فقط."""
+
+
+# ── Main generation function ────────────────────────────────────────
+
+_REQUIRED_STRING_FIELDS = (
+    "headline", "fit_summary", "recommended_next_action", "rent_context"
+)
+_REQUIRED_LIST_FIELDS = ("top_reasons_to_pursue", "top_risks")
+
+
+def generate_decision_memo(
+    *,
+    candidate: dict[str, Any],
+    brief: dict[str, Any],
+    lang: str = "en",
+) -> dict[str, Any]:
+    """Generate an LLM decision memo for a candidate site.
+
+    Args:
+        candidate: The candidate dict (from frontend state / API response).
+        brief: The brand brief dict (from frontend state / API response).
+        lang: "en" or "ar" — controls prompt language.
+
+    Returns:
+        Dict with headline, fit_summary, top_reasons_to_pursue,
+        top_risks, recommended_next_action, rent_context.
+
+    Raises:
+        RuntimeError: If daily cost ceiling is exceeded or API call fails.
+    """
+    _check_daily_ceiling()
+
+    template = _PROMPT_TEMPLATE_AR if lang == "ar" else _PROMPT_TEMPLATE_EN
+
+    # Extract fields with safe fallbacks
+    existing_branches = brief.get("existing_branches") or []
+    if isinstance(existing_branches, list):
+        branch_desc = (
+            f"{len(existing_branches)} branches"
+            if lang == "en"
+            else f"{len(existing_branches)} فروع"
+        )
+    else:
+        branch_desc = str(existing_branches)
+
+    district_median_rent = candidate.get("district_median_rent")
+    annual_rent = candidate.get(
+        "display_annual_rent_sar",
+        candidate.get("estimated_annual_rent_sar"),
+    )
+    rent_vs_median = _format_rent_vs_median(
+        annual_rent, district_median_rent, lang
+    )
+
+    area = candidate.get("area_m2") or candidate.get("unit_area_sqm")
+    rent_per_sqm = candidate.get("estimated_rent_sar_m2_year")
+    street_width = (
+        candidate.get("unit_street_width_m")
+        or candidate.get("street_width_m")
+    )
+
+    prompt = template.format(
+        brand_name=brief.get("brand_name", "—"),
+        category=brief.get("category", "—"),
+        service_model=brief.get("service_model", "—"),
+        target_area=brief.get("target_area_m2") or "—",
+        min_area=brief.get("min_area_m2", "—"),
+        max_area=brief.get("max_area_m2", "—"),
+        existing_branches=branch_desc,
+        primary_channel=(
+            brief.get("brand_profile", {}) or {}
+        ).get("primary_channel", "—"),
+        district=(
+            candidate.get("district_display")
+            or candidate.get("district")
+            or "—"
+        ),
+        area=area or "—",
+        annual_rent=annual_rent or "—",
+        rent_per_sqm=rent_per_sqm or "—",
+        street_width=street_width or "—",
+        final_score=candidate.get("final_score", "—"),
+        economics_score=candidate.get("economics_score", "—"),
+        brand_fit_score=candidate.get("brand_fit_score", "—"),
+        demand_score=candidate.get("demand_score", "—"),
+        whitespace_score=candidate.get(
+            "provider_whitespace_score",
+            candidate.get("whitespace_score", "—"),
+        ),
+        listing_quality_score=candidate.get("listing_quality_score", "—"),
+        llm_reasoning=candidate.get("llm_reasoning") or "not available",
+        district_median_rent=district_median_rent or "—",
+        rent_vs_median=rent_vs_median,
+    )
+
+    client = _get_client()
+    aqar_id = candidate.get("parcel_id") or candidate.get("id") or "unknown"
+
+    try:
+        response = client.chat.completions.create(
+            model=MODEL_ID,
+            messages=[{"role": "user", "content": prompt}],
+            response_format={"type": "json_object"},
+            temperature=TEMPERATURE,
+            max_tokens=MAX_TOKENS,
+        )
+    except Exception as exc:
+        logger.error(
+            "Decision memo OpenAI call failed for %s: %s", aqar_id, exc
+        )
+        raise RuntimeError(f"Decision memo generation failed: {exc}") from exc
+
+    # Parse response
+    content = (response.choices[0].message.content or "").strip()
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        logger.error(
+            "Decision memo JSON parse failed for %s: %s | raw=%s",
+            aqar_id, exc, content[:500],
+        )
+        raise RuntimeError(
+            "Decision memo returned invalid JSON from LLM"
+        ) from exc
+
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Decision memo LLM returned non-object JSON")
+
+    # Fill missing fields gracefully
+    for field in _REQUIRED_STRING_FIELDS:
+        if not isinstance(parsed.get(field), str) or not parsed[field].strip():
+            parsed[field] = "—"
+
+    for field in _REQUIRED_LIST_FIELDS:
+        if not isinstance(parsed.get(field), list):
+            parsed[field] = []
+
+    # Record cost
+    usage = response.usage
+    input_tokens = usage.prompt_tokens if usage else 0
+    output_tokens = usage.completion_tokens if usage else 0
+    cost = _record_cost(input_tokens, output_tokens)
+
+    logger.info(
+        "Decision memo generated | aqar_id=%s lang=%s "
+        "input_tokens=%d output_tokens=%d cost=$%.5f",
+        aqar_id, lang, input_tokens, output_tokens, cost,
+    )
+
+    return parsed

--- a/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import type { LLMDecisionMemo } from "../../lib/api/expansionAdvisor";
+import { generateDecisionMemo } from "../../lib/api/expansionAdvisor";
+
+type Props = {
+  candidate: Record<string, unknown>;
+  brief: Record<string, unknown>;
+  lang: string;
+};
+
+export default function DecisionMemoNarrative({ candidate, brief, lang }: Props) {
+  const { t } = useTranslation();
+  const [memo, setMemo] = useState<LLMDecisionMemo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Cache by candidate id so re-renders don't re-fetch
+  const cacheRef = useRef<Map<string, LLMDecisionMemo>>(new Map());
+  const candidateId = String((candidate as Record<string, unknown>).id ?? "");
+
+  useEffect(() => {
+    if (!candidateId) return;
+
+    const cached = cacheRef.current.get(candidateId);
+    if (cached) {
+      setMemo(cached);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setMemo(null);
+
+    generateDecisionMemo(candidate, brief, lang)
+      .then((result) => {
+        if (cancelled) return;
+        cacheRef.current.set(candidateId, result);
+        setMemo(result);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError(t("decisionMemo.error"));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [candidateId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (loading) {
+    return (
+      <div className="ea-memo-narrative ea-memo-narrative--loading">
+        <div className="ea-skeleton ea-skeleton--headline" />
+        <div className="ea-skeleton ea-skeleton--paragraph" />
+        <div className="ea-skeleton ea-skeleton--list" />
+        <div className="ea-skeleton ea-skeleton--list" />
+        <p className="ea-memo-narrative__loading-text">{t("decisionMemo.loading")}</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="ea-memo-narrative ea-memo-narrative--error">
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!memo) return null;
+
+  return (
+    <div className="ea-memo-narrative" dir={lang === "ar" ? "rtl" : "ltr"}>
+      {/* Headline */}
+      <h3 className="ea-memo-narrative__headline">{memo.headline}</h3>
+
+      {/* Fit summary */}
+      <p className="ea-memo-narrative__summary">{memo.fit_summary}</p>
+
+      {/* Why pursue */}
+      {memo.top_reasons_to_pursue.length > 0 && (
+        <div className="ea-memo-narrative__section">
+          <h5 className="ea-memo-narrative__section-title ea-memo-narrative__section-title--positive">
+            {t("decisionMemo.whyPursue")}
+          </h5>
+          <ul className="ea-memo-narrative__list">
+            {memo.top_reasons_to_pursue.map((reason, i) => (
+              <li key={i}>{reason}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Risks to weigh */}
+      {memo.top_risks.length > 0 && (
+        <div className="ea-memo-narrative__section">
+          <h5 className="ea-memo-narrative__section-title ea-memo-narrative__section-title--risk">
+            {t("decisionMemo.risksToWeigh")}
+          </h5>
+          <ul className="ea-memo-narrative__list">
+            {memo.top_risks.map((risk, i) => (
+              <li key={i}>{risk}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Recommended next action */}
+      {memo.recommended_next_action && memo.recommended_next_action !== "—" && (
+        <div className="ea-memo-narrative__callout">
+          <span className="ea-memo-narrative__callout-label">{t("decisionMemo.nextAction")}</span>
+          <span>{memo.recommended_next_action}</span>
+        </div>
+      )}
+
+      {/* Rent context */}
+      {memo.rent_context && memo.rent_context !== "—" && (
+        <p className="ea-memo-narrative__rent-context">{memo.rent_context}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/expansion-advisor/ExpansionAdvisorPage.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionAdvisorPage.tsx
@@ -161,7 +161,7 @@ export default function ExpansionAdvisorPage({
   externalSelectedCandidateId?: string | null;
   onMapViewRequest?: (view: MapViewState) => void;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [brief, setBrief] = useState<ExpansionBrief>(defaultBrief);
   const [candidates, setCandidates] = useState<ExpansionCandidate[]>([]);
   const [searchId, setSearchId] = useState<string>("");
@@ -939,6 +939,9 @@ export default function ExpansionAdvisorPage({
           loading={loadingMemo}
           isLeadCandidate={selectedCandidate?.id === leadCandidateId}
           report={report}
+          candidateRaw={selectedCandidate as unknown as Record<string, unknown>}
+          briefRaw={brief as unknown as Record<string, unknown>}
+          lang={i18n.language?.startsWith("ar") ? "ar" : "en"}
           onClose={() => setActiveDrawer("none")}
           onBackToDetail={() => setActiveDrawer("none")}
           onBackToCompare={compareResult ? () => setActiveDrawer("compare") : undefined}

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
@@ -5,6 +5,7 @@ import ScorePill from "./ScorePill";
 import ConfidenceBadge from "./ConfidenceBadge";
 import GateSummary from "./GateSummary";
 import CopySummaryBlock from "./CopySummaryBlock";
+import DecisionMemoNarrative from "./DecisionMemoNarrative";
 import { fmtScore, fmtMeters, fmtSAR, fmtSARCompact, fmtM2, businessGateLabel, safeDistrictLabel, getDisplayScore } from "./formatHelpers";
 
 function toList(input: unknown): string[] {
@@ -43,6 +44,9 @@ export default function ExpansionMemoPanel({
   loading,
   isLeadCandidate,
   report,
+  candidateRaw,
+  briefRaw,
+  lang,
   onClose,
   onBackToDetail,
   onBackToCompare,
@@ -54,6 +58,9 @@ export default function ExpansionMemoPanel({
   loading: boolean;
   isLeadCandidate?: boolean;
   report?: RecommendationReportResponse | null;
+  candidateRaw?: Record<string, unknown> | null;
+  briefRaw?: Record<string, unknown> | null;
+  lang?: string;
   onClose?: () => void;
   onBackToDetail?: () => void;
   onBackToCompare?: () => void;
@@ -66,6 +73,8 @@ export default function ExpansionMemoPanel({
   const [activeTab, setActiveTab] = useState<MemoTab>("economics");
 
   if (!memo && !loading) return null;
+
+  const effectiveLang = lang || "en";
 
   return (
     <div className="ea-drawer-backdrop" onClick={() => onClose?.()}>
@@ -119,258 +128,304 @@ export default function ExpansionMemoPanel({
 
             return (
               <>
-                {/* ── Summary card (always visible) ── */}
-                <div className="ea-memo-summary-card">
-                  <div className="ea-memo-summary-card__top">
-                    <div className="ea-memo-summary-card__score-donut">
+                {/* ══ Section 1: LLM Decision Narrative (top, always visible) ══ */}
+                {candidateRaw && briefRaw && (
+                  <DecisionMemoNarrative
+                    candidate={candidateRaw}
+                    brief={briefRaw}
+                    lang={effectiveLang}
+                  />
+                )}
+
+                {/* ══ Section 2: 4 Key Numbers (always visible) ══ */}
+                <div className="ea-memo-key-numbers">
+                  <div className="ea-memo-key-numbers__item">
+                    <span className="ea-memo-key-numbers__value">
                       <ScorePill value={(breakdown?.display_score as number | undefined) ?? (cand.final_score as number | undefined)} large />
-                    </div>
-                    {rec.verdict && (
-                      <span className={`ea-memo-verdict-badge ea-badge ea-badge--${verdictColor}`}>
-                        {rec.verdict}
-                      </span>
-                    )}
-                    <ConfidenceBadge grade={cand.confidence_grade as string | undefined} />
+                    </span>
+                    <span className="ea-memo-key-numbers__label">{t("decisionMemo.finalScore")}</span>
                   </div>
-                  {rec.headline && <p className="ea-memo-summary-card__headline">{rec.headline}</p>}
+                  <div className="ea-memo-key-numbers__item">
+                    <span className="ea-memo-key-numbers__value ea-memo-key-numbers__value--big">
+                      {fmtM2(cand.area_m2 as number | undefined)}
+                    </span>
+                    <span className="ea-memo-key-numbers__label">{t("decisionMemo.area")}</span>
+                  </div>
+                  <div className="ea-memo-key-numbers__item">
+                    <span className="ea-memo-key-numbers__value ea-memo-key-numbers__value--big">
+                      {fmtSAR(cand.estimated_annual_rent_sar as number | undefined)}
+                    </span>
+                    <span className="ea-memo-key-numbers__label">{t("decisionMemo.annualRent")}</span>
+                  </div>
+                  <div className="ea-memo-key-numbers__item">
+                    <span className="ea-memo-key-numbers__value ea-memo-key-numbers__value--big">
+                      {cand.unit_street_width_m != null ? `${cand.unit_street_width_m} m` : "—"}
+                    </span>
+                    <span className="ea-memo-key-numbers__label">{t("decisionMemo.streetWidth")}</span>
+                  </div>
                 </div>
 
-                {/* ── Tabbed sections ── */}
-                <div className="ea-memo-tabs">
-                  <div className="ea-memo-tabs__nav">
-                    {(["economics", "market", "site", "risks"] as MemoTab[]).map((tab) => (
-                      <button
-                        key={tab}
-                        type="button"
-                        className={`ea-memo-tabs__tab${activeTab === tab ? " ea-memo-tabs__tab--active" : ""}`}
-                        onClick={() => setActiveTab(tab)}
-                      >
-                        {t(`expansionAdvisor.memoTab_${tab}`)}
-                      </button>
-                    ))}
-                  </div>
+                {/* ══ Section 3: Full Score Breakdown (collapsed by default) ══ */}
+                <details className="ea-memo-full-breakdown">
+                  <summary className="ea-memo-full-breakdown__toggle">
+                    {t("decisionMemo.showFullBreakdown")}
+                  </summary>
 
-                  <div className="ea-memo-tabs__content">
-                    {/* Economics tab */}
-                    {activeTab === "economics" && (
-                      <div className="ea-memo-tab-panel">
-                        <div className="ea-detail__grid">
-                          <div className="ea-detail__kv">
-                            <span className="ea-detail__kv-label">{t("expansionAdvisor.annualRent")}</span>
-                            <span className="ea-detail__kv-value">{fmtSAR(cand.estimated_annual_rent_sar as number | undefined)}</span>
-                          </div>
-                          <div className="ea-detail__kv">
-                            <span className="ea-detail__kv-label">{t("expansionAdvisor.fitoutCost")}</span>
-                            <span className="ea-detail__kv-value">{fmtSAR(cand.estimated_fitout_cost_sar as number | undefined)}</span>
-                          </div>
-                          <div className="ea-detail__kv">
-                            <span className="ea-detail__kv-label">{t("expansionAdvisor.revenueIndex")}</span>
-                            <span className="ea-detail__kv-value">
-                              {fmtScore(cand.estimated_revenue_index as number | undefined, 1)}
-                              <span className="ea-memo-disclaimer-icon" title={t("expansionAdvisor.revenueDisclaimer")}>&#9432;</span>
-                            </span>
-                          </div>
-                          <div className="ea-detail__kv">
-                            <span className="ea-detail__kv-label">{t("expansionAdvisor.economicsLabel")}</span>
-                            <span className="ea-detail__kv-value">{fmtScore(cand.economics_score as number | undefined)}</span>
-                          </div>
-                          <div className="ea-detail__kv">
-                            <span className="ea-detail__kv-label">{t("expansionAdvisor.brandFitLabel")}</span>
-                            <span className="ea-detail__kv-value">{fmtScore(cand.brand_fit_score as number | undefined)}</span>
-                          </div>
+                  <div className="ea-memo-full-breakdown__content">
+                    {/* ── Summary card ── */}
+                    <div className="ea-memo-summary-card">
+                      <div className="ea-memo-summary-card__top">
+                        <div className="ea-memo-summary-card__score-donut">
+                          <ScorePill value={(breakdown?.display_score as number | undefined) ?? (cand.final_score as number | undefined)} large />
                         </div>
-                        {cand.cost_thesis && (
-                          <div className="ea-memo-callout ea-memo-callout--neutral" style={{ marginTop: 12 }}>
-                            <span className="ea-memo-callout__label">{t("expansionAdvisor.costThesis")}</span>
-                            <p className="ea-detail__text">{String(cand.cost_thesis)}</p>
-                          </div>
+                        {rec.verdict && (
+                          <span className={`ea-memo-verdict-badge ea-badge ea-badge--${verdictColor}`}>
+                            {rec.verdict}
+                          </span>
                         )}
+                        <ConfidenceBadge grade={cand.confidence_grade as string | undefined} />
                       </div>
-                    )}
+                      {rec.headline && <p className="ea-memo-summary-card__headline">{rec.headline}</p>}
+                    </div>
 
-                    {/* Market tab */}
-                    {activeTab === "market" && (
-                      <div className="ea-memo-tab-panel">
-                        {cand.demand_thesis && (
-                          <div className="ea-memo-callout ea-memo-callout--neutral">
-                            <span className="ea-memo-callout__label">{t("expansionAdvisor.demandThesis")}</span>
-                            <p className="ea-detail__text">{String(cand.demand_thesis)}</p>
-                          </div>
-                        )}
-                        {mr.delivery_market_summary && (
-                          <div className="ea-memo-callout ea-memo-callout--neutral">
-                            <span className="ea-memo-callout__label">{t("expansionAdvisor.deliveryMarket")}</span>
-                            <p className="ea-detail__text">{mr.delivery_market_summary}</p>
-                          </div>
-                        )}
-                        {mr.competitive_context && (
-                          <div className="ea-memo-callout ea-memo-callout--neutral">
-                            <span className="ea-memo-callout__label">{t("expansionAdvisor.competitiveContext")}</span>
-                            <p className="ea-detail__text">{mr.competitive_context}</p>
-                          </div>
-                        )}
-                        {mr.district_fit_summary && (
-                          <div className="ea-memo-callout ea-memo-callout--neutral">
-                            <span className="ea-memo-callout__label">{t("expansionAdvisor.districtFit")}</span>
-                            <p className="ea-detail__text">{mr.district_fit_summary}</p>
-                          </div>
-                        )}
-                        {comps.length > 0 && (
-                          <>
-                            <h5 className="ea-detail__section-title">{t("expansionAdvisor.comparableCompetitors")}</h5>
-                            <table className="ea-comp-table">
-                              <thead><tr><th>{t("expansionAdvisor.branchName")}</th><th>{t("expansionAdvisor.district")}</th><th>{t("expansionAdvisor.nearestBranch")}</th></tr></thead>
-                              <tbody>
-                                {comps.map((c, i) => (
-                                  <tr key={String(c.id || i)}>
-                                    <td>{String(c.name || "—")}</td>
-                                    <td>{String(c.district_display || c.district || "—")}</td>
-                                    <td>{fmtMeters(c.distance_m as number | undefined)}</td>
-                                  </tr>
-                                ))}
-                              </tbody>
-                            </table>
-                          </>
-                        )}
+                    {/* ── Tabbed sections ── */}
+                    <div className="ea-memo-tabs">
+                      <div className="ea-memo-tabs__nav">
+                        {(["economics", "market", "site", "risks"] as MemoTab[]).map((tab) => (
+                          <button
+                            key={tab}
+                            type="button"
+                            className={`ea-memo-tabs__tab${activeTab === tab ? " ea-memo-tabs__tab--active" : ""}`}
+                            onClick={() => setActiveTab(tab)}
+                          >
+                            {t(`expansionAdvisor.memoTab_${tab}`)}
+                          </button>
+                        ))}
                       </div>
-                    )}
 
-                    {/* Site tab */}
-                    {activeTab === "site" && (
-                      <div className="ea-memo-tab-panel">
-                        <div className="ea-detail__grid">
-                          <div className="ea-detail__kv">
-                            <span className="ea-detail__kv-label">{t("expansionAdvisor.areaLabel")}</span>
-                            <span className="ea-detail__kv-value">{fmtM2(cand.area_m2 as number | undefined)}</span>
-                          </div>
-                          <div className="ea-detail__kv">
-                            <span className="ea-detail__kv-label">{t("expansionAdvisor.rank")}</span>
-                            <span className="ea-detail__kv-value">#{String(cand.rank_position ?? "—")}</span>
-                          </div>
-                          <div className="ea-detail__kv">
-                            <span className="ea-detail__kv-label">{t("expansionAdvisor.confidence")}</span>
-                            <ConfidenceBadge grade={cand.confidence_grade as string | undefined} />
-                          </div>
-                        </div>
-                        {rec.gate_verdict && <p className="ea-detail__text" style={{ fontStyle: "italic", marginTop: 8 }}>{rec.gate_verdict}</p>}
-                        <GateSummary gates={gates} unknownGates={toList(gateReasons?.unknown)} />
-                        {gateReasons && (
-                          <div style={{ fontSize: "var(--oak-fs-xs)", marginTop: 6, display: "grid", gap: 4 }}>
-                            {toList(gateReasons.passed).length > 0 && <div><span className="ea-badge ea-badge--green">{t("expansionAdvisor.gatesPassed")}</span> {toList(gateReasons.passed).map(businessGateLabel).join(", ")}</div>}
-                            {toList(gateReasons.failed).length > 0 && <div><span className="ea-badge ea-badge--red">{t("expansionAdvisor.gatesFailed")}</span> {toList(gateReasons.failed).map(businessGateLabel).join(", ")}</div>}
-                            {toList(gateReasons.unknown).length > 0 && <div><span className="ea-badge ea-badge--amber">{t("expansionAdvisor.gatesNeedVerification")}</span> {toList(gateReasons.unknown).map(businessGateLabel).join(", ")}</div>}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Risks & Validation tab */}
-                    {activeTab === "risks" && (
-                      <div className="ea-memo-tab-panel">
-                        {/* Best use case + watchout */}
-                        {(rec.best_use_case || rec.main_watchout) && (
-                          <div style={{ display: "grid", gap: 8 }}>
-                            {rec.best_use_case && (
-                              <div className="ea-memo-callout ea-memo-callout--positive">
-                                <span className="ea-memo-callout__label">{t("expansionAdvisor.bestUseCase")}</span>
-                                <p className="ea-detail__text">{rec.best_use_case}</p>
+                      <div className="ea-memo-tabs__content">
+                        {/* Economics tab */}
+                        {activeTab === "economics" && (
+                          <div className="ea-memo-tab-panel">
+                            <div className="ea-detail__grid">
+                              <div className="ea-detail__kv">
+                                <span className="ea-detail__kv-label">{t("expansionAdvisor.annualRent")}</span>
+                                <span className="ea-detail__kv-value">{fmtSAR(cand.estimated_annual_rent_sar as number | undefined)}</span>
                               </div>
-                            )}
-                            {rec.main_watchout && (
-                              <div className="ea-memo-callout ea-memo-callout--risk">
-                                <span className="ea-memo-callout__label">{t("expansionAdvisor.mainWatchout")}</span>
-                                <p className="ea-detail__text">{rec.main_watchout}</p>
+                              <div className="ea-detail__kv">
+                                <span className="ea-detail__kv-label">{t("expansionAdvisor.fitoutCost")}</span>
+                                <span className="ea-detail__kv-value">{fmtSAR(cand.estimated_fitout_cost_sar as number | undefined)}</span>
+                              </div>
+                              <div className="ea-detail__kv">
+                                <span className="ea-detail__kv-label">{t("expansionAdvisor.revenueIndex")}</span>
+                                <span className="ea-detail__kv-value">
+                                  {fmtScore(cand.estimated_revenue_index as number | undefined, 1)}
+                                  <span className="ea-memo-disclaimer-icon" title={t("expansionAdvisor.revenueDisclaimer")}>&#9432;</span>
+                                </span>
+                              </div>
+                              <div className="ea-detail__kv">
+                                <span className="ea-detail__kv-label">{t("expansionAdvisor.economicsLabel")}</span>
+                                <span className="ea-detail__kv-value">{fmtScore(cand.economics_score as number | undefined)}</span>
+                              </div>
+                              <div className="ea-detail__kv">
+                                <span className="ea-detail__kv-label">{t("expansionAdvisor.brandFitLabel")}</span>
+                                <span className="ea-detail__kv-value">{fmtScore(cand.brand_fit_score as number | undefined)}</span>
+                              </div>
+                            </div>
+                            {cand.cost_thesis && (
+                              <div className="ea-memo-callout ea-memo-callout--neutral" style={{ marginTop: 12 }}>
+                                <span className="ea-memo-callout__label">{t("expansionAdvisor.costThesis")}</span>
+                                <p className="ea-detail__text">{String(cand.cost_thesis)}</p>
                               </div>
                             )}
                           </div>
                         )}
 
-                        {/* Strengths / risks — two-column */}
-                        <div className="ea-memo-two-col">
-                          <div>
-                            <span className="ea-memo-callout__label" style={{ color: "var(--oak-success, #16a34a)" }}>{t("expansionAdvisor.topPositives")}</span>
-                            {positives.length > 0 ? <ul className="ea-memo-list">{positives.map((s, i) => <li key={i}>{s}</li>)}</ul> : <p className="ea-detail__text">—</p>}
+                        {/* Market tab */}
+                        {activeTab === "market" && (
+                          <div className="ea-memo-tab-panel">
+                            {cand.demand_thesis && (
+                              <div className="ea-memo-callout ea-memo-callout--neutral">
+                                <span className="ea-memo-callout__label">{t("expansionAdvisor.demandThesis")}</span>
+                                <p className="ea-detail__text">{String(cand.demand_thesis)}</p>
+                              </div>
+                            )}
+                            {mr.delivery_market_summary && (
+                              <div className="ea-memo-callout ea-memo-callout--neutral">
+                                <span className="ea-memo-callout__label">{t("expansionAdvisor.deliveryMarket")}</span>
+                                <p className="ea-detail__text">{mr.delivery_market_summary}</p>
+                              </div>
+                            )}
+                            {mr.competitive_context && (
+                              <div className="ea-memo-callout ea-memo-callout--neutral">
+                                <span className="ea-memo-callout__label">{t("expansionAdvisor.competitiveContext")}</span>
+                                <p className="ea-detail__text">{mr.competitive_context}</p>
+                              </div>
+                            )}
+                            {mr.district_fit_summary && (
+                              <div className="ea-memo-callout ea-memo-callout--neutral">
+                                <span className="ea-memo-callout__label">{t("expansionAdvisor.districtFit")}</span>
+                                <p className="ea-detail__text">{mr.district_fit_summary}</p>
+                              </div>
+                            )}
+                            {comps.length > 0 && (
+                              <>
+                                <h5 className="ea-detail__section-title">{t("expansionAdvisor.comparableCompetitors")}</h5>
+                                <table className="ea-comp-table">
+                                  <thead><tr><th>{t("expansionAdvisor.branchName")}</th><th>{t("expansionAdvisor.district")}</th><th>{t("expansionAdvisor.nearestBranch")}</th></tr></thead>
+                                  <tbody>
+                                    {comps.map((c, i) => (
+                                      <tr key={String(c.id || i)}>
+                                        <td>{String(c.name || "—")}</td>
+                                        <td>{String(c.district_display || c.district || "—")}</td>
+                                        <td>{fmtMeters(c.distance_m as number | undefined)}</td>
+                                      </tr>
+                                    ))}
+                                  </tbody>
+                                </table>
+                              </>
+                            )}
                           </div>
-                          <div>
-                            <span className="ea-memo-callout__label" style={{ color: "var(--oak-error, #d4183d)" }}>{t("expansionAdvisor.topRisks")}</span>
-                            {risks.length > 0 ? <ul className="ea-memo-list">{risks.map((s, i) => <li key={i}>{s}</li>)}</ul> : <p className="ea-detail__text">—</p>}
-                          </div>
-                        </div>
+                        )}
 
-                        {/* Validation plan — 2-column layout */}
-                        {(toList(gateReasons?.unknown).length > 0 || toList(gateReasons?.passed).length > 0) && (
-                          <div className="ea-memo-validation-grid">
-                            <div className="ea-memo-validation-col">
-                              <h6 className="ea-memo-validation-col__title ea-memo-validation-col__title--must">{t("expansionAdvisor.vpMustVerify")}</h6>
-                              {toList(gateReasons?.unknown).map((item, i) => (
-                                <div key={i} className="ea-memo-validation-item ea-memo-validation-item--must">
-                                  <span className="ea-memo-validation-dot ea-memo-validation-dot--must" />
-                                  <span>{businessGateLabel(item)}</span>
-                                </div>
-                              ))}
-                              {toList(gateReasons?.failed).map((item, i) => (
-                                <div key={`f-${i}`} className="ea-memo-validation-item ea-memo-validation-item--must">
-                                  <span className="ea-memo-validation-dot ea-memo-validation-dot--fail" />
-                                  <span>{businessGateLabel(item)}</span>
-                                </div>
-                              ))}
+                        {/* Site tab */}
+                        {activeTab === "site" && (
+                          <div className="ea-memo-tab-panel">
+                            <div className="ea-detail__grid">
+                              <div className="ea-detail__kv">
+                                <span className="ea-detail__kv-label">{t("expansionAdvisor.areaLabel")}</span>
+                                <span className="ea-detail__kv-value">{fmtM2(cand.area_m2 as number | undefined)}</span>
+                              </div>
+                              <div className="ea-detail__kv">
+                                <span className="ea-detail__kv-label">{t("expansionAdvisor.rank")}</span>
+                                <span className="ea-detail__kv-value">#{String(cand.rank_position ?? "—")}</span>
+                              </div>
+                              <div className="ea-detail__kv">
+                                <span className="ea-detail__kv-label">{t("expansionAdvisor.confidence")}</span>
+                                <ConfidenceBadge grade={cand.confidence_grade as string | undefined} />
+                              </div>
                             </div>
-                            <div className="ea-memo-validation-col">
-                              <h6 className="ea-memo-validation-col__title ea-memo-validation-col__title--confirmed">{t("expansionAdvisor.vpAlreadyStrong")}</h6>
-                              {toList(gateReasons?.passed).map((item, i) => (
-                                <div key={i} className="ea-memo-validation-item ea-memo-validation-item--confirmed">
-                                  <span className="ea-memo-validation-check">&#10003;</span>
-                                  <span>{businessGateLabel(item)}</span>
-                                </div>
-                              ))}
+                            {rec.gate_verdict && <p className="ea-detail__text" style={{ fontStyle: "italic", marginTop: 8 }}>{rec.gate_verdict}</p>}
+                            <GateSummary gates={gates} unknownGates={toList(gateReasons?.unknown)} />
+                            {gateReasons && (
+                              <div style={{ fontSize: "var(--oak-fs-xs)", marginTop: 6, display: "grid", gap: 4 }}>
+                                {toList(gateReasons.passed).length > 0 && <div><span className="ea-badge ea-badge--green">{t("expansionAdvisor.gatesPassed")}</span> {toList(gateReasons.passed).map(businessGateLabel).join(", ")}</div>}
+                                {toList(gateReasons.failed).length > 0 && <div><span className="ea-badge ea-badge--red">{t("expansionAdvisor.gatesFailed")}</span> {toList(gateReasons.failed).map(businessGateLabel).join(", ")}</div>}
+                                {toList(gateReasons.unknown).length > 0 && <div><span className="ea-badge ea-badge--amber">{t("expansionAdvisor.gatesNeedVerification")}</span> {toList(gateReasons.unknown).map(businessGateLabel).join(", ")}</div>}
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {/* Risks & Validation tab */}
+                        {activeTab === "risks" && (
+                          <div className="ea-memo-tab-panel">
+                            {/* Best use case + watchout */}
+                            {(rec.best_use_case || rec.main_watchout) && (
+                              <div style={{ display: "grid", gap: 8 }}>
+                                {rec.best_use_case && (
+                                  <div className="ea-memo-callout ea-memo-callout--positive">
+                                    <span className="ea-memo-callout__label">{t("expansionAdvisor.bestUseCase")}</span>
+                                    <p className="ea-detail__text">{rec.best_use_case}</p>
+                                  </div>
+                                )}
+                                {rec.main_watchout && (
+                                  <div className="ea-memo-callout ea-memo-callout--risk">
+                                    <span className="ea-memo-callout__label">{t("expansionAdvisor.mainWatchout")}</span>
+                                    <p className="ea-detail__text">{rec.main_watchout}</p>
+                                  </div>
+                                )}
+                              </div>
+                            )}
+
+                            {/* Strengths / risks — two-column */}
+                            <div className="ea-memo-two-col">
+                              <div>
+                                <span className="ea-memo-callout__label" style={{ color: "var(--oak-success, #16a34a)" }}>{t("expansionAdvisor.topPositives")}</span>
+                                {positives.length > 0 ? <ul className="ea-memo-list">{positives.map((s, i) => <li key={i}>{s}</li>)}</ul> : <p className="ea-detail__text">—</p>}
+                              </div>
+                              <div>
+                                <span className="ea-memo-callout__label" style={{ color: "var(--oak-error, #d4183d)" }}>{t("expansionAdvisor.topRisks")}</span>
+                                {risks.length > 0 ? <ul className="ea-memo-list">{risks.map((s, i) => <li key={i}>{s}</li>)}</ul> : <p className="ea-detail__text">—</p>}
+                              </div>
                             </div>
+
+                            {/* Validation plan — 2-column layout */}
+                            {(toList(gateReasons?.unknown).length > 0 || toList(gateReasons?.passed).length > 0) && (
+                              <div className="ea-memo-validation-grid">
+                                <div className="ea-memo-validation-col">
+                                  <h6 className="ea-memo-validation-col__title ea-memo-validation-col__title--must">{t("expansionAdvisor.vpMustVerify")}</h6>
+                                  {toList(gateReasons?.unknown).map((item, i) => (
+                                    <div key={i} className="ea-memo-validation-item ea-memo-validation-item--must">
+                                      <span className="ea-memo-validation-dot ea-memo-validation-dot--must" />
+                                      <span>{businessGateLabel(item)}</span>
+                                    </div>
+                                  ))}
+                                  {toList(gateReasons?.failed).map((item, i) => (
+                                    <div key={`f-${i}`} className="ea-memo-validation-item ea-memo-validation-item--must">
+                                      <span className="ea-memo-validation-dot ea-memo-validation-dot--fail" />
+                                      <span>{businessGateLabel(item)}</span>
+                                    </div>
+                                  ))}
+                                </div>
+                                <div className="ea-memo-validation-col">
+                                  <h6 className="ea-memo-validation-col__title ea-memo-validation-col__title--confirmed">{t("expansionAdvisor.vpAlreadyStrong")}</h6>
+                                  {toList(gateReasons?.passed).map((item, i) => (
+                                    <div key={i} className="ea-memo-validation-item ea-memo-validation-item--confirmed">
+                                      <span className="ea-memo-validation-check">&#10003;</span>
+                                      <span>{businessGateLabel(item)}</span>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
                           </div>
                         )}
                       </div>
+                    </div>
+
+                    {/* Score breakdown — collapsed, with humanized labels */}
+                    {breakdown && breakdown.weighted_components && Object.keys(breakdown.weighted_components).length > 0 && (
+                      <details className="ea-report-section">
+                        <summary className="ea-detail__section-title" style={{ cursor: "pointer" }}>{t("expansionAdvisor.memoScoreBreakdown")}</summary>
+                        <div className="ea-detail__grid">
+                          {Object.entries(breakdown.weighted_components).map(([key, val]) => (
+                            <div key={key} className="ea-detail__kv">
+                              <span className="ea-detail__kv-label">{humanizeScoreLabel(key)}</span>
+                              <span className="ea-detail__kv-value">{typeof val === "number" ? fmtScore(val) : String(val ?? "—")}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </details>
+                    )}
+
+                    {/* Technical details — collapsed */}
+                    {snapshot && (
+                      <details className="ea-debug">
+                        <summary>{t("expansionAdvisor.technicalDetails")}</summary>
+                        <div className="ea-report-section">
+                          <h5 className="ea-detail__section-title">{t("expansionAdvisor.memoFeatureSnapshot")}</h5>
+                          <div className="ea-detail__grid">
+                            <div className="ea-detail__kv">
+                              <span className="ea-detail__kv-label">{t("expansionAdvisor.dataCompleteness")}</span>
+                              <span className="ea-detail__kv-value">{snapshot.data_completeness_score != null ? `${Math.round(Number(snapshot.data_completeness_score))}%` : "—"}</span>
+                            </div>
+                          </div>
+                          {Object.keys(snapshot.context_sources || {}).length > 0 && (
+                            <div style={{ fontSize: "var(--oak-fs-xs)", marginTop: 4, color: "var(--oak-text-light)" }}>
+                              {t("expansionAdvisor.contextSources")}: {Object.keys(snapshot.context_sources).join(", ")}
+                            </div>
+                          )}
+                          {(snapshot.missing_context || []).length > 0 && (
+                            <div style={{ fontSize: "var(--oak-fs-xs)", marginTop: 4, color: "var(--oak-error, #d4183d)" }}>
+                              {t("expansionAdvisor.missingData")}: {snapshot.missing_context.join(", ")}
+                            </div>
+                          )}
+                        </div>
+                      </details>
                     )}
                   </div>
-                </div>
-
-                {/* Score breakdown — collapsed, with humanized labels */}
-                {breakdown && breakdown.weighted_components && Object.keys(breakdown.weighted_components).length > 0 && (
-                  <details className="ea-report-section">
-                    <summary className="ea-detail__section-title" style={{ cursor: "pointer" }}>{t("expansionAdvisor.memoScoreBreakdown")}</summary>
-                    <div className="ea-detail__grid">
-                      {Object.entries(breakdown.weighted_components).map(([key, val]) => (
-                        <div key={key} className="ea-detail__kv">
-                          <span className="ea-detail__kv-label">{humanizeScoreLabel(key)}</span>
-                          <span className="ea-detail__kv-value">{typeof val === "number" ? fmtScore(val) : String(val ?? "—")}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </details>
-                )}
-
-                {/* Technical details — collapsed */}
-                {snapshot && (
-                  <details className="ea-debug">
-                    <summary>{t("expansionAdvisor.technicalDetails")}</summary>
-                    <div className="ea-report-section">
-                      <h5 className="ea-detail__section-title">{t("expansionAdvisor.memoFeatureSnapshot")}</h5>
-                      <div className="ea-detail__grid">
-                        <div className="ea-detail__kv">
-                          <span className="ea-detail__kv-label">{t("expansionAdvisor.dataCompleteness")}</span>
-                          <span className="ea-detail__kv-value">{snapshot.data_completeness_score != null ? `${Math.round(Number(snapshot.data_completeness_score))}%` : "—"}</span>
-                        </div>
-                      </div>
-                      {Object.keys(snapshot.context_sources || {}).length > 0 && (
-                        <div style={{ fontSize: "var(--oak-fs-xs)", marginTop: 4, color: "var(--oak-text-light)" }}>
-                          {t("expansionAdvisor.contextSources")}: {Object.keys(snapshot.context_sources).join(", ")}
-                        </div>
-                      )}
-                      {(snapshot.missing_context || []).length > 0 && (
-                        <div style={{ fontSize: "var(--oak-fs-xs)", marginTop: 4, color: "var(--oak-error, #d4183d)" }}>
-                          {t("expansionAdvisor.missingData")}: {snapshot.missing_context.join(", ")}
-                        </div>
-                      )}
-                    </div>
-                  </details>
-                )}
+                </details>
 
                 {/* Copy-ready summary block */}
                 {isLeadCandidate && (

--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -3738,6 +3738,189 @@
   background: #F0FDF4;
 }
 
+/* ── Decision Memo Narrative ── */
+
+.ea-memo-narrative {
+  padding: 16px;
+  margin-bottom: 16px;
+  background: #FFFDF5;
+  border: 1px solid #E8E0C8;
+  border-radius: var(--oak-radius, 8px);
+}
+
+.ea-memo-narrative--loading {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 180px;
+}
+
+.ea-memo-narrative--error {
+  background: #FEF2F2;
+  border-color: #FECACA;
+  color: var(--oak-error, #d4183d);
+}
+
+.ea-memo-narrative__headline {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--oak-text-dark, #171717);
+}
+
+.ea-memo-narrative__summary {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0 0 12px;
+  color: var(--oak-text-dark, #333);
+}
+
+.ea-memo-narrative__section {
+  margin-bottom: 12px;
+}
+
+.ea-memo-narrative__section-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.ea-memo-narrative__section-title--positive {
+  color: var(--oak-success, #16a34a);
+}
+
+.ea-memo-narrative__section-title--risk {
+  color: var(--oak-error, #d4183d);
+}
+
+.ea-memo-narrative__list {
+  margin: 0;
+  padding-inline-start: 18px;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.ea-memo-narrative__callout {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 10px 14px;
+  background: #EEF6FF;
+  border-radius: 6px;
+  margin: 12px 0 4px;
+  font-size: 0.9rem;
+}
+
+.ea-memo-narrative__callout-label {
+  font-weight: 600;
+  white-space: nowrap;
+  color: var(--oak-primary, #14312c);
+}
+
+.ea-memo-narrative__rent-context {
+  font-size: 0.82rem;
+  font-style: italic;
+  color: var(--oak-text-light, #6b6b6b);
+  margin: 8px 0 0;
+}
+
+.ea-memo-narrative__loading-text {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--oak-text-light, #6b6b6b);
+}
+
+/* Skeleton placeholders */
+.ea-skeleton {
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: ea-skeleton-pulse 1.5s ease-in-out infinite;
+  border-radius: 4px;
+}
+
+.ea-skeleton--headline { height: 28px; width: 70%; }
+.ea-skeleton--paragraph { height: 48px; width: 100%; }
+.ea-skeleton--list { height: 20px; width: 85%; }
+
+@keyframes ea-skeleton-pulse {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── Key Numbers Strip ── */
+
+.ea-memo-key-numbers {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  padding: 14px 16px;
+  background: #F9FAFB;
+  border: 1px solid var(--oak-outlines, #d7d7d7);
+  border-radius: var(--oak-radius, 8px);
+  margin-bottom: 16px;
+}
+
+.ea-memo-key-numbers__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.ea-memo-key-numbers__value--big {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--oak-text-dark, #171717);
+}
+
+.ea-memo-key-numbers__label {
+  font-size: 0.75rem;
+  color: var(--oak-text-light, #6b6b6b);
+  text-align: center;
+}
+
+/* ── Full Breakdown Disclosure ── */
+
+.ea-memo-full-breakdown {
+  border: 1px solid var(--oak-outlines, #d7d7d7);
+  border-radius: var(--oak-radius, 8px);
+  margin-bottom: 16px;
+}
+
+.ea-memo-full-breakdown__toggle {
+  cursor: pointer;
+  padding: 12px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--oak-primary, #14312c);
+  list-style: none;
+  user-select: none;
+}
+
+.ea-memo-full-breakdown__toggle::-webkit-details-marker {
+  display: none;
+}
+
+.ea-memo-full-breakdown__toggle::before {
+  content: "\25B8  ";
+}
+
+.ea-memo-full-breakdown[open] > .ea-memo-full-breakdown__toggle::before {
+  content: "\25BE  ";
+}
+
+.ea-memo-full-breakdown__content {
+  padding: 0 16px 16px;
+}
+
+@media (max-width: 640px) {
+  .ea-memo-key-numbers {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 /* ── Global transitions ── */
 .ea-candidate,
 .ea-card,

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -919,5 +919,17 @@
     "execReportKeyRisks": "المخاطر الرئيسية",
     "execReportNextSteps": "الخطوات التالية",
     "execCopySuccess": "تم النسخ"
+  },
+  "decisionMemo": {
+    "loading": "جارٍ إنشاء مذكرة القرار...",
+    "error": "تعذّر إنشاء مذكرة القرار. يرجى المحاولة مرة أخرى.",
+    "showFullBreakdown": "عرض تفاصيل الدرجات الكاملة",
+    "whyPursue": "لماذا نتابع",
+    "risksToWeigh": "مخاطر يجب مراعاتها",
+    "nextAction": "الخطوة التالية الموصى بها",
+    "finalScore": "الدرجة النهائية",
+    "area": "المساحة",
+    "annualRent": "الإيجار السنوي",
+    "streetWidth": "عرض الشارع"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -972,5 +972,17 @@
     "execReportKeyRisks": "Key Risks",
     "execReportNextSteps": "Next Steps",
     "execCopySuccess": "Copied to clipboard"
+  },
+  "decisionMemo": {
+    "loading": "Generating decision memo...",
+    "error": "Could not generate decision memo. Please try again.",
+    "showFullBreakdown": "Show full score breakdown",
+    "whyPursue": "Why pursue",
+    "risksToWeigh": "Risks to weigh",
+    "nextAction": "Recommended next action",
+    "finalScore": "Final score",
+    "area": "Area",
+    "annualRent": "Annual rent",
+    "streetWidth": "Street width"
   }
 }

--- a/frontend/src/lib/api/expansionAdvisor.ts
+++ b/frontend/src/lib/api/expansionAdvisor.ts
@@ -576,3 +576,28 @@ export async function searchBranchSuggestions(q: string, limit = 15): Promise<Br
   const data = await readJson<BranchSuggestionsResponse>(res);
   return data.items || [];
 }
+
+// ── LLM Decision Memo ──────────────────────────────────────────────
+
+export type LLMDecisionMemo = {
+  headline: string;
+  fit_summary: string;
+  top_reasons_to_pursue: string[];
+  top_risks: string[];
+  recommended_next_action: string;
+  rent_context: string;
+};
+
+export async function generateDecisionMemo(
+  candidate: Record<string, unknown>,
+  brief: Record<string, unknown>,
+  lang: string,
+): Promise<LLMDecisionMemo> {
+  const res = await fetchWithAuth(buildApiUrl("/v1/expansion-advisor/decision-memo"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ candidate, brief, lang }),
+  });
+  const data = await readJson<{ memo: LLMDecisionMemo }>(res);
+  return data.memo;
+}

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -1,0 +1,245 @@
+"""Tests for app.services.llm_decision_memo."""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.llm_decision_memo import (
+    _daily_cost_tracker,
+    _format_rent_vs_median,
+    _today_key,
+    generate_decision_memo,
+)
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+SAMPLE_BRIEF = {
+    "brand_name": "TestCafe",
+    "category": "cafe",
+    "service_model": "cafe",
+    "min_area_m2": 40,
+    "max_area_m2": 120,
+    "target_area_m2": 80,
+    "existing_branches": [
+        {"name": "Branch 1", "lat": 24.7, "lon": 46.7, "district": "Olaya"},
+    ],
+    "brand_profile": {"primary_channel": "dine_in"},
+}
+
+SAMPLE_CANDIDATE = {
+    "id": "cand-001",
+    "parcel_id": "aqar-12345",
+    "district_display": "Al Marwah",
+    "district": "marwah",
+    "area_m2": 65,
+    "estimated_annual_rent_sar": 35000,
+    "estimated_rent_sar_m2_year": 538,
+    "unit_street_width_m": 20,
+    "final_score": 82,
+    "economics_score": 75,
+    "brand_fit_score": 88,
+    "demand_score": 70,
+    "provider_whitespace_score": 60,
+    "listing_quality_score": 72,
+    "district_median_rent": 40000,
+    "llm_reasoning": "Landlord excludes laundromats, near Hyper Panda.",
+}
+
+VALID_LLM_RESPONSE = {
+    "headline": "GO: Al Marwah is a strong cafe fit near high footfall.",
+    "fit_summary": (
+        "Al Marwah offers TestCafe a competitive location with strong foot "
+        "traffic. As a cafe operator, TestCafe benefits from proximity to "
+        "Hyper Panda and the landlord's preference for quality tenants."
+    ),
+    "top_reasons_to_pursue": [
+        "Strong footfall from adjacent Hyper Panda",
+        "Landlord explicitly excludes low-value tenants",
+        "Rent 12% below district median",
+    ],
+    "top_risks": [
+        "Street width may limit visibility",
+        "No drive-thru capability",
+        "Competition from existing cafes in corridor",
+    ],
+    "recommended_next_action": "Schedule a site visit to confirm storefront visibility from main road.",
+    "rent_context": "Annual rent of SAR 35,000 is 12% below the Al Marwah district median of SAR 40,000.",
+}
+
+
+def _make_mock_response(content_dict: dict | str, input_tokens: int = 500, output_tokens: int = 300):
+    """Build a mock OpenAI ChatCompletion response."""
+    mock = MagicMock()
+    if isinstance(content_dict, dict):
+        mock.choices = [MagicMock(message=MagicMock(content=json.dumps(content_dict)))]
+    else:
+        mock.choices = [MagicMock(message=MagicMock(content=content_dict))]
+    mock.usage = MagicMock(prompt_tokens=input_tokens, completion_tokens=output_tokens)
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def _reset_cost_tracker():
+    """Reset the daily cost tracker before each test."""
+    _daily_cost_tracker.clear()
+    yield
+    _daily_cost_tracker.clear()
+
+
+# ── Tests ───────────────────────────────────────────────────────────
+
+
+class TestFormatRentVsMedian:
+    def test_none_inputs_return_unknown_en(self):
+        assert _format_rent_vs_median(None, 40000, "en") == "unknown"
+        assert _format_rent_vs_median(35000, None, "en") == "unknown"
+        assert _format_rent_vs_median(None, None, "en") == "unknown"
+
+    def test_none_inputs_return_unknown_ar(self):
+        assert _format_rent_vs_median(None, 40000, "ar") == "غير معروف"
+
+    def test_in_line_with_median(self):
+        assert _format_rent_vs_median(40000, 40000, "en") == "in line with median"
+        assert _format_rent_vs_median(40000, 40000, "ar") == "متوافق مع المتوسط"
+        # Within 5% threshold
+        assert _format_rent_vs_median(41000, 40000, "en") == "in line with median"
+
+    def test_above_median(self):
+        result = _format_rent_vs_median(48000, 40000, "en")
+        assert "above median" in result
+        assert "20%" in result
+
+    def test_below_median(self):
+        result = _format_rent_vs_median(35000, 40000, "en")
+        assert "below median" in result
+
+    def test_below_median_ar(self):
+        result = _format_rent_vs_median(35000, 40000, "ar")
+        assert "أقل من المتوسط" in result
+
+    def test_zero_median_returns_unknown(self):
+        assert _format_rent_vs_median(35000, 0, "en") == "unknown"
+
+
+class TestDailyCeilingBlocksCall:
+    def test_ceiling_blocks_when_exceeded(self):
+        today = _today_key()
+        _daily_cost_tracker[today] = 1.00
+
+        with pytest.raises(RuntimeError, match="daily cost ceiling"):
+            generate_decision_memo(
+                candidate=SAMPLE_CANDIDATE,
+                brief=SAMPLE_BRIEF,
+                lang="en",
+            )
+
+
+class TestSuccessfulGeneration:
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_returns_all_fields(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_mock_response(VALID_LLM_RESPONSE)
+        mock_get_client.return_value = mock_client
+
+        result = generate_decision_memo(
+            candidate=SAMPLE_CANDIDATE,
+            brief=SAMPLE_BRIEF,
+            lang="en",
+        )
+
+        assert result["headline"] == VALID_LLM_RESPONSE["headline"]
+        assert result["fit_summary"] == VALID_LLM_RESPONSE["fit_summary"]
+        assert len(result["top_reasons_to_pursue"]) == 3
+        assert len(result["top_risks"]) == 3
+        assert result["recommended_next_action"] == VALID_LLM_RESPONSE["recommended_next_action"]
+        assert result["rent_context"] == VALID_LLM_RESPONSE["rent_context"]
+
+
+class TestMissingFieldFilledGracefully:
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_missing_list_field_filled_with_empty_list(self, mock_get_client):
+        incomplete = {
+            "headline": "CONSIDER: Decent spot",
+            "fit_summary": "Looks OK for TestCafe.",
+            "recommended_next_action": "Visit site.",
+            "rent_context": "Rent is reasonable.",
+            # top_reasons_to_pursue and top_risks are missing
+        }
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_mock_response(incomplete)
+        mock_get_client.return_value = mock_client
+
+        result = generate_decision_memo(
+            candidate=SAMPLE_CANDIDATE,
+            brief=SAMPLE_BRIEF,
+            lang="en",
+        )
+
+        assert result["top_risks"] == []
+        assert result["top_reasons_to_pursue"] == []
+        assert result["headline"] == "CONSIDER: Decent spot"
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_missing_string_field_filled_with_dash(self, mock_get_client):
+        incomplete = {
+            "headline": "GO: Good site",
+            "top_reasons_to_pursue": ["reason 1"],
+            "top_risks": ["risk 1"],
+            # fit_summary, recommended_next_action, rent_context missing
+        }
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_mock_response(incomplete)
+        mock_get_client.return_value = mock_client
+
+        result = generate_decision_memo(
+            candidate=SAMPLE_CANDIDATE,
+            brief=SAMPLE_BRIEF,
+            lang="en",
+        )
+
+        assert result["fit_summary"] == "—"
+        assert result["recommended_next_action"] == "—"
+        assert result["rent_context"] == "—"
+
+
+class TestInvalidJsonRaises:
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_non_json_raises_runtime_error(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_mock_response(
+            "This is not JSON at all, just plain text."
+        )
+        mock_get_client.return_value = mock_client
+
+        with pytest.raises(RuntimeError, match="invalid JSON"):
+            generate_decision_memo(
+                candidate=SAMPLE_CANDIDATE,
+                brief=SAMPLE_BRIEF,
+                lang="en",
+            )
+
+
+class TestArabicLangUsesArabicTemplate:
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_arabic_prompt_contains_arabic_text(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _make_mock_response(VALID_LLM_RESPONSE)
+        mock_get_client.return_value = mock_client
+
+        generate_decision_memo(
+            candidate=SAMPLE_CANDIDATE,
+            brief=SAMPLE_BRIEF,
+            lang="ar",
+        )
+
+        # Capture the prompt sent to the mock client
+        call_args = mock_client.chat.completions.create.call_args
+        messages = call_args.kwargs.get("messages") or call_args[1].get("messages", [])
+        prompt_text = messages[0]["content"]
+
+        # The Arabic template contains this string
+        assert "موجز العلامة التجارية للمشغّل" in prompt_text


### PR DESCRIPTION
## Summary
Adds an AI-generated decision memo narrative feature to the Expansion Advisor memo panel. When viewing a candidate site, users can now see an LLM-generated summary explaining whether the site is a fit for their brand, including key reasons to pursue, risks to weigh, and recommended next actions.

## Key Changes

**Backend (Python)**
- New `app/services/llm_decision_memo.py` module that generates decision memos using OpenAI's API
  - Supports both English and Arabic prompts with culturally appropriate formatting
  - Implements daily cost ceiling tracking to control API spending
  - Gracefully handles missing fields in LLM responses
  - Includes rent-vs-median comparison helper for contextual analysis
  - Configurable via environment variables (model, max tokens, daily ceiling)
- New `/v1/expansion-advisor/decision-memo` POST endpoint in `app/api/expansion_advisor.py`
- Comprehensive test suite (`tests/test_llm_decision_memo.py`) covering cost tracking, field validation, error handling, and both languages

**Frontend (React/TypeScript)**
- New `DecisionMemoNarrative.tsx` component that:
  - Fetches and displays the LLM-generated memo
  - Implements client-side caching by candidate ID to avoid re-fetching
  - Shows skeleton loaders during generation
  - Handles errors gracefully
  - Supports RTL layout for Arabic
- Restructured `ExpansionMemoPanel.tsx` layout:
  - LLM narrative now appears at the top (always visible when data available)
  - New "4 Key Numbers" strip showing final score, area, annual rent, and street width
  - Full score breakdown (economics, market, site, risks tabs) moved into a collapsible `<details>` section
  - Passes `candidateRaw`, `briefRaw`, and `lang` props to enable memo generation
- New API function `generateDecisionMemo()` in `frontend/src/lib/api/expansionAdvisor.ts`
- Added i18n strings for both English and Arabic in `en.json` and `ar.json`
- New CSS styles in `expansion-advisor.css` for narrative display, key numbers strip, and collapsible breakdown section

## Notable Implementation Details

- **Cost Control**: Daily spending ceiling prevents runaway API costs; raises `RuntimeError` before calling OpenAI if limit exceeded
- **Graceful Degradation**: Missing LLM response fields are filled with empty lists or "—" placeholders rather than failing
- **Bilingual Support**: Separate prompt templates for English and Arabic with language-appropriate formatting
- **Caching**: Frontend caches memos by candidate ID to avoid duplicate API calls during re-renders
- **Responsive Layout**: Key numbers grid adapts from 4 columns to 2 columns on mobile
- **Accessibility**: Proper heading hierarchy, semantic HTML, and RTL support for Arabic

https://claude.ai/code/session_011DMgchR3aiFT9DXTDDkwK6