### PR TITLE
Add realized-demand signal (rating_count Δ) to delivery scoring

### DIFF
--- a/alembic/versions/20260413_ea_delivery_rating_history.py
+++ b/alembic/versions/20260413_ea_delivery_rating_history.py
@@ -1,0 +1,71 @@
+"""Expansion Advisor — delivery rating-count history for realized-demand signal.
+
+Creates ``expansion_delivery_rating_history``: a per-snapshot record of the
+rating_count observed on each delivery_source_record (HungerStation, Jahez,
+Keeta, Talabat, Mrsool, …).  Snapshotting rating_count nightly lets the
+service layer compute a *realized* demand signal (Δrating_count per hex per
+category over a trailing window) instead of the current *supply* proxy
+(listing count).
+
+The table is additive and not yet wired into scoring by default — the
+service layer only consults it when ``EXPANSION_REALIZED_DEMAND_ENABLED``
+is true, so creating this table is safe with no immediate behavior change.
+
+Revision ID: 20260413_ea_rating_hist
+Revises: 20260411_llm_suitability
+Create Date: 2026-04-13
+"""
+from alembic import op
+
+
+revision = "20260413_ea_rating_hist"
+down_revision = "20260411_llm_suitability"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS expansion_delivery_rating_history (
+            id                      BIGSERIAL PRIMARY KEY,
+            source_record_id        INTEGER NOT NULL,
+            platform                VARCHAR(32) NOT NULL,
+            brand_name              VARCHAR(256),
+            category_raw            VARCHAR(128),
+            cuisine_raw             VARCHAR(128),
+            rating                  NUMERIC(3,2),
+            rating_count            INTEGER,
+            lat                     DOUBLE PRECISION,
+            lon                     DOUBLE PRECISION,
+            geom                    geometry(Point, 4326),
+            captured_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+            captured_date           DATE GENERATED ALWAYS AS
+                                    (((captured_at AT TIME ZONE 'UTC')::date)) STORED
+        )
+    """)
+    # Idempotent daily snapshots: a given source_record gets at most one row per UTC day.
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS
+            ux_edrh_source_captured_date
+        ON expansion_delivery_rating_history (source_record_id, captured_date)
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_edrh_captured_at "
+        "ON expansion_delivery_rating_history USING btree (captured_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_edrh_geom "
+        "ON expansion_delivery_rating_history USING gist (geom)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_edrh_source_captured_desc "
+        "ON expansion_delivery_rating_history (source_record_id, captured_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_edrh_source_captured_desc")
+    op.execute("DROP INDEX IF EXISTS ix_edrh_geom")
+    op.execute("DROP INDEX IF EXISTS ix_edrh_captured_at")
+    op.execute("DROP INDEX IF EXISTS ux_edrh_source_captured_date")
+    op.execute("DROP TABLE IF EXISTS expansion_delivery_rating_history")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -75,5 +75,27 @@ class Settings:
         "EXPANSION_COMPETITOR_TABLE", "expansion_competitor_quality"
     )
 
+    # --- Realized demand (rating_count Δ) signal ---
+    # When enabled AND the ``expansion_delivery_rating_history`` table has
+    # ≥2 snapshots for the candidate's catchment, the service layer blends a
+    # realized-demand score (rating_count growth per category per radius over
+    # the last N days) into the supply-based _delivery_score().  Default OFF
+    # so behavior is unchanged until history has accumulated.
+    EXPANSION_REALIZED_DEMAND_ENABLED: bool = (
+        os.getenv("EXPANSION_REALIZED_DEMAND_ENABLED", "").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+    EXPANSION_REALIZED_DEMAND_WINDOW_DAYS: int = int(
+        os.getenv("EXPANSION_REALIZED_DEMAND_WINDOW_DAYS", "30")
+    )
+    EXPANSION_REALIZED_DEMAND_RADIUS_M: int = int(
+        os.getenv("EXPANSION_REALIZED_DEMAND_RADIUS_M", "1200")
+    )
+    # Weight given to realized-demand vs listing-count when both are available.
+    # 0.5 = equal blend; 1.0 = realized-demand only; 0.0 = listing-count only.
+    EXPANSION_REALIZED_DEMAND_BLEND: float = float(
+        os.getenv("EXPANSION_REALIZED_DEMAND_BLEND", "0.5")
+    )
+
 
 settings = Settings()

--- a/app/ingest/expansion_advisor_delivery.py
+++ b/app/ingest/expansion_advisor_delivery.py
@@ -205,6 +205,67 @@ def _normalize_delivery_records(db, platforms: list[str], allow_empty: bool) -> 
     }
 
 
+def _snapshot_rating_counts(db, platforms: list[str]) -> dict:
+    """Append a daily snapshot of rating_count per delivery_source_record.
+
+    Feeds the ``expansion_delivery_rating_history`` table so the service
+    layer can derive a realized-demand signal (Δrating_count over a trailing
+    window) per category per hex.  Idempotent per UTC day via the
+    ``ux_edrh_source_captured_date`` unique index.
+
+    Safe no-op when the history table does not yet exist (migration not
+    applied).  Only Riyadh-geolocated rows are captured.
+    """
+    if not table_exists(db, "expansion_delivery_rating_history"):
+        msg = "expansion_delivery_rating_history table does not exist; skipping snapshot"
+        logger.info(msg)
+        return {"inserted": 0, "skipped_reason": msg}
+    if not table_exists(db, "delivery_source_record"):
+        return {"inserted": 0, "skipped_reason": "delivery_source_record missing"}
+
+    bbox = RIYADH_BBOX
+    platform_list = ", ".join(f"'{p}'" for p in platforms)
+    insert_sql = text(f"""
+        INSERT INTO expansion_delivery_rating_history (
+            source_record_id, platform, brand_name,
+            category_raw, cuisine_raw, rating, rating_count,
+            lat, lon, geom
+        )
+        SELECT
+            dsr.id,
+            lower(dsr.platform),
+            COALESCE(dsr.brand_raw, dsr.restaurant_name_normalized, dsr.restaurant_name_raw),
+            dsr.category_raw,
+            dsr.cuisine_raw,
+            dsr.rating,
+            dsr.rating_count,
+            CAST(BTRIM(CAST(dsr.lat AS text)) AS double precision),
+            CAST(BTRIM(CAST(dsr.lon AS text)) AS double precision),
+            ST_SetSRID(ST_MakePoint(
+                CAST(BTRIM(CAST(dsr.lon AS text)) AS double precision),
+                CAST(BTRIM(CAST(dsr.lat AS text)) AS double precision)
+            ), 4326)
+        FROM delivery_source_record dsr
+        WHERE dsr.rating_count IS NOT NULL
+          AND dsr.lat IS NOT NULL
+          AND dsr.lon IS NOT NULL
+          AND BTRIM(CAST(dsr.lon AS text)) ~ '^[-+]?[0-9]*\\.?[0-9]+$'
+          AND BTRIM(CAST(dsr.lat AS text)) ~ '^[-+]?[0-9]*\\.?[0-9]+$'
+          AND CAST(BTRIM(CAST(dsr.lon AS text)) AS double precision)
+              BETWEEN {bbox['min_lon']} AND {bbox['max_lon']}
+          AND CAST(BTRIM(CAST(dsr.lat AS text)) AS double precision)
+              BETWEEN {bbox['min_lat']} AND {bbox['max_lat']}
+          AND lower(dsr.platform) IN ({platform_list})
+        ON CONFLICT (source_record_id, captured_date) DO NOTHING
+    """)
+
+    result = db.execute(insert_sql)
+    db.commit()
+    inserted = result.rowcount or 0
+    logger.info("Appended %d delivery rating-count history rows", inserted)
+    return {"inserted": inserted}
+
+
 def _run_delivery_scrape(platforms: list[str], max_pages: int) -> list[dict]:
     """Run the delivery scrape pipeline to populate delivery_source_record.
 
