### PR TITLE
Add Aqar Scraper workflow trigger to LLM suitability backfill

### DIFF
--- a/.github/workflows/llm-suitability-backfill.yml
+++ b/.github/workflows/llm-suitability-backfill.yml
@@ -12,7 +12,9 @@ on:
         required: false
         default: "false"
   workflow_run:
-    workflows: ["Deploy to sccc (Alibaba Cloud Riyadh)"]
+    workflows:
+      - "Deploy to sccc (Alibaba Cloud Riyadh)"
+      - "Aqar Scraper"
     types: [completed]
 
 jobs:


### PR DESCRIPTION
## Summary
Updated the LLM suitability backfill workflow to be triggered by an additional workflow completion event.

## Key Changes
- Reformatted the `workflows` trigger from a single-item string to a list format for better maintainability
- Added "Aqar Scraper" workflow as an additional trigger alongside the existing "Deploy to sccc (Alibaba Cloud Riyadh)" workflow
- The backfill job will now execute upon completion of either workflow

## Implementation Details
The workflow trigger configuration now uses explicit list syntax, making it easier to manage multiple workflow dependencies and add future triggers as needed.

https://claude.ai/code/session_01Ecd2ngnbbawv1yVqtBPuzs