### PR TITLE
Add polarity-aware evidence routing to legacy memo shim

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -1000,26 +1000,70 @@ def _structured_to_legacy_shape(memo_json: dict[str, Any]) -> dict[str, Any]:
 
     Canonical (new) fields are ``response["memo_json"]`` / ``response["memo_text"]``.
     ``response["memo"]`` is a backward-compat shim only.
+
+    Evidence is routed by its ``polarity`` field: positive/neutral implications
+    populate ``top_reasons_to_pursue`` (positives first), and negative
+    implications are merged into ``top_risks`` after the explicit risks list.
+    Missing or malformed polarity is treated as ``"neutral"`` so cached memos
+    generated before polarity was required still render correctly.
     """
+    if not isinstance(memo_json, dict):
+        memo_json = {}
     evidence = memo_json.get("key_evidence") or []
     risks = memo_json.get("risks") or []
-    reasons: list[str] = []
+    if not isinstance(evidence, list):
+        evidence = []
+    if not isinstance(risks, list):
+        risks = []
+
+    positive_reasons: list[str] = []
+    negative_implications: list[str] = []
+    neutral_context: list[str] = []
     for item in evidence:
-        if isinstance(item, dict):
-            impl = item.get("implication")
-            if impl:
-                reasons.append(str(impl))
-    risk_strings: list[str] = []
+        if not isinstance(item, dict):
+            continue
+        impl = item.get("implication")
+        if not impl:
+            continue
+        impl_str = str(impl)
+        polarity_raw = item.get("polarity")
+        polarity = str(polarity_raw).strip().lower() if polarity_raw else ""
+        if polarity == "positive":
+            positive_reasons.append(impl_str)
+        elif polarity == "negative":
+            negative_implications.append(impl_str)
+        else:
+            neutral_context.append(impl_str)
+
+    explicit_risks: list[str] = []
     for item in risks:
-        if isinstance(item, dict):
-            r = item.get("risk")
-            if r:
-                risk_strings.append(str(r))
+        if not isinstance(item, dict):
+            continue
+        r = item.get("risk")
+        if not r:
+            continue
+        explicit_risks.append(str(r))
+
+    top_reasons_to_pursue = positive_reasons + neutral_context
+
+    top_risks: list[str] = []
+    seen: set[str] = set()
+    for s in explicit_risks + negative_implications:
+        if s in seen:
+            continue
+        seen.add(s)
+        top_risks.append(s)
+
+    if not top_reasons_to_pursue:
+        ranking_explanation = str(memo_json.get("ranking_explanation") or "").strip()
+        if ranking_explanation:
+            top_reasons_to_pursue = [ranking_explanation[:200]]
+
     return {
         "headline": str(memo_json.get("headline_recommendation") or "—"),
         "fit_summary": str(memo_json.get("ranking_explanation") or "—"),
-        "top_reasons_to_pursue": reasons,
-        "top_risks": risk_strings,
+        "top_reasons_to_pursue": top_reasons_to_pursue,
+        "top_risks": top_risks,
         "recommended_next_action": str(memo_json.get("bottom_line") or "—"),
         # Structured prompt does not produce a rent_context field; keep the
         # legacy key populated with a placeholder so callers that expect it

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -637,10 +637,10 @@ You will receive a JSON object describing:
 Return ONLY a single JSON object (no markdown fences, no commentary before or after). The object must contain EXACTLY these six top-level keys with the types and semantics described:
 
 {
-  "headline_recommendation": "string — one sentence. Must be one of 'recommend', 'recommend with reservations', or 'pass', plus the single strongest reason.",
+  "headline_recommendation": "string — one sentence. Must be one of 'recommend', 'recommend with reservations', or 'decline', plus the single strongest reason. Use 'decline' (not 'pass') so the verdict is unambiguous in English.",
   "ranking_explanation": "string — 2-3 sentences. Must cite which of the 9 components drove the rank and by how much, using the numbers from score_breakdown.contributions (e.g., 'occupancy_economics contributed 27.2 out of 30').",
   "key_evidence": [
-    {"signal": "string", "value": "string with units", "implication": "string — what this fact means for the decision"}
+    {"signal": "string", "value": "string with units", "implication": "string — what this fact means for the decision", "polarity": "positive | negative | neutral"}
   ],
   "risks": [
     {"risk": "string", "mitigation": "string or null"}
@@ -655,6 +655,7 @@ Hard rules:
 - Do not use the phrases "overall,", "appears to be,", "could potentially,", or "generally speaking."
 - Write like an analyst who has actually visited the site, not a summarizer.
 - key_evidence must be a non-empty list. risks may be an empty list, but the key must be present.
+- Each key_evidence item MUST include a polarity field. Use 'positive' for facts that favor pursuing the site (strong demand, below-median rent, motivated landlord, etc.), 'negative' for facts that discourage pursuing it (high competition, bad frontage, above-median rent, parking failure, etc.), and 'neutral' for context that is important but neither favorable nor unfavorable. A key_evidence item with `implication` text that describes a concern or drawback MUST be tagged 'negative', not 'neutral'.
 - Return ONLY the JSON object, with no markdown fences, no leading or trailing commentary."""
 
 
