### PR TITLE
Add structured decision memo LLM path (Phase 1)

### DIFF
--- a/alembic/versions/20260414_memo_json.py
+++ b/alembic/versions/20260414_memo_json.py
@@ -1,0 +1,50 @@
+"""Expansion Advisor — structured decision memo columns.
+
+Adds two nullable display columns to ``expansion_candidate``:
+
+* ``decision_memo`` (TEXT) — rendered, human-readable memo. On the structured
+  path this is the text rendered from the JSON; on the legacy fallback path
+  this is the generic memo returned to the caller. Populated whenever a memo
+  is generated; never queried for filtering/ranking.
+* ``decision_memo_json`` (JSONB) — the structured memo object (headline,
+  ranking_explanation, key_evidence, risks, comparison, bottom_line) when
+  the structured LLM path succeeds; NULL on fallback.
+
+Both columns are nullable, have no default, and are intentionally unindexed —
+they are display fields, not query fields. Raw SQL is used (instead of
+``op.add_column``) to match the style of ``20260413_ea_rating_hist`` and to
+keep the upgrade idempotent via ``IF NOT EXISTS`` / ``IF EXISTS`` guards.
+
+Revision ID: 20260414_memo_json
+Revises: 20260413_ea_rating_hist
+Create Date: 2026-04-14
+"""
+from alembic import op
+
+
+revision = "20260414_memo_json"
+down_revision = "20260413_ea_rating_hist"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE expansion_candidate "
+        "ADD COLUMN IF NOT EXISTS decision_memo TEXT"
+    )
+    op.execute(
+        "ALTER TABLE expansion_candidate "
+        "ADD COLUMN IF NOT EXISTS decision_memo_json JSONB"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE expansion_candidate "
+        "DROP COLUMN IF EXISTS decision_memo_json"
+    )
+    op.execute(
+        "ALTER TABLE expansion_candidate "
+        "DROP COLUMN IF EXISTS decision_memo"
+    )

--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -35,7 +35,12 @@ from app.services.expansion_advisor import (
 )
 
 
-from app.services.llm_decision_memo import generate_decision_memo
+from app.services.llm_decision_memo import (
+    build_memo_context,
+    generate_decision_memo,
+    generate_structured_memo,
+    render_structured_memo_as_text,
+)
 from app.services.aqar_district_match import normalize_district_key
 from app.api.search import normalize_search_text
 
@@ -981,18 +986,228 @@ class DecisionMemoRequest(BaseModel):
     candidate: dict[str, Any]
     brief: dict[str, Any]
     lang: str = "en"
+    # Additive (Phase 1) — frontend will be updated in Phase 3 to pass these
+    # so the endpoint can cache memos per-candidate in ``expansion_candidate``.
+    # When either is missing, the endpoint behaves as today (generate fresh,
+    # no cache, no persistence).
+    parcel_id: str | None = None
+    search_id: str | None = None
+
+
+def _legacy_memo_to_text(memo: dict[str, Any], lang: str) -> str:
+    """Render the legacy decision-memo dict to a plain text block so we
+    can still populate ``expansion_candidate.decision_memo`` on the
+    legacy-fallback path.
+    """
+    parts: list[str] = []
+    headline = memo.get("headline")
+    fit = memo.get("fit_summary")
+    reasons = memo.get("top_reasons_to_pursue") or []
+    risks = memo.get("top_risks") or []
+    action = memo.get("recommended_next_action")
+    rent = memo.get("rent_context")
+
+    if headline:
+        parts.append(str(headline))
+    if fit:
+        parts.append(str(fit))
+    if reasons:
+        label = "الأسباب" if lang == "ar" else "Reasons to pursue"
+        parts.append(label + ":\n" + "\n".join(f"- {r}" for r in reasons))
+    if risks:
+        label = "المخاطر" if lang == "ar" else "Risks"
+        parts.append(label + ":\n" + "\n".join(f"- {r}" for r in risks))
+    if action:
+        label = "الخطوة التالية" if lang == "ar" else "Next action"
+        parts.append(f"{label}: {action}")
+    if rent:
+        parts.append(str(rent))
+    return "\n\n".join(parts).strip() + "\n"
+
+
+def _decision_memo_cache_lookup(
+    db: Session,
+    search_id: str,
+    parcel_id: str,
+) -> tuple[str | None, dict[str, Any] | None] | None:
+    """Return (cached_text, cached_json) if a row exists, else None.
+    Any DB error is swallowed and treated as a cache miss."""
+    try:
+        row = db.execute(
+            text(
+                "SELECT decision_memo, decision_memo_json "
+                "FROM expansion_candidate "
+                "WHERE search_id = :sid AND parcel_id = :pid "
+                "LIMIT 1"
+            ),
+            {"sid": search_id, "pid": parcel_id},
+        ).fetchone()
+    except Exception as exc:
+        logger.warning(
+            "Decision memo cache lookup failed for (%s,%s): %s",
+            search_id, parcel_id, exc,
+        )
+        return None
+    if row is None:
+        return None
+    cached_text = row[0]
+    cached_json = row[1]
+    if cached_text is None and cached_json is None:
+        return None
+    return cached_text, cached_json
+
+
+def _decision_memo_cache_write(
+    db: Session,
+    search_id: str,
+    parcel_id: str,
+    memo_text: str | None,
+    memo_json: dict[str, Any] | None,
+) -> None:
+    """Persist the memo to expansion_candidate. Swallows errors — a persist
+    failure must not break the endpoint response."""
+    try:
+        db.execute(
+            text(
+                "UPDATE expansion_candidate "
+                "SET decision_memo = :txt, "
+                "    decision_memo_json = CAST(:j AS JSONB) "
+                "WHERE search_id = :sid AND parcel_id = :pid"
+            ),
+            {
+                "sid": search_id,
+                "pid": parcel_id,
+                "txt": memo_text,
+                "j": json.dumps(memo_json, ensure_ascii=False) if memo_json is not None else None,
+            },
+        )
+        db.commit()
+    except Exception as exc:
+        logger.warning(
+            "Decision memo persist failed for (%s,%s): %s",
+            search_id, parcel_id, exc,
+        )
+        try:
+            db.rollback()
+        except Exception:
+            pass
 
 
 @router.post("/decision-memo")
-def post_decision_memo(req: DecisionMemoRequest):
-    """Generate an LLM decision memo for a candidate site."""
+def post_decision_memo(
+    req: DecisionMemoRequest,
+    db: Session = Depends(get_db),
+):
+    """Generate (or fetch cached) LLM decision memo for a candidate site.
+
+    Flow:
+      1. If both ``search_id`` and ``parcel_id`` are supplied, check the
+         cache in ``expansion_candidate``. If either column has a value,
+         serve it — never regenerate. (Phase 1: memos never expire;
+         reruning the search produces a new search_id and a fresh memo.)
+      2. Otherwise, build a MemoContext and call ``generate_structured_memo``.
+         On success, render text, optionally persist both columns, and
+         return the structured output.
+      3. On any structured-path failure (flag off, LLM error, malformed
+         JSON, renderer blow-up), fall back to the legacy generic memo
+         path. Persist only the text column; leave ``decision_memo_json``
+         NULL. Still return a valid response to the caller.
+      4. Ceiling-breach raises ``RuntimeError`` from the legacy path and
+         surfaces as HTTP 503 — same as today.
+    """
+    lang = req.lang if req.lang in ("en", "ar") else "en"
+
+    # Allow parcel_id to be inferred from the candidate dict if the frontend
+    # hasn't been updated yet to pass it at the top level.
+    parcel_id = req.parcel_id or (
+        req.candidate.get("parcel_id") if isinstance(req.candidate, dict) else None
+    )
+    search_id = req.search_id
+    cache_keyed = bool(search_id and parcel_id)
+
+    # 1) Cache lookup
+    if cache_keyed:
+        cached = _decision_memo_cache_lookup(db, search_id, parcel_id)
+        if cached is not None:
+            cached_text, cached_json = cached
+            if cached_json is not None:
+                return {
+                    "memo": cached_json,
+                    "memo_text": cached_text,
+                    "memo_json": cached_json,
+                    "cached": True,
+                }
+            if cached_text is not None:
+                # Legacy-fallback memo was persisted earlier — serve as-is,
+                # do not regenerate.
+                return {
+                    "memo": {"text": cached_text},
+                    "memo_text": cached_text,
+                    "memo_json": None,
+                    "cached": True,
+                }
+
+    # 2) Cache miss / unkeyed — try structured path first
+    memo_json: dict[str, Any] | None = None
+    memo_text: str | None = None
+    ctx = None
     try:
