### PR TITLE
Bypass structural heuristics for high-confidence LLM suitability verdicts

### DIFF
--- a/app/ingest/candidate_locations.py
+++ b/app/ingest/candidate_locations.py
@@ -77,14 +77,30 @@ def _ingest_tier1_aqar(db: Session, run_id: str) -> int:
         WHERE cu.status = 'active'
           AND cu.restaurant_suitable = TRUE
           AND (cu.property_type IS NULL OR cu.property_type NOT IN ('Residential', 'سكني'))
-          AND NOT (cu.is_furnished = TRUE AND cu.listing_type = 'building')
-          AND NOT (COALESCE(cu.apartments_count, 0) >= 2 AND cu.listing_type = 'building')
-          AND NOT (COALESCE(cu.num_rooms, 0) >= 6 AND cu.listing_type = 'building')
-          AND NOT (
-                cu.listing_type = 'building'
-                AND (
-                    cu.description ~* '(bedroom|غرفة نوم|غرف نوم|غرفة ماستر|ماستر)'
-                    OR cu.area_sqm < 150
+          -- Structural residential heuristics below are bypassed when the LLM
+          -- suitability classifier has strong unit-level ground truth
+          -- (verdict='suitable' AND score>=70). Rationale: Riyadh mixed-use
+          -- buildings often list legitimate ground-floor F&B units whose
+          -- structural fields (apartments_count, num_rooms, small area) look
+          -- residential. The LLM reads the ad copy + photos and is more
+          -- reliable at the unit level. See Codespace Test 2 (2026-04-13):
+          -- ~34 rescued listings, e.g. aqar_id 6518374, 6642176, 6618901.
+          AND (
+                (
+                    cu.llm_suitability_verdict = 'suitable'
+                    AND COALESCE(cu.llm_suitability_score, 0) >= 70
+                )
+                OR (
+                    NOT (cu.is_furnished = TRUE AND cu.listing_type = 'building')
+                    AND NOT (COALESCE(cu.apartments_count, 0) >= 2 AND cu.listing_type = 'building')
+                    AND NOT (COALESCE(cu.num_rooms, 0) >= 6 AND cu.listing_type = 'building')
+                    AND NOT (
+                        cu.listing_type = 'building'
+                        AND (
+                            cu.description ~* '(bedroom|غرفة نوم|غرف نوم|غرفة ماستر|ماستر)'
+                            OR cu.area_sqm < 150
+                        )
+                    )
                 )
             )
           AND cu.listing_type != 'warehouse'


### PR DESCRIPTION
## Summary
Updated the Tier 1 AQAR candidate location ingestion logic to bypass structural residential heuristics when the LLM suitability classifier has strong unit-level ground truth. This allows legitimate ground-floor F&B units in mixed-use buildings to be rescued from false negatives.

## Key Changes
- Modified the WHERE clause in `_ingest_tier1_aqar()` to add a conditional bypass mechanism
- When `llm_suitability_verdict = 'suitable'` AND `llm_suitability_score >= 70`, the structural heuristics (furnished + building type, apartments count, room count, bedroom keywords, and area size checks) are skipped
- When LLM confidence is below the threshold, the original structural heuristics are applied as before
- Added detailed inline comments explaining the rationale: Riyadh mixed-use buildings often have legitimate ground-floor F&B units whose structural fields (apartments_count, num_rooms, small area) appear residential, but the LLM's analysis of ad copy and photos is more reliable at the unit level

## Implementation Details
- The change wraps the original heuristics in an OR condition with the LLM confidence check
- This preserves backward compatibility while leveraging high-confidence LLM predictions
- Based on testing (Codespace Test 2, 2026-04-13), this approach rescues ~34 listings that were previously filtered out, including specific examples: aqar_id 6518374, 6642176, 6618901

https://claude.ai/code/session_01B85iv4ERE5VkYsKjURkJY5