@@ -734,7 +735,7 @@ def render_structured_memo_prompt(ctx: MemoContext) -> list[dict]:
             "GATE FAILURE: One or more gates failed — "
             + failure_list
             + ". Lead the headline_recommendation with this failure and frame "
-            "the overall recommendation accordingly (likely 'pass' unless the "
+            "the overall recommendation accordingly (likely 'decline' unless the "
             "failure is borderline and clearly mitigable)."
         )
 

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -262,8 +262,8 @@ VALID_STRUCTURED_RESPONSE = {
         "component and the gap to rank 1 is narrow."
     ),
     "key_evidence": [
-        {"signal": "annual rent", "value": "SAR 480,000/yr", "implication": "15% below Al Olaya median"},
-        {"signal": "realized demand 30d", "value": "1,400 orders", "implication": "7.8x district median"},
+        {"signal": "annual rent", "value": "SAR 480,000/yr", "implication": "15% below Al Olaya median", "polarity": "positive"},
+        {"signal": "realized demand 30d", "value": "1,400 orders", "implication": "7.8x district median", "polarity": "positive"},
     ],
     "risks": [
         {"risk": "street width 8 m limits drive-thru", "mitigation": "curbside handoff via Keeta"},
@@ -750,3 +750,166 @@ class TestRenderStructuredMemoAsTextSmoke:
             "## Bottom Line",
         ):
             assert header in out