-        memo = generate_decision_memo(
+        ctx = build_memo_context(
             candidate=req.candidate,
             brief=req.brief,
-            lang=req.lang if req.lang in ("en", "ar") else "en",
+            lang=lang,
         )
-        return {"memo": memo}
-    except RuntimeError as exc:
-        logger.warning("Decision memo generation failed: %s", exc)
-        raise HTTPException(status_code=503, detail=str(exc))
+    except Exception as exc:  # pragma: no cover — build is designed not to raise
+        logger.warning("build_memo_context failed: %s", exc)
+
+    if ctx is not None:
+        memo_json = generate_structured_memo(ctx)
+
+    if memo_json is not None:
+        # Renderer is wrapped defensively — a malformed-but-validation-passing
+        # JSON must not 500 the endpoint. On renderer failure, drop to legacy
+        # and log the offending JSON so we can tighten validation later.
+        try:
+            memo_text = render_structured_memo_as_text(memo_json, lang)
+        except Exception as exc:
+            logger.warning(
+                "render_structured_memo_as_text failed for %s: %s | json=%s",
+                parcel_id, exc, json.dumps(memo_json, ensure_ascii=False)[:500],
+            )
+            memo_json = None
+            memo_text = None
+
+    if memo_json is not None:
+        response_payload = {
+            "memo": memo_json,
+            "memo_text": memo_text,
+            "memo_json": memo_json,
+            "cached": False,
+        }
+    else:
+        # 3) Legacy fallback (also the flag-off path — byte-for-byte legacy
+        # behavior when EXPANSION_MEMO_STRUCTURED_ENABLED=False).
+        try:
+            legacy = generate_decision_memo(
+                candidate=req.candidate,
+                brief=req.brief,
+                lang=lang,
+            )
+        except RuntimeError as exc:
+            logger.warning("Decision memo generation failed: %s", exc)
+            raise HTTPException(status_code=503, detail=str(exc))
+        memo_text = _legacy_memo_to_text(legacy, lang)
+        response_payload = {
+            "memo": legacy,
+            "memo_text": memo_text,
+            "memo_json": None,
+            "cached": False,
+        }
+
+    # 4) Persist when keyed
+    if cache_keyed:
+        _decision_memo_cache_write(
+            db, search_id, parcel_id, memo_text, response_payload["memo_json"]
+        )
+
+    return response_payload

--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -994,6 +994,55 @@ class DecisionMemoRequest(BaseModel):
     search_id: str | None = None
 
 
+def _structured_to_legacy_shape(memo_json: dict[str, Any]) -> dict[str, Any]:
+    """Project a structured memo onto the legacy response-dict shape so
+    ``response["memo"]`` is always safe for un-updated frontends.
+
+    Canonical (new) fields are ``response["memo_json"]`` / ``response["memo_text"]``.
+    ``response["memo"]`` is a backward-compat shim only.
+    """
+    evidence = memo_json.get("key_evidence") or []
+    risks = memo_json.get("risks") or []
+    reasons: list[str] = []
+    for item in evidence:
+        if isinstance(item, dict):
+            impl = item.get("implication")
+            if impl:
+                reasons.append(str(impl))
+    risk_strings: list[str] = []
+    for item in risks:
+        if isinstance(item, dict):
+            r = item.get("risk")
+            if r:
+                risk_strings.append(str(r))
+    return {
+        "headline": str(memo_json.get("headline_recommendation") or "—"),
+        "fit_summary": str(memo_json.get("ranking_explanation") or "—"),
+        "top_reasons_to_pursue": reasons,
+        "top_risks": risk_strings,
+        "recommended_next_action": str(memo_json.get("bottom_line") or "—"),
+        # Structured prompt does not produce a rent_context field; keep the
+        # legacy key populated with a placeholder so callers that expect it
+        # never KeyError.
+        "rent_context": "—",
+    }
+
+
+def _text_only_to_legacy_shape(cached_text: str) -> dict[str, Any]:
+    """Project a text-only cache hit (legacy-fallback memo persisted earlier)
+    onto the legacy response-dict shape."""
+    text_str = str(cached_text or "").strip()
+    headline = text_str[:120] if text_str else "—"
+    return {
+        "headline": headline or "—",
+        "fit_summary": text_str or "—",
+        "top_reasons_to_pursue": [],
+        "top_risks": [],
+        "recommended_next_action": "—",
+        "rent_context": "—",
+    }
+
+
 def _legacy_memo_to_text(memo: dict[str, Any], lang: str) -> str:
     """Render the legacy decision-memo dict to a plain text block so we
     can still populate ``expansion_candidate.decision_memo`` on the
@@ -1114,6 +1163,19 @@ def post_decision_memo(
          NULL. Still return a valid response to the caller.
       4. Ceiling-breach raises ``RuntimeError`` from the legacy path and
          surfaces as HTTP 503 — same as today.
+
+    Response shape (backward-compat contract):
+      ``response["memo"]`` is ALWAYS a legacy-shape dict (keys: headline,
+      fit_summary, top_reasons_to_pursue, top_risks, recommended_next_action,
+      rent_context). On the structured path it is synthesized from the
+      structured JSON; on legacy fallback it is the dict as-returned by
+      ``generate_decision_memo``; on a text-only cache hit it is derived
+      from the cached text. Un-updated frontends that read
+      ``response.memo.headline`` (etc.) never crash.
+
+      New Phase-3 frontend code should prefer ``response["memo_text"]`` and
+      ``response["memo_json"]`` as the canonical fields. ``response["memo"]``
+      is a backward-compat shim only.
     """
     lang = req.lang if req.lang in ("en", "ar") else "en"
 
@@ -1132,7 +1194,7 @@ def post_decision_memo(
             cached_text, cached_json = cached
             if cached_json is not None:
                 return {
-                    "memo": cached_json,
+                    "memo": _structured_to_legacy_shape(cached_json),
                     "memo_text": cached_text,
                     "memo_json": cached_json,
                     "cached": True,
@@ -1141,7 +1203,7 @@ def post_decision_memo(
                 # Legacy-fallback memo was persisted earlier — serve as-is,
                 # do not regenerate.
                 return {
-                    "memo": {"text": cached_text},
+                    "memo": _text_only_to_legacy_shape(cached_text),
                     "memo_text": cached_text,
                     "memo_json": None,
                     "cached": True,
@@ -1179,7 +1241,7 @@ def post_decision_memo(
 
     if memo_json is not None:
         response_payload = {
-            "memo": memo_json,
+            "memo": _structured_to_legacy_shape(memo_json),
             "memo_text": memo_text,
             "memo_json": memo_json,
             "cached": False,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -97,5 +97,21 @@ class Settings:
         os.getenv("EXPANSION_REALIZED_DEMAND_BLEND", "0.5")
     )
 
+    # --- Expansion Advisor structured decision memo (Phase 1) ---
+    # Model/token/temperature controls for the new structured memo path in
+    # ``app.services.llm_decision_memo``. When ``EXPANSION_MEMO_STRUCTURED_ENABLED``
+    # is false the service falls back to the legacy generic memo path byte-for-byte.
+    EXPANSION_MEMO_MODEL: str = os.getenv("EXPANSION_MEMO_MODEL", "gpt-4o-mini")
+    EXPANSION_MEMO_MAX_TOKENS: int = int(
+        os.getenv("EXPANSION_MEMO_MAX_TOKENS", "1200")
+    )
+    EXPANSION_MEMO_TEMPERATURE: float = float(
+        os.getenv("EXPANSION_MEMO_TEMPERATURE", "0.3")
+    )
+    EXPANSION_MEMO_STRUCTURED_ENABLED: bool = (
+        os.getenv("EXPANSION_MEMO_STRUCTURED_ENABLED", "true").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+
 
 settings = Settings()

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+from dataclasses import dataclass, field
 from datetime import date
 from typing import Any
+
+from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -342,3 +345,594 @@ def generate_decision_memo(
     )
 
     return parsed
+
+
+# ── Structured decision memo (Phase 1) ──────────────────────────────
+#
+# The structured memo path is additive: it sits on top of the 9-component
+# deterministic scorer, does NOT modify scoring/gating/ranking, and can be
+# toggled off via ``settings.EXPANSION_MEMO_STRUCTURED_ENABLED`` to revert
+# to the legacy ``generate_decision_memo`` output byte-for-byte.
+
+# Deterministic scorer weights — kept in sync with the 9-component weights
+# in ``app.services.expansion_advisor``. Editing these here does NOT change
+# scoring; these are used only to compute memo-display contributions.
+COMPONENT_WEIGHTS: dict[str, float] = {
+    "occupancy_economics": 0.30,
+    "listing_quality": 0.11,
+    "brand_fit": 0.11,
+    "competition_whitespace": 0.10,
+    "demand_potential": 0.10,
+    "access_visibility": 0.10,
+    "landlord_signal": 0.08,
+    "delivery_demand": 0.05,
+    "confidence": 0.05,
+}
+
+# Feature-snapshot fields that actually drive a decision. Used to truncate
+# oversized snapshots to a compact LLM-friendly payload.
+_FEATURE_SNAPSHOT_WHITELIST: tuple[str, ...] = (
+    "district",
+    "district_display",
+    "area_m2",
+    "unit_area_sqm",
+    "estimated_annual_rent_sar",
+    "display_annual_rent_sar",
+    "estimated_rent_sar_m2_year",
+    "district_median_rent",
+    "unit_street_width_m",
+    "street_width_m",
+    "population_reach",
+    "competitor_count",
+    "delivery_listing_count",
+    "access_visibility_score",
+    "landlord_signal",
+    "realized_demand_30d",
+    "realized_demand_branches",
+    "realized_demand_district_median",
+    "zoning_fit",
+    "parking_score",
+    "frontage_score",
+)
+
+
+@dataclass
+class MemoContext:
+    """Inputs to the structured memo LLM call.
+
+    All optional fields tolerate None / empty; callers should never have
+    to pre-normalize before constructing this.
+    """
+
+    candidate_id: str
+    parcel_id: str | None
+    rank_position: int
+    next_candidate_summary: dict | None
+    brand_profile: dict
+    feature_snapshot: dict
+    score_breakdown: dict
+    gate_verdicts: list[dict]
+    comparable_competitors: list[dict]
+    realized_demand: dict | None
+    listing_image_url: str | None
+    locale: str
+
+
+# ── Context assembly helpers ────────────────────────────────────────
+
+
+def _as_dict(v: Any) -> dict:
+    if isinstance(v, dict):
+        return dict(v)
+    return {}
+
+
+def _as_list(v: Any) -> list:
+    if isinstance(v, list):
+        return list(v)
+    return []
+
+
+def _coerce_gate_verdicts(raw: Any) -> list[dict]:
+    """Normalize various gate-status shapes into a list of
+    ``{gate, verdict, reason}`` dicts."""
+    if isinstance(raw, list):
+        out: list[dict] = []
+        for item in raw:
+            if isinstance(item, dict):
+                out.append({
+                    "gate": item.get("gate") or item.get("name") or "",
+                    "verdict": item.get("verdict") or item.get("status") or "",
+                    "reason": item.get("reason") or item.get("message") or "",
+                })
+        return out
+    if isinstance(raw, dict):
+        out = []
+        for name, val in raw.items():
+            if isinstance(val, dict):
+                out.append({
+                    "gate": name,
+                    "verdict": val.get("verdict") or val.get("status") or "",
+                    "reason": val.get("reason") or val.get("message") or "",
+                })
+            else:
+                out.append({
+                    "gate": name,
+                    "verdict": "pass" if bool(val) else "fail",
+                    "reason": "",
+                })
+        return out
+    return []
+
+
+def _component_score_value(
+    score_breakdown: dict,
+    candidate: dict | None,
+    comp: str,
+) -> float:
+    """Best-effort lookup of a per-component score (0..100) by trying the
+    canonical key, then ``<comp>_score``, then the flat candidate dict."""
+    bd = score_breakdown or {}
+    if isinstance(bd.get(comp), (int, float)):
+        return float(bd[comp])
+    score_key = f"{comp}_score"
+    if isinstance(bd.get(score_key), (int, float)):
+        return float(bd[score_key])
+    components = bd.get("components")
+    if isinstance(components, dict):
+        v = components.get(comp)
+        if isinstance(v, (int, float)):
+            return float(v)
+        if isinstance(v, dict) and isinstance(v.get("score"), (int, float)):
+            return float(v["score"])
+    if candidate is not None:
+        for k in (comp, score_key):
+            if isinstance(candidate.get(k), (int, float)):
+                return float(candidate[k])
+    return 0.0
+
+
+def _build_contributions(
+    score_breakdown: dict,
+    candidate: dict | None = None,
+) -> dict[str, float]:
+    """Return ``{component: weight × component_score}`` for all 9 components."""
+    return {
+        comp: round(weight * _component_score_value(score_breakdown, candidate, comp), 3)
+        for comp, weight in COMPONENT_WEIGHTS.items()
+    }
+
+
+def _extract_realized_demand(
+    candidate: dict,
+    feature_snapshot: dict,
+) -> dict | None:
+    """Pull realized-demand fields from candidate/feature_snapshot into the
+    canonical ``{value_30d, branch_count, district_median}`` shape.
+    Returns None when neither value_30d nor branch_count is present — matching
+    the realized-demand signal being OFF or absent for this catchment.
+    """
+    def _pick(key: str) -> Any:
+        return candidate.get(key) if candidate.get(key) is not None else feature_snapshot.get(key)
+
+    v30 = _pick("realized_demand_30d")
+    branches = _pick("realized_demand_branches")
+    district_median = _pick("realized_demand_district_median")
+    if v30 is None and branches is None:
+        return None
+    out: dict[str, Any] = {}
+    if v30 is not None:
+        out["value_30d"] = v30
+    if branches is not None:
+        out["branch_count"] = branches
+    if district_median is not None:
+        out["district_median"] = district_median
+    return out or None
+
+
+def build_memo_context(
+    *,
+    candidate: dict[str, Any],
+    brief: dict[str, Any],
+    lang: str = "en",
+    next_candidate_summary: dict[str, Any] | None = None,
+) -> MemoContext:
+    """Build a MemoContext from the raw candidate/brief dicts already
+    available at the existing call site.
+
+    Pure: never raises on missing fields. Missing optional fields become
+    None or an empty list. Always enriches ``score_breakdown`` with
+    ``weights`` and ``contributions`` (``weight × component_score``) so the
+    LLM can cite per-component impact directly.
+    """
+    candidate_id = str(
+        candidate.get("id")
+        or candidate.get("candidate_id")
+        or candidate.get("parcel_id")
+        or ""
+    )
+    parcel_id = candidate.get("parcel_id")
+
+    feature_snapshot = _as_dict(candidate.get("feature_snapshot_json"))
+    if not feature_snapshot:
+        # Fall back to a flat whitelist of candidate fields so the LLM still
+        # gets the decision-driving signals even when feature_snapshot_json
+        # isn't populated.
+        feature_snapshot = {
+            k: candidate.get(k)
+            for k in _FEATURE_SNAPSHOT_WHITELIST
+            if candidate.get(k) is not None
+        }
+
+    raw_breakdown = _as_dict(candidate.get("score_breakdown_json"))
+    contributions = _build_contributions(raw_breakdown, candidate)
+    # Do not mutate caller's dict.
+    score_breakdown = dict(raw_breakdown)
+    score_breakdown["weights"] = dict(COMPONENT_WEIGHTS)
+    score_breakdown["contributions"] = contributions
+
+    gate_verdicts = _coerce_gate_verdicts(
+        candidate.get("gate_status_json")
+        or candidate.get("gate_reasons_json")
+    )
+    comparable_competitors = _as_list(
+        candidate.get("comparable_competitors_json")
+    )
+    realized_demand = _extract_realized_demand(candidate, feature_snapshot)
+
+    rank_raw = candidate.get("rank_position")
+    try:
+        rank_position = int(rank_raw) if rank_raw is not None else 0
+    except (TypeError, ValueError):
+        rank_position = 0
+
+    brand_profile = _as_dict(brief.get("brand_profile"))
+    for k in (
+        "brand_name",
+        "category",
+        "service_model",
+        "expansion_goal",
+        "target_area_m2",
+        "min_area_m2",
+        "max_area_m2",
+    ):
+        if brand_profile.get(k) is None and brief.get(k) is not None:
+            brand_profile[k] = brief.get(k)
+
+    listing_image_url = (
+        candidate.get("listing_image_url")
+        or candidate.get("primary_image_url")
+    )
+    locale = "ar" if lang == "ar" else "en"
+
+    return MemoContext(
+        candidate_id=candidate_id,
+        parcel_id=parcel_id,
+        rank_position=rank_position,
+        next_candidate_summary=next_candidate_summary,
+        brand_profile=brand_profile,
+        feature_snapshot=feature_snapshot,
+        score_breakdown=score_breakdown,
+        gate_verdicts=gate_verdicts,
+        comparable_competitors=comparable_competitors,
+        realized_demand=realized_demand,
+        listing_image_url=listing_image_url,
+        locale=locale,
+    )
+
+
+# ── Prompt ──────────────────────────────────────────────────────────
+
+
+STRUCTURED_MEMO_SYSTEM_PROMPT = """You are a senior commercial real-estate analyst covering Riyadh, Saudi Arabia, evaluating a candidate site for a specific restaurant/retail operator's expansion.
+
+You will receive a JSON object describing:
+- the brand profile (category, service model, expansion goal, preferences),
+- the candidate's feature snapshot (area, rent, street width, competitor counts, delivery signals, etc.),
+- the candidate's score_breakdown, including the 9 deterministic component scores, their weights, and each component's contribution (weight × component_score) to the final score,
+- the gate verdicts (pass/fail) applied during screening,
+- comparable competitors and (optionally) the next-ranked candidate,
+- optionally, a realized_demand block (actual customer-order growth, not supply proxy).
+
+Return ONLY a single JSON object (no markdown fences, no commentary before or after). The object must contain EXACTLY these six top-level keys with the types and semantics described:
+
+{
+  "headline_recommendation": "string — one sentence. Must be one of 'recommend', 'recommend with reservations', or 'pass', plus the single strongest reason.",
+  "ranking_explanation": "string — 2-3 sentences. Must cite which of the 9 components drove the rank and by how much, using the numbers from score_breakdown.contributions (e.g., 'occupancy_economics contributed 27.2 out of 30').",
+  "key_evidence": [
+    {"signal": "string", "value": "string with units", "implication": "string — what this fact means for the decision"}
+  ],
+  "risks": [
+    {"risk": "string", "mitigation": "string or null"}
+  ],
+  "comparison": "string — 1-2 sentences on how this compares to the comparable competitors or the next-ranked candidate.",
+  "bottom_line": "string — one sentence an analyst would say to the CEO in a hallway."
+}
+
+Hard rules:
+- Cite specific numbers with units. Do not hedge.
+- If a signal is strong, say so. If it's weak, say so.
+- Do not use the phrases "overall,", "appears to be,", "could potentially,", or "generally speaking."
+- Write like an analyst who has actually visited the site, not a summarizer.
+- key_evidence must be a non-empty list. risks may be an empty list, but the key must be present.
+- Return ONLY the JSON object, with no markdown fences, no leading or trailing commentary."""
+
+
+_MAX_USER_PAYLOAD_CHARS = 12000
+_FEATURE_SNAPSHOT_SOFT_LIMIT = 4000
+
+
+def _serialize_context_for_user_message(ctx: MemoContext) -> str:
+    """Serialize the MemoContext to a compact JSON string for the user turn,
+    truncating ``feature_snapshot`` to the whitelist if the full payload would
+    blow the size budget."""
+    snap = ctx.feature_snapshot
+    serialized_full = json.dumps(snap, default=str, ensure_ascii=False)
+    if len(serialized_full) > _FEATURE_SNAPSHOT_SOFT_LIMIT:
+        snap = {
+            k: snap.get(k)
+            for k in _FEATURE_SNAPSHOT_WHITELIST
+            if snap.get(k) is not None
+        }
+
+    body = {
+        "candidate_id": ctx.candidate_id,
+        "parcel_id": ctx.parcel_id,
+        "rank_position": ctx.rank_position,
+        "brand_profile": ctx.brand_profile,
+        "feature_snapshot": snap,
+        "score_breakdown": ctx.score_breakdown,
+        "gate_verdicts": ctx.gate_verdicts,
+        "comparable_competitors": ctx.comparable_competitors[:5],
+        "next_candidate_summary": ctx.next_candidate_summary,
+        "realized_demand": ctx.realized_demand,
+        "listing_image_url": ctx.listing_image_url,
+        "locale": ctx.locale,
+    }
+    text = json.dumps(body, default=str, ensure_ascii=False)
+    if len(text) > _MAX_USER_PAYLOAD_CHARS:
+        # Last-resort: drop most competitors and tighten feature_snapshot.
+        body["comparable_competitors"] = body["comparable_competitors"][:2]
+        body["feature_snapshot"] = {
+            k: snap.get(k)
+            for k in _FEATURE_SNAPSHOT_WHITELIST
+            if snap.get(k) is not None
+        }
+        text = json.dumps(body, default=str, ensure_ascii=False)
+    return text
+
+
+def render_structured_memo_prompt(ctx: MemoContext) -> list[dict]:
+    """Render an OpenAI-style ``[system, user]`` messages list for the
+    structured memo call. Appends situational instructions to the system
+    prompt when locale is Arabic, realized_demand is present, or any gate
+    failed.
+    """
+    addenda: list[str] = []
+    if ctx.locale == "ar":
+        addenda.append(
+            "LOCALE: Produce every string value in Modern Standard Arabic "
+            "(فصحى). JSON keys stay in English; all string values in Arabic."
+        )
+    if ctx.realized_demand is not None:
+        addenda.append(
+            "EVIDENCE PRIORITY: realized_demand is present. Prioritize it in "
+            "key_evidence because it reflects actual customer orders, not just "
+            "supply presence. Cite value_30d, branch_count, and district_median "
+            "when available."
+        )
+    failed = [
+        g for g in ctx.gate_verdicts
+        if str(g.get("verdict") or "").lower() == "fail"
+    ]
+    if failed:
+        failure_list = "; ".join(
+            f"{g.get('gate','?')}: {g.get('reason','')}".rstrip(": ")
+            for g in failed
+        )
+        addenda.append(
+            "GATE FAILURE: One or more gates failed — "
+            + failure_list
+            + ". Lead the headline_recommendation with this failure and frame "
+            "the overall recommendation accordingly (likely 'pass' unless the "
+            "failure is borderline and clearly mitigable)."
+        )
+
+    system_content = STRUCTURED_MEMO_SYSTEM_PROMPT
+    if addenda:
+        system_content = (
+            system_content
+            + "\n\nSITUATIONAL INSTRUCTIONS:\n- "
+            + "\n- ".join(addenda)
+        )
+
+    return [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": _serialize_context_for_user_message(ctx)},
+    ]
+
+
+# ── Generation with graceful fallback ───────────────────────────────
+
+
+_STRUCTURED_REQUIRED_KEYS: tuple[str, ...] = (
+    "headline_recommendation",
+    "ranking_explanation",
+    "key_evidence",
+    "risks",
+    "comparison",
+    "bottom_line",
+)
+
+
+def generate_structured_memo(ctx: MemoContext) -> dict | None:
+    """Call the LLM for a structured memo, or return None on any failure.
+
+    Never raises — logs a warning and returns None so the caller can fall
+    back to the legacy ``generate_decision_memo`` path.
+
+    Returns the parsed JSON dict on success. Token usage is recorded against
+    the same ``_daily_cost_tracker`` as the legacy path so the $/day ceiling
+    covers both surfaces.
+    """
+    if not settings.EXPANSION_MEMO_STRUCTURED_ENABLED:
+        return None
+
+    # Same hard cost cap as the legacy path. Skip (not raise) when breached so
+    # the caller can fall through to legacy; legacy will raise uniformly and
+    # the endpoint will translate to a 503 as it does today.
+    #
+    # NOTE: on a ceiling breach this function returns None and relies on the
+    # caller's legacy fallback to raise. The endpoint's 503 therefore comes
+    # from the legacy path, not from here — the path is indirect but the
+    # end-user behavior (HTTP 503) is unchanged.
+    try:
+        _check_daily_ceiling()
+    except RuntimeError as exc:
+        logger.warning("Structured memo skipped (cost ceiling): %s", exc)
+        return None
+
+    try:
+        client = _get_client()
+    except RuntimeError as exc:
+        logger.warning("Structured memo client unavailable: %s", exc)
+        return None
+
+    messages = render_structured_memo_prompt(ctx)
+
+    try:
+        response = client.chat.completions.create(
+            model=settings.EXPANSION_MEMO_MODEL,
+            messages=messages,
+            temperature=settings.EXPANSION_MEMO_TEMPERATURE,
+            max_tokens=settings.EXPANSION_MEMO_MAX_TOKENS,
+            response_format={"type": "json_object"},
+        )
+    except Exception as exc:
+        logger.warning(
+            "Structured memo OpenAI call failed for %s: %s",
+            ctx.candidate_id, exc,
+        )
+        return None
+
+    try:
+        content = (response.choices[0].message.content or "").strip()
+    except Exception as exc:
+        logger.warning(
+            "Structured memo response malformed for %s: %s",
+            ctx.candidate_id, exc,
+        )
+        return None
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Structured memo JSON parse failed for %s: %s | raw=%s",
+            ctx.candidate_id, exc, content[:500],
+        )
+        return None
+
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "Structured memo returned non-object JSON for %s",
+            ctx.candidate_id,
+        )
+        return None
+
+    missing = [k for k in _STRUCTURED_REQUIRED_KEYS if k not in parsed]
+    if missing:
+        logger.warning(
+            "Structured memo missing keys for %s: %s",
+            ctx.candidate_id, missing,
+        )
+        return None
+
+    if not isinstance(parsed.get("key_evidence"), list) or not parsed["key_evidence"]:
+        logger.warning(
+            "Structured memo key_evidence invalid/empty for %s",
+            ctx.candidate_id,
+        )
+        return None
+
+    if not isinstance(parsed.get("risks"), list):
+        logger.warning(
+            "Structured memo risks not a list for %s",
+            ctx.candidate_id,
+        )
+        return None
+
+    usage = getattr(response, "usage", None)
+    input_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+    output_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+    cost = _record_cost(input_tokens, output_tokens)
+
+    logger.info(
+        "Structured memo generated | candidate_id=%s locale=%s "
+        "input_tokens=%d output_tokens=%d cost=$%.5f",
+        ctx.candidate_id, ctx.locale, input_tokens, output_tokens, cost,
+    )
+
+    return parsed
+
+
+# ── Text rendering of structured memo (for legacy text column) ──────
+
+
+_TEXT_SECTION_HEADERS_EN: tuple[tuple[str, str], ...] = (
+    ("headline_recommendation", "Headline Recommendation"),
+    ("ranking_explanation", "Ranking Explanation"),
+    ("key_evidence", "Key Evidence"),
+    ("risks", "Risks"),
+    ("comparison", "Comparison"),
+    ("bottom_line", "Bottom Line"),
+)
+_TEXT_SECTION_HEADERS_AR: tuple[tuple[str, str], ...] = (
+    ("headline_recommendation", "التوصية الرئيسية"),
+    ("ranking_explanation", "تفسير الترتيب"),
+    ("key_evidence", "الأدلة الرئيسية"),
+    ("risks", "المخاطر"),
+    ("comparison", "المقارنة"),
+    ("bottom_line", "الخلاصة"),
+)
+
+
+def render_structured_memo_as_text(memo_json: dict, locale: str) -> str:
+    """Render the six-section structured memo as a plain-text memo with
+    markdown-style headers, suitable for the legacy ``decision_memo`` text
+    column so existing consumers keep working unchanged.
+    """
+    headers = _TEXT_SECTION_HEADERS_AR if locale == "ar" else _TEXT_SECTION_HEADERS_EN
+    lines: list[str] = []
+    for key, label in headers:
+        value = memo_json.get(key)
+        lines.append(f"## {label}")
+        if key == "key_evidence" and isinstance(value, list):
+            if not value:
+                lines.append("- —")
+            for item in value:
+                if not isinstance(item, dict):
+                    continue
+                signal = str(item.get("signal", "—"))
+                v = str(item.get("value", "—"))
+                impl = str(item.get("implication", "") or "")
+                line = f"- {signal}: {v}"
+                if impl:
+                    line = f"{line} — {impl}"
+                lines.append(line)
+        elif key == "risks" and isinstance(value, list):
+            if not value:
+                lines.append("- —")
+            for item in value:
+                if not isinstance(item, dict):
+                    continue
+                risk = str(item.get("risk", "—"))
+                mit = item.get("mitigation")
+                if mit:
+                    lines.append(f"- {risk} (mitigation: {mit})")
+                else:
+                    lines.append(f"- {risk}")
+        else:
+            lines.append(str(value) if value else "—")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -826,10 +826,12 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
 
     try:
         parsed = json.loads(content)
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, TypeError) as exc:
+        # TypeError guards against a client returning a non-string for
+        # ``content`` (real OpenAI always returns str; defensive only).
         logger.warning(
             "Structured memo JSON parse failed for %s: %s | raw=%s",
-            ctx.candidate_id, exc, content[:500],
+            ctx.candidate_id, exc, str(content)[:500],
         )
         return None
 

--- a/scripts/sample_regression_memos.py
+++ b/scripts/sample_regression_memos.py
@@ -1,0 +1,318 @@
+"""Sample regression memos — run the four standard Expansion-Advisor searches
+end-to-end, generate a structured decision memo for each top-ranked candidate,
+and dump the raw ``memo_json`` for eyeballing prompt/signal quality.
+
+WHAT THIS IS
+    A read-mostly CLI sanity script. For each of the four canonical searches
+    (QSR burger in Al Olaya; delivery shawarma citywide; dine-in Indian in
+    Al Nakheel; café in Al Yasmin) it:
+
+      1. Calls ``run_expansion_search(db, …)`` directly against the service
+         layer (NOT the HTTP API). This creates an ``expansion_search`` row
+         and the usual ``expansion_candidate`` rows via the normal pipeline.
+      2. Picks rank 1.
+      3. Runs ``build_memo_context`` → ``generate_structured_memo`` directly.
+         Does NOT hit the /decision-memo endpoint, does NOT write to the
+         ``decision_memo`` / ``decision_memo_json`` columns. We never want
+         this script to prime the decision-memo cache because future runs
+         should regenerate cleanly against a new prompt or a new signal.
+
+WHEN TO RUN IT
+    - After tweaking the structured-memo prompt (``STRUCTURED_MEMO_SYSTEM_PROMPT``
+      or ``render_structured_memo_prompt``) and wanting to eyeball the delta.
+    - After calibrating a new signal (realized demand, delivery blend, rent
+      comps, etc.) and wanting to see whether the memo surfaces the change.
+    - Before any PR that touches memo wording or scoring components — use
+      this as the human-judgment sanity pass that the pytest suite cannot
+      substitute for.
+
+COST AND PREREQS
+    Requires ``OPENAI_API_KEY`` to be set in the environment. Requires a
+    populated Riyadh database reachable via the app's normal DB settings
+    (``DATABASE_URL`` or ``POSTGRES_*``) — the four searches rely on real
+    parcel, competitor, delivery, and rent-comp data.
+
+    One full run issues four ``chat.completions.create`` calls against
+    ``settings.EXPANSION_MEMO_MODEL`` (default ``gpt-4o-mini``). Typical
+    cost with ``gpt-4o-mini`` is ~$0.01–0.04 total across four searches.
+    Not free — don't loop it in CI.
+
+USAGE
+    python scripts/sample_regression_memos.py
+    python scripts/sample_regression_memos.py --search cafe_al_yasmin
+    python scripts/sample_regression_memos.py --out /tmp/memos.json
+
+OUTPUT
+    A single JSON object keyed by search name; each value is either the
+    raw structured ``memo_json`` produced by the LLM or
+    ``{"error": "<reason>", "skipped": true}`` when the search or memo
+    step couldn't run.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import uuid
+from typing import Any
+
+logger = logging.getLogger("sample_regression_memos")
+
+
+# ── Canonical regression briefs ─────────────────────────────────────
+#
+# Hardcoded on purpose: this is a one-off quality check, not a configurable
+# tool. A generous Riyadh bbox covers every search so the district filter
+# is the discriminator that matters.
+
+_RIYADH_BBOX = {
+    "min_lon": 46.40,
+    "min_lat": 24.40,
+    "max_lon": 47.00,
+    "max_lat": 25.00,
+}
+
+
+REGRESSION_BRIEFS: dict[str, dict[str, Any]] = {
+    "qsr_burger_al_olaya": {
+        "brand_name": "Sample Burger Co",
+        "category": "burger",
+        "service_model": "qsr",
+        "min_area_m2": 100,
+        "target_area_m2": 160,
+        "max_area_m2": 250,
+        "limit": 12,
+        "bbox": _RIYADH_BBOX,
+        "target_districts": ["Al Olaya"],
+        "existing_branches": [],
+        "brand_profile": {
+            "primary_channel": "dine_in",
+            "price_tier": "mid",
+        },
+    },
+    "delivery_shawarma_citywide": {
+        "brand_name": "Sample Shawarma Co",
+        "category": "shawarma",
+        "service_model": "delivery",
+        "min_area_m2": 50,
+        "target_area_m2": 80,
+        "max_area_m2": 120,
+        "limit": 12,
+        "bbox": _RIYADH_BBOX,
+        "target_districts": [],
+        "existing_branches": [],
+        "brand_profile": {
+            "primary_channel": "delivery",
+            "price_tier": "value",
+        },
+    },
+    "dine_in_indian_al_nakheel": {
+        "brand_name": "Sample Indian Co",
+        "category": "indian",
+        "service_model": "dine_in",
+        "min_area_m2": 150,
+        "target_area_m2": 250,
+        "max_area_m2": 400,
+        "limit": 12,
+        "bbox": _RIYADH_BBOX,
+        "target_districts": ["Al Nakheel"],
+        "existing_branches": [],
+        "brand_profile": {
+            "primary_channel": "dine_in",
+            "price_tier": "premium",
+        },
+    },
+    "cafe_al_yasmin": {
+        "brand_name": "Sample Cafe Co",
+        "category": "cafe",
+        "service_model": "cafe",
+        "min_area_m2": 60,
+        "target_area_m2": 100,
+        "max_area_m2": 150,
+        "limit": 12,
+        "bbox": _RIYADH_BBOX,
+        "target_districts": ["Al Yasmin"],
+        "existing_branches": [],
+        "brand_profile": {
+            "primary_channel": "dine_in",
+            "price_tier": "mid",
+        },
+    },
+}
+
+
+_REQUIRED_CANDIDATE_FIELDS = (
+    "parcel_id",
+    "search_id",
+    "feature_snapshot_json",
+    "score_breakdown_json",
+)
+
+
+def _pick_rank_one(candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the candidate at rank 1, falling back to the first item when
+    ``rank_position`` isn't populated. Returns None for an empty list."""
+    if not candidates:
+        return None
+    for c in candidates:
+        if c.get("rank_position") == 1:
+            return c
+    return candidates[0]
+
+
+def _skipped(reason: str) -> dict[str, Any]:
+    return {"error": reason, "skipped": True}
+
+
+def _run_one_search(
+    db,
+    name: str,
+    brief: dict[str, Any],
+) -> dict[str, Any]:
+    """Run one search end-to-end and return the resulting ``memo_json``
+    or a ``{"error", "skipped"}`` dict explaining why not."""
+    # Imports are local so ``--help`` works without hitting DB / config.
+    from app.services.expansion_advisor import run_expansion_search
+    from app.services.llm_decision_memo import (
+        build_memo_context,
+        generate_structured_memo,
+    )
+
+    search_id = str(uuid.uuid4())
+    try:
+        candidates = run_expansion_search(
+            db,
+            search_id=search_id,
+            brand_name=brief["brand_name"],
+            category=brief["category"],
+            service_model=brief["service_model"],
+            min_area_m2=brief["min_area_m2"],
+            max_area_m2=brief["max_area_m2"],
+            target_area_m2=brief["target_area_m2"],
+            limit=brief["limit"],
+            bbox=brief.get("bbox"),
+            target_districts=brief.get("target_districts"),
+            existing_branches=brief.get("existing_branches"),
+            brand_profile=brief.get("brand_profile"),
+        )
+    except Exception as exc:
+        logger.warning("[%s] run_expansion_search raised: %s", name, exc)
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        return _skipped(f"run_expansion_search raised: {exc}")
+
+    rank_one = _pick_rank_one(candidates)
+    if rank_one is None:
+        logger.warning("[%s] search returned 0 candidates", name)
+        return _skipped("search returned 0 candidates")
+
+    missing = [f for f in _REQUIRED_CANDIDATE_FIELDS if not rank_one.get(f)]
+    if missing:
+        logger.warning(
+            "[%s] rank-1 candidate missing required fields: %s",
+            name, missing,
+        )
+        return _skipped(f"rank-1 candidate missing fields: {missing}")
+
+    try:
+        ctx = build_memo_context(candidate=rank_one, brief=brief, lang="en")
+    except Exception as exc:
+        logger.warning("[%s] build_memo_context raised: %s", name, exc)
+        return _skipped(f"build_memo_context raised: {exc}")
+
+    memo_json = generate_structured_memo(ctx)
+    if memo_json is None:
+        # generate_structured_memo already logged the specific reason
+        # (flag off / ceiling / api error / malformed / missing keys).
+        logger.warning(
+            "[%s] generate_structured_memo returned None — see prior WARNING",
+            name,
+        )
+        return _skipped(
+            "generate_structured_memo returned None "
+            "(flag off, ceiling hit, LLM error, or malformed response — "
+            "see preceding WARNING log lines)"
+        )
+
+    return memo_json
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    db=None,
+    briefs: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Entry point.
+
+    Args:
+        argv: CLI args (``None`` → ``sys.argv[1:]``).
+        db: Injected DB session for tests. Production uses ``SessionLocal()``.
+        briefs: Injected briefs dict for tests. Production uses
+            ``REGRESSION_BRIEFS``.
+
+    Returns the results dict (also written to stdout / ``--out``).
+    """
+    parser = argparse.ArgumentParser(
+        description="Run the four standard expansion-advisor regression "
+                    "searches and print structured memo_json for each."
+    )
+    parser.add_argument(
+        "--search",
+        choices=sorted(REGRESSION_BRIEFS.keys()),
+        default=None,
+        help="Run only this search (default: run all four).",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Write pretty-printed JSON to this path instead of stdout.",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable INFO/WARNING log output to stderr.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+    briefs = briefs if briefs is not None else REGRESSION_BRIEFS
+    selected = {args.search: briefs[args.search]} if args.search else briefs
+
+    owns_db = db is None
+    if owns_db:
+        from app.db.session import SessionLocal
+        db = SessionLocal()
+
+    try:
+        results: dict[str, Any] = {}
+        for name, brief in selected.items():
+            logger.info("=== running %s ===", name)
+            results[name] = _run_one_search(db, name, brief)
+    finally:
+        if owns_db:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+    rendered = json.dumps(results, indent=2, ensure_ascii=False)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(rendered + "\n")
+    else:
+        print(rendered)
+
+    return results
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -678,6 +678,61 @@ class TestDecisionMemoEndpointCeilingStillReturns503:
         assert resp.status_code == 503
 
 
+class TestDecisionMemoEndpointMemoIsLegacyShape:
+    """Backward-compat contract: response['memo'] is always a legacy-shape
+    dict so un-updated frontends reading memo.headline never crash.
+    """
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_structured_path_memo_has_all_six_legacy_keys_populated(self, mock_get_client):
+        mock_get_client.return_value = _mock_client_returning(VALID_STRUCTURED_RESPONSE)
+
+        db = _DummyDB(preload_row=None)
+        api = _endpoint_client(db)
+
+        payload = {
+            "candidate": BASE_STRUCTURED_CANDIDATE,
+            "brief": BASE_STRUCTURED_BRIEF,
+            "lang": "en",
+            "search_id": "search-legacy-shape",
+            "parcel_id": "parcel-9",
+        }
+        resp = api.post("/v1/expansion-advisor/decision-memo", json=payload)
+        assert resp.status_code == 200, resp.text
+        memo = resp.json()["memo"]
+
+        # All six legacy keys present and non-empty
+        for key in (
+            "headline",
+            "fit_summary",
+            "top_reasons_to_pursue",
+            "top_risks",
+            "recommended_next_action",
+            "rent_context",
+        ):
+            assert key in memo, f"missing legacy key: {key}"
+            assert memo[key], f"legacy key empty: {key}"
+
+        # Headline maps from headline_recommendation
+        assert memo["headline"] == VALID_STRUCTURED_RESPONSE["headline_recommendation"]
+        # fit_summary maps from ranking_explanation
+        assert memo["fit_summary"] == VALID_STRUCTURED_RESPONSE["ranking_explanation"]
+        # recommended_next_action maps from bottom_line
+        assert memo["recommended_next_action"] == VALID_STRUCTURED_RESPONSE["bottom_line"]
+
+        # Lists are non-empty when source key_evidence / risks are non-empty
+        assert isinstance(memo["top_reasons_to_pursue"], list)
+        assert len(memo["top_reasons_to_pursue"]) == len(VALID_STRUCTURED_RESPONSE["key_evidence"])
+        assert memo["top_reasons_to_pursue"][0] == VALID_STRUCTURED_RESPONSE["key_evidence"][0]["implication"]
+
+        assert isinstance(memo["top_risks"], list)
+        assert len(memo["top_risks"]) == len(VALID_STRUCTURED_RESPONSE["risks"])
+        assert memo["top_risks"][0] == VALID_STRUCTURED_RESPONSE["risks"][0]["risk"]
+
+        # rent_context is the documented placeholder
+        assert memo["rent_context"] == "—"
+
+
 class TestRenderStructuredMemoAsTextSmoke:
     def test_text_renderer_uses_six_section_headers(self):
         out = render_structured_memo_as_text(VALID_STRUCTURED_RESPONSE, "en")

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -498,9 +498,14 @@ class TestGenerateStructuredMemoFlagOff:
 
     @patch("app.services.llm_decision_memo._get_client")
     def test_flag_off_returns_none_without_calling_client(self, mock_get_client, monkeypatch):
-        from app.core.config import settings as _settings
-
-        monkeypatch.setattr(_settings, "EXPANSION_MEMO_STRUCTURED_ENABLED", False)
+        # IMPORTANT: patch the settings binding the function actually reads,
+        # not app.core.config.settings. Other tests (test_config_settings,
+        # test_parcel_table_overrides) reload app.core.config during the
+        # suite, which creates a fresh settings singleton — but
+        # llm_decision_memo.settings was bound at its own import time and
+        # still references the original instance.
+        import app.services.llm_decision_memo as memo_mod
+        monkeypatch.setattr(memo_mod.settings, "EXPANSION_MEMO_STRUCTURED_ENABLED", False)
 
         ctx = build_memo_context(
             candidate=BASE_STRUCTURED_CANDIDATE,

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -9,10 +9,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services.llm_decision_memo import (
+    COMPONENT_WEIGHTS,
+    MemoContext,
     _daily_cost_tracker,
     _format_rent_vs_median,
     _today_key,
+    build_memo_context,
     generate_decision_memo,
+    generate_structured_memo,
+    render_structured_memo_as_text,
+    render_structured_memo_prompt,
 )
 
 # ── Fixtures ────────────────────────────────────────────────────────
@@ -243,3 +249,444 @@ class TestArabicLangUsesArabicTemplate:
 
         # The Arabic template contains this string
         assert "موجز العلامة التجارية للمشغّل" in prompt_text
+
+
+# ── Structured memo (Phase 1) ───────────────────────────────────────
+
+
+VALID_STRUCTURED_RESPONSE = {
+    "headline_recommendation": "recommend — 15% below-median rent with strong delivery pull",
+    "ranking_explanation": (
+        "occupancy_economics contributed 27.0 out of 30 and brand_fit 8.8 out of 11, "
+        "driving rank 2 of 12. Access_visibility at 6.5 of 10 was the only sub-median "
+        "component and the gap to rank 1 is narrow."
+    ),
+    "key_evidence": [
+        {"signal": "annual rent", "value": "SAR 480,000/yr", "implication": "15% below Al Olaya median"},
+        {"signal": "realized demand 30d", "value": "1,400 orders", "implication": "7.8x district median"},
+    ],
+    "risks": [
+        {"risk": "street width 8 m limits drive-thru", "mitigation": "curbside handoff via Keeta"},
+    ],
+    "comparison": "Matches Peer A on rent and beats Peer B on realized demand by 3x.",
+    "bottom_line": "Take it — the rent alone justifies the deal.",
+}
+
+
+BASE_STRUCTURED_CANDIDATE = {
+    "id": "cand-structured-1",
+    "parcel_id": "parcel-9",
+    "rank_position": 2,
+    "feature_snapshot_json": {
+        "district": "Al Olaya",
+        "district_display": "العليا",
+        "area_m2": 120,
+        "estimated_annual_rent_sar": 480000,
+        "district_median_rent": 560000,
+        "unit_street_width_m": 8,
+    },
+    "score_breakdown_json": {
+        "occupancy_economics": 90,
+        "listing_quality": 70,
+        "brand_fit": 80,
+        "competition_whitespace": 60,
+        "demand_potential": 75,
+        "access_visibility": 65,
+        "landlord_signal": 55,
+        "delivery_demand": 50,
+        "confidence": 85,
+    },
+    "gate_status_json": [
+        {"gate": "zoning_fit_pass", "verdict": "pass", "reason": "C-2 allowed"},
+        {"gate": "rent_reasonable", "verdict": "pass", "reason": "15% below median"},
+    ],
+    "comparable_competitors_json": [
+        {"name": "Peer A", "district": "Al Olaya"},
+        {"name": "Peer B", "district": "Al Olaya"},
+    ],
+}
+
+BASE_STRUCTURED_BRIEF = {
+    "brand_name": "BurgerCo",
+    "category": "QSR",
+    "service_model": "qsr",
+    "min_area_m2": 100,
+    "max_area_m2": 200,
+    "target_area_m2": 120,
+}
+
+
+def _mock_client_returning(content, input_tokens: int = 400, output_tokens: int = 220):
+    """Build a mocked OpenAI client whose .chat.completions.create returns a canned reply."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = _make_mock_response(
+        content, input_tokens=input_tokens, output_tokens=output_tokens
+    )
+    return client
+
+
+class TestBuildMemoContextContributionsMath:
+    """Step 8, test 9."""
+
+    def test_contributions_equal_weight_times_score_for_all_nine(self):
+        ctx = build_memo_context(
+            candidate=BASE_STRUCTURED_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        scores = BASE_STRUCTURED_CANDIDATE["score_breakdown_json"]
+        contributions = ctx.score_breakdown["contributions"]
+        # All nine components represented
+        assert set(contributions.keys()) == set(COMPONENT_WEIGHTS.keys())
+        for comp, weight in COMPONENT_WEIGHTS.items():
+            expected = round(weight * scores[comp], 3)
+            assert contributions[comp] == expected, f"{comp}: got {contributions[comp]}, want {expected}"
+        # Spot-check the headline number the prompt expects to see
+        assert contributions["occupancy_economics"] == 27.0
+        # Weights sub-dict carried through for the LLM
+        assert ctx.score_breakdown["weights"] == dict(COMPONENT_WEIGHTS)
+
+
+class TestGenerateStructuredMemoHappyPath:
+    """Step 8, test 1 — service level."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_returns_parsed_dict_with_six_keys(self, mock_get_client):
+        mock_get_client.return_value = _mock_client_returning(VALID_STRUCTURED_RESPONSE)
+
+        ctx = build_memo_context(
+            candidate=BASE_STRUCTURED_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        result = generate_structured_memo(ctx)
+
+        assert isinstance(result, dict)
+        expected_keys = {
+            "headline_recommendation",
+            "ranking_explanation",
+            "key_evidence",
+            "risks",
+            "comparison",
+            "bottom_line",
+        }
+        assert set(result.keys()) >= expected_keys
+        assert result["bottom_line"] == VALID_STRUCTURED_RESPONSE["bottom_line"]
+
+
+class TestGenerateStructuredMemoMalformedJsonFallback:
+    """Step 8, test 2."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_non_json_returns_none(self, mock_get_client, caplog):
+        mock_get_client.return_value = _mock_client_returning(
+            "this is not json at all, just prose"
+        )
+
+        ctx = build_memo_context(
+            candidate=BASE_STRUCTURED_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        with caplog.at_level("WARNING"):
+            result = generate_structured_memo(ctx)
+
+        assert result is None
+        assert any("JSON parse failed" in rec.message for rec in caplog.records)
+
+
+class TestGenerateStructuredMemoMissingKeyFallback:
+    """Step 8, test 3."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_missing_bottom_line_returns_none(self, mock_get_client, caplog):
+        incomplete = {k: v for k, v in VALID_STRUCTURED_RESPONSE.items() if k != "bottom_line"}
+        mock_get_client.return_value = _mock_client_returning(incomplete)
+
+        ctx = build_memo_context(
+            candidate=BASE_STRUCTURED_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        with caplog.at_level("WARNING"):
+            result = generate_structured_memo(ctx)
+
+        assert result is None
+        assert any("missing keys" in rec.message for rec in caplog.records)
+
+
+class TestGenerateStructuredMemoExceptionFallback:
+    """Step 8, test 4."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_timeout_returns_none_no_raise(self, mock_get_client, caplog):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = TimeoutError("llm timed out")
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=BASE_STRUCTURED_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        with caplog.at_level("WARNING"):
+            # Must not raise
+            result = generate_structured_memo(ctx)
+
+        assert result is None
+        assert any("OpenAI call failed" in rec.message for rec in caplog.records)
+
+
+class TestRenderPromptRealizedDemandPresent:
+    """Step 8, test 5."""
+
+    def test_user_message_contains_realized_demand_numbers(self):
+        cand = dict(BASE_STRUCTURED_CANDIDATE)
+        cand["realized_demand_30d"] = 1400
+        cand["realized_demand_branches"] = 8
+        cand["realized_demand_district_median"] = 180
+
+        ctx = build_memo_context(candidate=cand, brief=BASE_STRUCTURED_BRIEF, lang="en")
+        messages = render_structured_memo_prompt(ctx)
+        user_content = messages[1]["content"]
+
+        # Serialized numbers appear verbatim
+        assert "1400" in user_content
+        assert '"branch_count": 8' in user_content or "\"branch_count\":8" in user_content
+        assert "180" in user_content
+        # System prompt was upgraded with EVIDENCE PRIORITY instruction
+        assert "EVIDENCE PRIORITY" in messages[0]["content"]
+
+
+class TestRenderPromptFailedGate:
+    """Step 8, test 6."""
+
+    def test_failed_gate_triggers_lead_with_failure_instruction(self):
+        cand = dict(BASE_STRUCTURED_CANDIDATE)
+        cand["gate_status_json"] = [
+            {"gate": "zoning_fit_pass", "verdict": "fail", "reason": "C-2 not allowed on this parcel"},
+            {"gate": "rent_reasonable", "verdict": "pass", "reason": "ok"},
+        ]
+
+        ctx = build_memo_context(candidate=cand, brief=BASE_STRUCTURED_BRIEF, lang="en")
+        messages = render_structured_memo_prompt(ctx)
+        system_content = messages[0]["content"]
+
+        assert "GATE FAILURE" in system_content
+        assert "zoning_fit_pass" in system_content
+        assert "Lead the headline_recommendation with this failure" in system_content
+
+
+class TestRenderPromptArabicLocale:
+    """Step 8, test 7."""
+
+    def test_arabic_locale_adds_msa_instruction(self):
+        ctx = build_memo_context(
+            candidate=BASE_STRUCTURED_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="ar",
+        )
+        messages = render_structured_memo_prompt(ctx)
+        system_content = messages[0]["content"]
+
+        assert "Modern Standard Arabic" in system_content
+        assert ctx.locale == "ar"
+
+
+class TestGenerateStructuredMemoFlagOff:
+    """Step 8, test 8."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_flag_off_returns_none_without_calling_client(self, mock_get_client, monkeypatch):
+        from app.core.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "EXPANSION_MEMO_STRUCTURED_ENABLED", False)
+
+        ctx = build_memo_context(
+            candidate=BASE_STRUCTURED_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        result = generate_structured_memo(ctx)
+
+        assert result is None
+        mock_get_client.assert_not_called()
+
+
+# ── Endpoint integration (happy path + persistence + ceiling) ───────
+
+
+class _DummyRow:
+    def __init__(self, values):
+        self._values = values
+
+    def __getitem__(self, i):
+        return self._values[i]
+
+
+class _DummyResult:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _DummyDB:
+    """In-memory DB stub supporting the two SQL statements the endpoint uses."""
+
+    def __init__(self, preload_row=None):
+        self.executed: list[tuple[str, dict]] = []
+        self.committed = False
+        self.rolled_back = False
+        self._preload_row = preload_row
+        self.persisted: dict | None = None
+
+    def execute(self, stmt, params=None):
+        sql_text = stmt.text if hasattr(stmt, "text") else str(stmt)
+        self.executed.append((sql_text, dict(params or {})))
+        if "SELECT" in sql_text:
+            return _DummyResult(self._preload_row)
+        if "UPDATE" in sql_text:
+            self.persisted = dict(params or {})
+            return _DummyResult(None)
+        return _DummyResult(None)
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        pass
+
+
+def _endpoint_client(db):
+    from fastapi.testclient import TestClient
+    from app.db.deps import get_db
+    from app.main import app
+
+    def override_get_db():
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestDecisionMemoEndpointHappyPathPersists:
+    """Step 8, test 1 — endpoint persists both columns on structured success."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_endpoint_persists_memo_text_and_memo_json(self, mock_get_client):
+        mock_get_client.return_value = _mock_client_returning(VALID_STRUCTURED_RESPONSE)
+
+        db = _DummyDB(preload_row=None)  # cache miss
+        client = _endpoint_client(db)
+
+        payload = {
+            "candidate": BASE_STRUCTURED_CANDIDATE,
+            "brief": BASE_STRUCTURED_BRIEF,
+            "lang": "en",
+            "search_id": "search-1",
+            "parcel_id": "parcel-9",
+        }
+        resp = client.post("/v1/expansion-advisor/decision-memo", json=payload)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert body["cached"] is False
+        assert body["memo_json"] is not None
+        assert body["memo_json"]["bottom_line"] == VALID_STRUCTURED_RESPONSE["bottom_line"]
+        assert isinstance(body["memo_text"], str) and body["memo_text"].startswith("## Headline Recommendation")
+
+        # Persisted with both columns populated
+        assert db.persisted is not None
+        assert db.persisted["sid"] == "search-1"
+        assert db.persisted["pid"] == "parcel-9"
+        assert isinstance(db.persisted["txt"], str)
+        persisted_json = json.loads(db.persisted["j"])
+        assert persisted_json["bottom_line"] == VALID_STRUCTURED_RESPONSE["bottom_line"]
+        assert db.committed is True
+
+
+class TestDecisionMemoEndpointMalformedFallsBackToLegacy:
+    """Step 8, test 2 — endpoint persists only text on legacy fallback."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_malformed_falls_back_and_persists_only_text(self, mock_get_client):
+        # Structured returns non-JSON; legacy then called — we stub both via
+        # a side_effect list on the SAME mocked client.
+        structured_bad = _make_mock_response("not json at all")
+        legacy_good = _make_mock_response(VALID_LLM_RESPONSE)
+        client_mock = MagicMock()
+        client_mock.chat.completions.create.side_effect = [structured_bad, legacy_good]
+        mock_get_client.return_value = client_mock
+
+        db = _DummyDB(preload_row=None)
+        api = _endpoint_client(db)
+
+        payload = {
+            "candidate": BASE_STRUCTURED_CANDIDATE,
+            "brief": BASE_STRUCTURED_BRIEF,
+            "lang": "en",
+            "search_id": "search-1",
+            "parcel_id": "parcel-9",
+        }
+        resp = api.post("/v1/expansion-advisor/decision-memo", json=payload)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert body["memo_json"] is None
+        assert isinstance(body["memo_text"], str) and body["memo_text"]
+        # Legacy-shape memo under "memo" (not structured)
+        assert body["memo"]["headline"] == VALID_LLM_RESPONSE["headline"]
+
+        # Persistence: text yes, JSON null
+        assert db.persisted is not None
+        assert db.persisted["txt"]
+        assert db.persisted["j"] is None
+
+
+class TestDecisionMemoEndpointCeilingStillReturns503:
+    """Ceiling-breach path consistency — the 503 contract must hold."""
+
+    def test_ceiling_breach_returns_503(self):
+        db = _DummyDB(preload_row=None)
+        api = _endpoint_client(db)
+
+        # Pin the tracker above the ceiling so both structured AND legacy
+        # short-circuit on _check_daily_ceiling(). Structured returns None
+        # (fallback), legacy raises RuntimeError, endpoint → 503.
+        today = _today_key()
+        _daily_cost_tracker[today] = 999.0
+        try:
+            payload = {
+                "candidate": BASE_STRUCTURED_CANDIDATE,
+                "brief": BASE_STRUCTURED_BRIEF,
+                "lang": "en",
+                "search_id": "search-1",
+                "parcel_id": "parcel-9",
+            }
+            resp = api.post("/v1/expansion-advisor/decision-memo", json=payload)
+        finally:
+            _daily_cost_tracker.clear()
+
+        assert resp.status_code == 503
+
+
+class TestRenderStructuredMemoAsTextSmoke:
+    def test_text_renderer_uses_six_section_headers(self):
+        out = render_structured_memo_as_text(VALID_STRUCTURED_RESPONSE, "en")
+        for header in (
+            "## Headline Recommendation",
+            "## Ranking Explanation",
+            "## Key Evidence",
+            "## Risks",
+            "## Comparison",
+            "## Bottom Line",
+        ):
+            assert header in out

--- a/tests/test_sample_regression_memos.py
+++ b/tests/test_sample_regression_memos.py
@@ -1,0 +1,205 @@
+"""Plumbing coverage for ``scripts/sample_regression_memos.py``.
+
+The script is manually invoked against the live stack to eyeball structured
+memo quality (Step 9 of the Phase-1 decision-memo upgrade). This test does
+NOT hit the real DB or real LLM — it only checks that the script's ``main``
+produces the documented output shape when its two external dependencies
+(``run_expansion_search`` and ``generate_structured_memo``) are mocked.
+
+Purpose: stop future edits to the script from silently breaking the shape
+contract that Ahmed's live-run output relies on.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+class _DummyDB:
+    def rollback(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def _fake_candidate(search_id: str, parcel_id: str = "parcel-rank-1") -> dict[str, Any]:
+    return {
+        "id": "cand-1",
+        "parcel_id": parcel_id,
+        "search_id": search_id,
+        "rank_position": 1,
+        "feature_snapshot_json": {
+            "district": "Al Olaya",
+            "area_m2": 160,
+            "estimated_annual_rent_sar": 420000,
+        },
+        "score_breakdown_json": {
+            "occupancy_economics": 82,
+            "listing_quality": 70,
+            "brand_fit": 75,
+            "competition_whitespace": 60,
+            "demand_potential": 65,
+            "access_visibility": 70,
+            "landlord_signal": 55,
+            "delivery_demand": 50,
+            "confidence": 80,
+        },
+        "gate_status_json": [
+            {"gate": "zoning_fit_pass", "verdict": "pass", "reason": "ok"},
+        ],
+        "comparable_competitors_json": [],
+    }
+
+
+_CANNED_MEMO = {
+    "headline_recommendation": "recommend — strong occupancy economics",
+    "ranking_explanation": "occupancy_economics contributed 24.6 of 30, driving rank 1.",
+    "key_evidence": [
+        {"signal": "rent", "value": "SAR 420k/yr", "implication": "below district median"},
+    ],
+    "risks": [
+        {"risk": "limited frontage", "mitigation": None},
+    ],
+    "comparison": "Beats the next candidate on occupancy economics by 3 points.",
+    "bottom_line": "Take it.",
+}
+
+
+def _install_mocks(monkeypatch, *, memo_override=None):
+    """Mock the two external collaborators the script calls inside
+    _run_one_search. Must be patched where the script imports them
+    (local imports inside _run_one_search)."""
+    import app.services.expansion_advisor as svc
+    import app.services.llm_decision_memo as memo_mod
+
+    def fake_run_expansion_search(db, *, search_id, **kwargs):
+        return [_fake_candidate(search_id)]
+
+    def fake_generate_structured_memo(ctx):
+        return memo_override if memo_override is not None else dict(_CANNED_MEMO)
+
+    monkeypatch.setattr(svc, "run_expansion_search", fake_run_expansion_search)
+    monkeypatch.setattr(memo_mod, "generate_structured_memo", fake_generate_structured_memo)
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+def test_main_returns_dict_keyed_by_search_name_with_structured_memos(monkeypatch, capsys):
+    _install_mocks(monkeypatch)
+
+    from scripts.sample_regression_memos import main, REGRESSION_BRIEFS
+
+    results = main(argv=[], db=_DummyDB())
+
+    # Keyed by every canonical search name
+    assert set(results.keys()) == set(REGRESSION_BRIEFS.keys())
+    for name, memo in results.items():
+        assert isinstance(memo, dict), f"{name} value not a dict"
+        # Structured memo shape — all six keys from the prompt contract
+        for key in (
+            "headline_recommendation",
+            "ranking_explanation",
+            "key_evidence",
+            "risks",
+            "comparison",
+            "bottom_line",
+        ):
+            assert key in memo, f"{name} missing {key}"
+        assert "skipped" not in memo
+
+    # stdout is a single pretty-printed JSON blob
+    stdout = capsys.readouterr().out
+    parsed = json.loads(stdout)
+    assert set(parsed.keys()) == set(REGRESSION_BRIEFS.keys())
+
+
+def test_main_filter_to_single_search(monkeypatch, capsys):
+    _install_mocks(monkeypatch)
+
+    from scripts.sample_regression_memos import main
+
+    results = main(argv=["--search", "cafe_al_yasmin"], db=_DummyDB())
+
+    assert list(results.keys()) == ["cafe_al_yasmin"]
+    assert results["cafe_al_yasmin"]["bottom_line"] == "Take it."
+
+
+def test_main_writes_to_out_path(monkeypatch, tmp_path):
+    _install_mocks(monkeypatch)
+
+    from scripts.sample_regression_memos import main
+
+    out_path = tmp_path / "memos.json"
+    results = main(
+        argv=["--search", "qsr_burger_al_olaya", "--out", str(out_path)],
+        db=_DummyDB(),
+    )
+
+    assert out_path.exists()
+    on_disk = json.loads(out_path.read_text(encoding="utf-8"))
+    assert on_disk == results
+    assert "qsr_burger_al_olaya" in on_disk
+
+
+def test_skipped_when_memo_generation_returns_none(monkeypatch):
+    _install_mocks(monkeypatch, memo_override=False)  # sentinel replaced below
+    # Override to simulate generate_structured_memo returning None
+    import app.services.llm_decision_memo as memo_mod
+    monkeypatch.setattr(memo_mod, "generate_structured_memo", lambda ctx: None)
+
+    from scripts.sample_regression_memos import main
+
+    results = main(argv=["--search", "cafe_al_yasmin"], db=_DummyDB())
+
+    entry = results["cafe_al_yasmin"]
+    assert entry.get("skipped") is True
+    assert "error" in entry
+    assert "generate_structured_memo" in entry["error"]
+
+
+def test_skipped_when_rank_one_missing_required_fields(monkeypatch):
+    import app.services.expansion_advisor as svc
+    import app.services.llm_decision_memo as memo_mod
+
+    def bad_run(db, *, search_id, **kwargs):
+        # Candidate missing feature_snapshot_json & score_breakdown_json
+        return [{
+            "id": "cand-x",
+            "parcel_id": "p-x",
+            "search_id": search_id,
+            "rank_position": 1,
+        }]
+
+    monkeypatch.setattr(svc, "run_expansion_search", bad_run)
+    # Should never be called on this path
+    monkeypatch.setattr(
+        memo_mod, "generate_structured_memo",
+        lambda ctx: pytest.fail("generate_structured_memo should not be called"),
+    )
+
+    from scripts.sample_regression_memos import main
+
+    results = main(argv=["--search", "qsr_burger_al_olaya"], db=_DummyDB())
+    entry = results["qsr_burger_al_olaya"]
+    assert entry.get("skipped") is True
+    assert "missing fields" in entry["error"]
+
+
+def test_skipped_when_search_returns_no_candidates(monkeypatch):
+    import app.services.expansion_advisor as svc
+
+    monkeypatch.setattr(
+        svc, "run_expansion_search",
+        lambda db, *, search_id, **kwargs: [],
+    )
+
+    from scripts.sample_regression_memos import main
+
+    results = main(argv=["--search", "delivery_shawarma_citywide"], db=_DummyDB())
+    entry = results["delivery_shawarma_citywide"]
+    assert entry.get("skipped") is True
+    assert "0 candidates" in entry["error"]


### PR DESCRIPTION
## Summary

Implements Phase 1 of the structured decision memo upgrade for Expansion Advisor. Adds a new LLM-powered path that generates rich, component-aware decision memos alongside the existing deterministic scoring system. The new path is additive and can be toggled off via configuration to maintain byte-for-byte compatibility with the legacy system.

## Key Changes

- **New structured memo service** (`llm_decision_memo.py`):
  - Added `MemoContext` dataclass to encapsulate all inputs needed for memo generation
  - Implemented `build_memo_context()` to assemble context from candidate/brief dicts, with automatic enrichment of score breakdowns with component weights and contributions
  - Added `generate_structured_memo()` to call the LLM with graceful fallback on errors (timeout, malformed JSON, missing keys)
  - Implemented `render_structured_memo_prompt()` to generate OpenAI-style messages with situational instructions (Arabic locale, realized demand presence, gate failures)
  - Added `render_structured_memo_as_text()` to convert structured JSON output to human-readable text
  - Defined `STRUCTURED_MEMO_SYSTEM_PROMPT` with hard rules for analyst-style output (specific numbers, no hedging, component citations)
  - Included helper functions for context assembly: `_coerce_gate_verdicts()`, `_component_score_value()`, `_build_contributions()`, `_extract_realized_demand()`, `_serialize_context_for_user_message()`

- **Endpoint integration** (`expansion_advisor.py`):
  - Updated `/decision-memo` POST endpoint to support caching via `search_id` and `parcel_id` parameters
  - Implemented cache lookup/write functions (`_decision_memo_cache_lookup()`, `_decision_memo_cache_write()`)
  - Added fallback path: structured memo on success → legacy generic memo on any failure
  - Implemented backward-compatibility shims (`_structured_to_legacy_shape()`, `_text_only_to_legacy_shape()`, `_legacy_memo_to_text()`) so un-updated frontends continue to work
  - Response now includes both `memo_json` (structured) and `memo_text` (rendered) with `memo` as legacy compat field

- **Database schema** (`alembic/versions/20260414_memo_json.py`):
  - Added `decision_memo` (TEXT) column for rendered memo text
  - Added `decision_memo_json` (JSONB) column for structured memo object
  - Both columns nullable, unindexed (display-only fields)

- **Configuration** (`core/config.py`):
  - Added `EXPANSION_MEMO_STRUCTURED_ENABLED` flag (default: True)
  - Added `EXPANSION_MEMO_MODEL` (default: "gpt-4o-mini")
  - Added `EXPANSION_MEMO_TEMPERATURE` (default: 0.7)
  - Added `EXPANSION_MEMO_MAX_TOKENS` (default: 1200)

- **Testing**:
  - Comprehensive test suite in `test_llm_decision_memo.py` covering:
    - Contribution math (weight × component_score for all 9 components)
    - Happy path (valid JSON response parsing)
    - Malformed JSON fallback
    - Missing required keys fallback
    - Exception handling (timeout, etc.)
    - Prompt rendering with realized demand, failed gates, Arabic locale
    - Feature flag off behavior
    - Endpoint integration with caching and persistence
  - Added `test_sample_regression_memos.py` for script plumbing coverage

- **Regression testing script** (`scripts/sample_regression_memos.py`):
  - CLI tool to run four canonical searches (QSR burger, delivery shawarma, dine-in Indian, café) end-to-end
  - Generates structured memos for rank-1 candidates without hitting cache or persisting
  - Outputs raw `memo_json` for manual quality review
  - Useful for prompt/signal calibration before PR submission

## Notable Implementation Details

- **Component weights** hardcoded in sync

https://claude.ai/code/session_01SEHcNeTda5iyVEKKnKyh1v