@@ -268,6 +329,12 @@ def main() -> None:
         stats = _normalize_delivery_records(db, platforms, args.allow_empty)
         stats["resolved_platforms"] = platforms
         stats["platform_preset"] = args.platforms
+        # Append a daily rating_count snapshot for the realized-demand signal.
+        # Safe when the history table does not yet exist.
+        try:
+            stats["rating_history_snapshot"] = _snapshot_rating_counts(db, platforms)
+        except Exception:
+            logger.warning("rating-count history snapshot failed", exc_info=True)
         stats["scrape_results"] = [
             {k: v for k, v in r.items() if k != "raw_results"}
             for r in scrape_results

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -1782,11 +1782,41 @@ def _population_score(
     return _clamp((population_reach / reference) ** 0.5 * 100.0)
 
 
-def _delivery_score(delivery_listing_count: int) -> float:
-    """Square-root scaled delivery score for wider dynamic range."""
-    if delivery_listing_count <= 0:
-        return 0.0
-    return _clamp((delivery_listing_count / 40.0) ** 0.5 * 100.0)
+def _delivery_score(
+    delivery_listing_count: int,
+    *,
+    realized_demand: float | None = None,
+    blend_weight: float = 0.5,
+) -> float:
+    """Square-root scaled delivery score for wider dynamic range.
+
+    Two signals are supported:
+
+    * ``delivery_listing_count`` — same-category branches observed in the
+      delivery catchment (supply / saturation proxy).  Always available.
+    * ``realized_demand`` — Σ Δrating_count across same-category branches in
+      the catchment over the trailing window (proxy for actual order volume;
+      a rating accrues roughly per order on delivery platforms).  Only
+      populated when ``EXPANSION_REALIZED_DEMAND_ENABLED`` is true and the
+      history table has ≥2 snapshots for the catchment.
+
+    When realized demand is available, blend it with the listing-count
+    signal: ``score = (1-w) · listing + w · realized``.  Otherwise fall
+    back to today's supply-count behavior unchanged.
+    """
+    listing_score = (
+        0.0
+        if delivery_listing_count <= 0
+        else _clamp((delivery_listing_count / 40.0) ** 0.5 * 100.0)
+    )
+    if realized_demand is None or realized_demand <= 0:
+        return listing_score
+    # Reference: 200 new ratings/window ≈ 100.  Square-root scaling mirrors
+    # the listing-count term so the two blend cleanly.  Calibrate once
+    # enough history has accumulated across Riyadh.
+    realized_score = _clamp((realized_demand / 200.0) ** 0.5 * 100.0)
+    bw = max(0.0, min(1.0, blend_weight))
+    return _clamp(listing_score * (1.0 - bw) + realized_score * bw)
 
 
 def _demand_blend_weights(service_model: str) -> tuple[float, float]:
@@ -5113,6 +5143,105 @@ def run_expansion_search(
                 )
         except Exception:
             logger.warning("expansion_search bulk delivery enrichment failed, using legacy counts", exc_info=True)
+
+    # ── Bulk realized-demand enrichment (Δrating_count over trailing window) ──
+    # Category-specific realized-demand signal derived from the rating_count
+    # history table.  Runs only when the feature flag is on AND the history
+    # table is present with data.  Listing-count-only behavior is preserved
+    # when disabled or when the history table is empty for the catchment.
+    if (
+        settings.EXPANSION_REALIZED_DEMAND_ENABLED
+        and _bulk_delivery
+        and _cached_table_available(db, "expansion_delivery_rating_history")
+    ):
+        try:
+            _window_days = int(settings.EXPANSION_REALIZED_DEMAND_WINDOW_DAYS)
+            _rd_radius_m = int(settings.EXPANSION_REALIZED_DEMAND_RADIUS_M)
+            _rd_values_parts: list[str] = []
+            _rd_cat_terms = _expand_category_terms(category)
+            _rd_cat_conditions = " OR ".join(
+                f"(lower(COALESCE(h.category_raw, '')) LIKE :rd_cat_{i} "
+                f"OR lower(COALESCE(h.cuisine_raw, '')) LIKE :rd_cat_{i})"
+                for i in range(len(_rd_cat_terms))
+            )
+            _rd_params: dict[str, Any] = {
+                f"rd_cat_{i}": f"%{term}%"
+                for i, term in enumerate(_rd_cat_terms)
+            }
+            _rd_params["rd_window_days"] = _window_days
+            _rd_params["rd_radius_m"] = _rd_radius_m
+            for _idx, _r in enumerate(rows):
+                _pid = str(_r.get("parcel_id") or "")
+                _lon = _safe_float(_r.get("lon"))
+                _lat = _safe_float(_r.get("lat"))
+                if _pid and _lon != 0.0 and _lat != 0.0:
+                    _rd_values_parts.append(f"(:rdp_{_idx}, :rdx_{_idx}, :rdy_{_idx})")
+                    _rd_params[f"rdp_{_idx}"] = _pid
+                    _rd_params[f"rdx_{_idx}"] = _lon
+                    _rd_params[f"rdy_{_idx}"] = _lat
+            if _rd_values_parts:
+                _rd_values_sql = ", ".join(_rd_values_parts)
+                with db.begin_nested():
+                    _rd_rows = db.execute(
+                        text(f"""
+                            WITH cands(parcel_id, lon, lat) AS (
+                                VALUES {_rd_values_sql}
+                            ),
+                            branch_delta AS (
+                                SELECT
+                                    h.source_record_id,
+                                    (ARRAY_AGG(h.geom ORDER BY h.captured_at DESC))[1] AS geom,
+                                    GREATEST(
+                                        0,
+                                        MAX(h.rating_count) - MIN(h.rating_count)
+                                    ) AS delta
+                                FROM expansion_delivery_rating_history h
+                                WHERE h.captured_at >= now() - (:rd_window_days || ' days')::interval
+                                  AND h.rating_count IS NOT NULL
+                                  AND h.geom IS NOT NULL
+                                  AND ({_rd_cat_conditions})
+                                GROUP BY h.source_record_id
+                                HAVING COUNT(*) >= 2
+                            )
+                            SELECT
+                                c.parcel_id,
+                                COALESCE(SUM(bd.delta), 0) AS realized_demand,
+                                COUNT(DISTINCT bd.source_record_id) AS contributing_branches
+                            FROM cands c
+                            LEFT JOIN branch_delta bd
+                              ON bd.geom IS NOT NULL
+                             AND ST_DWithin(
+                                 bd.geom::geography,
+                                 ST_SetSRID(ST_MakePoint(
+                                     c.lon::double precision, c.lat::double precision
+                                 ), 4326)::geography,
+                                 :rd_radius_m
+                             )
+                            GROUP BY c.parcel_id
+                        """),
+                        _rd_params,
+                    ).mappings().all()
+                _rd_hits = 0
+                for _dr in _rd_rows:
+                    _pid_key = str(_dr["parcel_id"])
+                    _rd_val = _safe_int(_dr.get("realized_demand"))
+                    _rd_branches = _safe_int(_dr.get("contributing_branches"))
+                    if _pid_key in _bulk_delivery:
+                        _bulk_delivery[_pid_key]["realized_demand_30d"] = _rd_val
+                        _bulk_delivery[_pid_key]["realized_demand_branches"] = _rd_branches
+                        if _rd_branches > 0:
+                            _rd_hits += 1
+                logger.info(
+                    "expansion_search realized-demand enrichment: search_id=%s "
+                    "window_days=%d radius_m=%d parcels_with_signal=%d/%d",
+                    search_id, _window_days, _rd_radius_m, _rd_hits, len(_bulk_delivery),
+                )
+        except Exception:
+            logger.warning(
+                "expansion_search realized-demand enrichment failed; falling back to listing-count only",
+                exc_info=True,
+            )
+
     t_delivery_enrich_done = time.monotonic()
     logger.info(
         "expansion_search timing: delivery_enrichment=%.2fs search_id=%s",
@@ -5194,19 +5323,31 @@ def run_expansion_search(
         )
         # ── Apply bulk delivery enrichment results ──
         _pid_key = str(row.get("parcel_id") or "")
+        _realized_demand_30d: float | None = None
+        _realized_demand_branches: int = 0
         if _pid_key and _pid_key in _bulk_delivery:
             _del_stats = _bulk_delivery[_pid_key]
             provider_listing_count = _del_stats["listing_count"]
             provider_platform_count = _del_stats["platform_count"]
             delivery_listing_count = _del_stats["cat_count"]
             delivery_competition_count = delivery_listing_count
+            # Realized-demand signal (populated only when feature flag is on
+            # AND ≥2 rating_count snapshots exist for branches in the catchment).
+            _rd_raw = _del_stats.get("realized_demand_30d")
+            _realized_demand_branches = int(_del_stats.get("realized_demand_branches") or 0)
+            if _rd_raw is not None and _realized_demand_branches >= 3:
+                _realized_demand_30d = float(_rd_raw)
 
         district_norm = normalize_district_key(district)
         if target_district_norm and (not district_norm or district_norm not in target_district_norm):
             continue
 
         pop_score = _population_score(population_reach, service_model=service_model)
-        delivery_score = _delivery_score(delivery_listing_count)
+        delivery_score = _delivery_score(
+            delivery_listing_count,
+            realized_demand=_realized_demand_30d,
+            blend_weight=settings.EXPANSION_REALIZED_DEMAND_BLEND,
+        )
         _pop_w, _del_w = _demand_blend_weights(service_model)
         demand_score = _clamp(pop_score * _pop_w + delivery_score * _del_w)
 
@@ -5314,8 +5455,14 @@ def run_expansion_search(
                 multi_platform_presence_score = 0.0
                 delivery_competition_score = 0.0
 
-        # Recompute demand_score if district fallback modified delivery_listing_count
-        delivery_score = _delivery_score(delivery_listing_count)
+        # Recompute demand_score if district fallback modified delivery_listing_count.
+        # Realized-demand signal (if any) still applies at catchment level, so
+        # pass it through — the district fallback only adjusts listing_count.
+        delivery_score = _delivery_score(
+            delivery_listing_count,
+            realized_demand=_realized_demand_30d,
+            blend_weight=settings.EXPANSION_REALIZED_DEMAND_BLEND,
+        )
         demand_score = _clamp(pop_score * _pop_w + delivery_score * _del_w)
 
         _is_listing = bool(row.get("commercial_unit_id"))
@@ -6041,6 +6188,24 @@ def run_expansion_search(
         )
         cs["competitor_source"] = "expansion_competitor_quality" if ea_competitor_populated else "restaurant_poi"
         cs["delivery_observed"] = provider_listing_count > 0
+        # Realized-demand evidence (rating_count velocity over the trailing
+        # window).  Only populated when the feature flag is on and the
+        # history table has ≥3 contributing branches in the catchment;
+        # otherwise the field is explicitly None so the UI can distinguish
+        # "not computed" from "zero demand observed".
+        if _realized_demand_30d is not None:
+            feature_snapshot_json["realized_demand_30d"] = _realized_demand_30d
+            feature_snapshot_json["realized_demand_branches"] = _realized_demand_branches
+            feature_snapshot_json["realized_demand_window_days"] = int(
+                settings.EXPANSION_REALIZED_DEMAND_WINDOW_DAYS
+            )
+            cs["realized_demand_source"] = "expansion_delivery_rating_history"
+        else:
+            cs["realized_demand_source"] = (
+                "history_unavailable"
+                if not settings.EXPANSION_REALIZED_DEMAND_ENABLED
+                else "insufficient_history"
+            )
         cs["rent_micro_adjustment"] = prepared_item.get("rent_micro_meta")
         cs["rent_base_sar_m2_year"] = prepared_item.get("rent_base_sar_m2_year")
         _unit_street_width = _safe_float(row.get("unit_street_width_m")) if row.get("unit_street_width_m") else None

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -1951,3 +1951,52 @@ def test_report_compatible_with_legacy_two_arg_get_candidates():
     report = get_recommendation_report(db, "search-1")
     assert report is not None
     assert report["recommendation"]["best_candidate_id"] == "c1"
+
+
+# ── Realized-demand signal (rating_count Δ) ──
+
+def test_delivery_score_backwards_compatible_without_realized_demand():
+    """Legacy call signature must return the original supply-proxy score."""
+    from app.services.expansion_advisor import _delivery_score
+
+    # Reference point from the existing calibration: 40 listings → 100
+    assert _delivery_score(0) == 0.0
+    assert _delivery_score(40) == 100.0
+    assert 0.0 < _delivery_score(10) < _delivery_score(40)
+    # Explicit None realized_demand must equal listing-only score
+    assert _delivery_score(10, realized_demand=None) == _delivery_score(10)
+    # Zero realized_demand means "no signal" and must not drag the score down
+    assert _delivery_score(10, realized_demand=0.0) == _delivery_score(10)
+
+
+def test_delivery_score_blends_realized_demand_when_provided():
+    """When realized_demand is present, it blends with listing-count."""
+    from app.services.expansion_advisor import _delivery_score
+
+    listing_only = _delivery_score(10)  # ~50
+    # Realized demand of 200 Δ ratings ≈ 100 on the realized curve
+    blended = _delivery_score(10, realized_demand=200.0, blend_weight=0.5)
+    # Blend pulls the score toward the stronger realized signal
+    assert blended > listing_only
+    # Full-realized weight = realized score only
+    realized_only = _delivery_score(
+        10, realized_demand=200.0, blend_weight=1.0
+    )
+    assert abs(realized_only - 100.0) < 0.01
+    # Zero blend weight = listing-only
+    ignore_realized = _delivery_score(
+        10, realized_demand=200.0, blend_weight=0.0
+    )
+    assert abs(ignore_realized - listing_only) < 0.01
+
+
+def test_delivery_score_realized_low_demand_pulls_score_down():
+    """Saturated supply but no realized growth signals stagnation."""
+    from app.services.expansion_advisor import _delivery_score
+
+    saturated_listing_only = _delivery_score(80)  # high supply score
+    # Tiny realized-demand delta: catchment is over-served
+    saturated_with_low_demand = _delivery_score(
+        80, realized_demand=5.0, blend_weight=0.5
+    )
+    assert saturated_with_low_demand < saturated_listing_only


### PR DESCRIPTION
## Summary

Introduces a realized-demand signal based on rating_count velocity to complement the existing supply-based delivery scoring in Expansion Advisor. This allows the service to distinguish between high-supply-but-stagnant markets and markets with actual order growth, improving candidate ranking accuracy.

## Key Changes

- **Enhanced `_delivery_score()` function**: Extended to accept optional `realized_demand` and `blend_weight` parameters. When realized demand is available, it blends with the listing-count signal using configurable weights; otherwise falls back to the original supply-proxy behavior unchanged.

- **New database table `expansion_delivery_rating_history`**: Stores daily snapshots of rating_count per delivery_source_record with geospatial indexing. Idempotent per UTC day via unique constraint on (source_record_id, captured_date).

- **Bulk realized-demand enrichment in candidate search**: Queries the history table to compute Δrating_count per category per catchment over a configurable trailing window (default 30 days, 1200m radius). Results are merged into candidate rows only when ≥3 contributing branches exist in the catchment.

- **Feature flag controls**: Four new environment variables govern behavior:
  - `EXPANSION_REALIZED_DEMAND_ENABLED`: Master switch (default OFF for safe rollout)
  - `EXPANSION_REALIZED_DEMAND_WINDOW_DAYS`: Trailing window for Δ calculation (default 30)
  - `EXPANSION_REALIZED_DEMAND_RADIUS_M`: Catchment radius (default 1200m)
  - `EXPANSION_REALIZED_DEMAND_BLEND`: Weight for realized vs listing signal (default 0.5)

- **Daily snapshot ingestion**: `_snapshot_rating_counts()` in the delivery scrape pipeline appends history records. Safe no-op when the table doesn't exist (pre-migration).

- **Scoring output enrichment**: Candidate snapshots now include `realized_demand_30d`, `realized_demand_branches`, and `realized_demand_source` fields to surface the signal's provenance to the UI.

## Implementation Details

- **Calibration**: Realized-demand reference point is 200 new ratings/window ≈ 100 score, using square-root scaling to match listing-count term for clean blending.
- **Graceful degradation**: When the history table is absent, unavailable, or has insufficient snapshots, the service silently falls back to listing-count-only scoring with no behavior change.
- **Spatial query**: Uses PostGIS `ST_DWithin` to find same-category branches within the catchment radius, aggregating their rating_count deltas.
- **Backward compatibility**: Legacy code calling `_delivery_score(count)` with one argument continues to work identically.

## Testing

Added three test cases covering:
- Backward compatibility without realized demand
- Blending behavior with configurable weights
- Score reduction when supply is high but realized demand is low (stagnation detection)

https://claude.ai/code/session_01BA1eVtnAFYghM2haDwEtEa