+
+
+# ── Phase 1 hotfix: evidence polarity routing in the legacy shim ─────
+
+VALID_STRUCTURED_RESPONSE_WITH_POLARITY = {
+    "headline_recommendation": "recommend with reservations — rent is attractive but competition is heavy",
+    "ranking_explanation": (
+        "occupancy_economics contributed 26.0 out of 30 and competition_whitespace "
+        "only 4.0 out of 10, netting rank 3 of 12."
+    ),
+    "key_evidence": [
+        {
+            "signal": "annual rent",
+            "value": "SAR 480,000/yr",
+            "implication": "15% below Al Olaya median",
+            "polarity": "positive",
+        },
+        {
+            "signal": "competitor density",
+            "value": "3 QSR within 400 m",
+            "implication": "3 competitors limit market share",
+            "polarity": "negative",
+        },
+        {
+            "signal": "street width",
+            "value": "12 m",
+            "implication": "adequate but not drive-thru capable",
+            "polarity": "neutral",
+        },
+    ],
+    "risks": [
+        {"risk": "landlord wants 3-year escalator", "mitigation": "negotiate cap at CPI+2%"},
+    ],
+    "comparison": "Matches Peer A on rent; trails Peer B on competition exposure.",
+    "bottom_line": "Worth a site visit but push hard on the escalator.",
+}
+
+
+class TestStructuredToLegacyShapeEvidencePolarity:
+    """Phase 1 hotfix: polarity-aware routing of key_evidence into
+    top_reasons_to_pursue vs top_risks in _structured_to_legacy_shape."""
+
+    def test_mixed_polarity_routes_positives_and_neutrals_to_reasons_and_negatives_to_risks(self):
+        from app.api.expansion_advisor import _structured_to_legacy_shape
+
+        memo = _structured_to_legacy_shape(VALID_STRUCTURED_RESPONSE_WITH_POLARITY)
+
+        positive_impl = "15% below Al Olaya median"
+        neutral_impl = "adequate but not drive-thru capable"
+        negative_impl = "3 competitors limit market share"
+        explicit_risk = "landlord wants 3-year escalator"
+
+        # top_reasons_to_pursue: positive first, then neutral — order matters.
+        assert memo["top_reasons_to_pursue"] == [positive_impl, neutral_impl]
+        assert memo["top_reasons_to_pursue"].index(positive_impl) < memo["top_reasons_to_pursue"].index(neutral_impl)
+        assert negative_impl not in memo["top_reasons_to_pursue"]
+
+        # top_risks: explicit risk first, then negative implication — order matters.
+        assert memo["top_risks"] == [explicit_risk, negative_impl]
+        assert memo["top_risks"].index(explicit_risk) < memo["top_risks"].index(negative_impl)
+
+    def test_missing_polarity_is_backward_compat_and_treated_as_neutral(self):
+        """Cached structured memos generated before this hotfix have no
+        polarity field; the shim must route every implication to
+        top_reasons_to_pursue (same behavior as before the hotfix) and must
+        not raise."""
+        from app.api.expansion_advisor import _structured_to_legacy_shape
+
+        legacy_cached_memo = {
+            "headline_recommendation": "recommend — below-median rent",
+            "ranking_explanation": "occupancy_economics drove the rank.",
+            "key_evidence": [
+                {"signal": "rent", "value": "SAR 400k/yr", "implication": "12% below median"},
+                {"signal": "footfall", "value": "high", "implication": "adjacent to Hyper Panda"},
+                {"signal": "frontage", "value": "10 m", "implication": "decent visibility"},
+            ],
+            "risks": [{"risk": "permit delay", "mitigation": "start early"}],
+            "comparison": "Matches peers.",
+            "bottom_line": "Pursue.",
+        }
+
+        memo = _structured_to_legacy_shape(legacy_cached_memo)
+
+        assert memo["top_reasons_to_pursue"] == [
+            "12% below median",
+            "adjacent to Hyper Panda",
+            "decent visibility",
+        ]
+        assert memo["top_risks"] == ["permit delay"]
+
+    def test_all_negative_evidence_falls_back_to_ranking_explanation(self):
+        from app.api.expansion_advisor import _structured_to_legacy_shape
+
+        ranking_explanation = (
+            "access_visibility was the only component above median at 6.8 of 10; "
+            "every other component trailed peers, leaving rank 11 of 12 with a "
+            "final score that sits two full points below the recommend threshold."
+        )
+        all_negative_memo = {
+            "headline_recommendation": "decline — every signal except frontage is weak",
+            "ranking_explanation": ranking_explanation,
+            "key_evidence": [
+                {"signal": "rent", "value": "SAR 700k/yr", "implication": "22% above median", "polarity": "negative"},
+                {"signal": "competition", "value": "5 QSR within 300 m", "implication": "saturated corridor", "polarity": "negative"},
+            ],
+            "risks": [{"risk": "parking fails municipal minimum", "mitigation": None}],
+            "comparison": "Trails all peers.",
+            "bottom_line": "Skip.",
+        }
+
+        memo = _structured_to_legacy_shape(all_negative_memo)
+
+        # top_reasons_to_pursue falls back to ranking_explanation truncated to 200 chars.
+        assert len(memo["top_reasons_to_pursue"]) == 1
+        assert memo["top_reasons_to_pursue"][0] == ranking_explanation[:200]
+        assert len(memo["top_reasons_to_pursue"][0]) <= 200
+
+        # top_risks contains every negative implication plus the explicit risk.
+        assert "parking fails municipal minimum" in memo["top_risks"]
+        assert "22% above median" in memo["top_risks"]
+        assert "saturated corridor" in memo["top_risks"]
+        # Explicit risk comes before negative implications.
+        assert memo["top_risks"][0] == "parking fails municipal minimum"
+
+    def test_malformed_evidence_items_are_skipped_not_crashed(self):
+        from app.api.expansion_advisor import _structured_to_legacy_shape
+
+        malformed_memo = {
+            "headline_recommendation": "recommend — rent edge",
+            "ranking_explanation": "occupancy_economics drove the rank.",
+            "key_evidence": [
+                {"signal": "rent", "value": "SAR 400k/yr", "implication": "below median", "polarity": "positive"},
+                "not a dict, should be skipped",
+                {"signal": "frontage", "value": "10 m"},  # missing implication, should be skipped
+                None,  # not a dict, should be skipped
+                {"signal": "footfall", "value": "high", "implication": "busy corridor", "polarity": "neutral"},
+            ],
+            "risks": [
+                {"risk": "permit delay", "mitigation": "start early"},
+                "not a dict",
+                {"mitigation": "no risk key"},  # missing risk, should be skipped
+                None,
+            ],
+            "comparison": "Matches peers.",
+            "bottom_line": "Pursue.",
+        }
+
+        memo = _structured_to_legacy_shape(malformed_memo)
+
+        # Only the two well-formed evidence items made it through.
+        assert memo["top_reasons_to_pursue"] == ["below median", "busy corridor"]
+        # Only the one well-formed risk made it through.
+        assert memo["top_risks"] == ["permit delay"]
+        # Function returned a valid legacy-shape dict (all six keys present).
+        for key in (
+            "headline",
+            "fit_summary",
+            "top_reasons_to_pursue",
+            "top_risks",
+            "recommended_next_action",
+            "rent_context",
+        ):
+            assert key in memo


### PR DESCRIPTION
## Summary
This PR implements evidence polarity routing in the `_structured_to_legacy_shape` function to properly categorize key evidence items as reasons to pursue or risks based on their polarity classification. It also updates the LLM prompt to require polarity metadata on evidence items and clarifies the verdict language.

## Key Changes

- **Evidence polarity routing**: Modified `_structured_to_legacy_shape` to classify evidence by polarity field:
  - `"positive"` and `"neutral"` implications → `top_reasons_to_pursue` (positives first)
  - `"negative"` implications → `top_risks` (after explicit risks)
  - Missing polarity treated as `"neutral"` for backward compatibility with cached memos

- **Fallback for all-negative evidence**: When no positive/neutral evidence exists, `top_reasons_to_pursue` falls back to the first 200 characters of `ranking_explanation`

- **Robustness improvements**:
  - Added type checking for `memo_json`, `evidence`, and `risks` to handle malformed inputs gracefully
  - Malformed evidence items (missing `implication` field) and risk items (missing `risk` field) are skipped without crashing
  - Deduplication of risk strings to prevent duplicates

- **LLM prompt updates**:
  - Added `"polarity"` field to `key_evidence` schema with values `"positive | negative | neutral"`
  - Changed verdict language from `"pass"` to `"decline"` for unambiguous English phrasing
  - Updated prompt instructions to clarify polarity semantics

- **Test coverage**: Added comprehensive test suite (`TestStructuredToLegacyShapeEvidencePolarity`) covering:
  - Mixed polarity routing with correct ordering
  - Backward compatibility with legacy cached memos (no polarity field)
  - All-negative evidence fallback behavior
  - Malformed evidence and risk item handling

## Implementation Details

The routing logic prioritizes explicit risks first, then negative implications, ensuring that structured risks take precedence. Positive implications are ordered before neutral ones in reasons to pursue, maintaining a persuasive narrative order. The implementation is defensive against schema violations to ensure graceful degradation when processing cached memos or malformed data.

https://claude.ai/code/session_01PLwamEfEjR27cr6SCpXe2Z