### PR TITLE
Make forbidden-phrase check per-candidate with cycle-aware revert

### DIFF
--- a/app/services/expansion_rerank.py
+++ b/app/services/expansion_rerank.py
@@ -140,7 +140,13 @@ def _candidate_payload(
     competitor_keep: int,
     truncate_descriptions: bool,
 ) -> dict[str, Any]:
-    """Build the per-candidate dict that goes into the user message."""
+    """Build the per-candidate dict that goes into the user message.
+
+    Search-service candidate dicts use ``_json``-suffixed keys
+    (``score_breakdown_json``, ``feature_snapshot_json``, etc.).  Test
+    helpers may use the bare names, so we try both with the ``_json``
+    variant first.
+    """
     payload: dict[str, Any] = {
         "parcel_id": candidate.get("parcel_id") or candidate.get("id"),
         "deterministic_rank": candidate.get(
@@ -148,22 +154,56 @@ def _candidate_payload(
         ),
         "final_score": candidate.get("final_score", candidate.get("score")),
     }
-    breakdown = candidate.get("score_breakdown")
+    # Score breakdown.
+    breakdown = (
+        candidate.get("score_breakdown_json")
+        or candidate.get("score_breakdown")
+    )
     if breakdown:
         payload["score_breakdown"] = breakdown
-    gates = candidate.get("gate_verdicts")
-    if gates:
-        payload["gate_verdicts"] = gates
+    # Gate verdicts — search-service candidates store status and reasons
+    # in two separate ``_json``-suffixed keys.
+    gate_status = candidate.get("gate_status_json")
+    gate_reasons = candidate.get("gate_reasons_json")
+    if gate_status or gate_reasons:
+        payload["gate_verdicts"] = {
+            "status": gate_status,
+            "reasons": gate_reasons,
+        }
+    elif candidate.get("gate_verdicts"):
+        payload["gate_verdicts"] = candidate["gate_verdicts"]
+    # Feature snapshot.
     snapshot = _trim_feature_snapshot(
-        candidate.get("feature_snapshot"), whitelist_only=whitelist_only
+        candidate.get("feature_snapshot_json")
+        or candidate.get("feature_snapshot"),
+        whitelist_only=whitelist_only,
     )
     if snapshot:
         payload["feature_snapshot"] = snapshot
-    realized = candidate.get("realized_demand")
-    if realized is not None:
-        payload["realized_demand"] = realized
+    # Realized demand — lives inside the feature snapshot; surface it at
+    # the top level so the LLM sees it prominently (the system prompt
+    # describes it as the strongest available signal).
+    fs = (
+        candidate.get("feature_snapshot_json")
+        or candidate.get("feature_snapshot")
+        or {}
+    )
+    if isinstance(fs, dict):
+        rd_30d = fs.get("realized_demand_30d")
+        if rd_30d is not None:
+            payload["realized_demand"] = {
+                "realized_demand_30d": rd_30d,
+                "realized_demand_branches": fs.get(
+                    "realized_demand_branches"
+                ),
+                "realized_demand_district_median": fs.get(
+                    "realized_demand_district_median"
+                ),
+            }
+    # Comparable competitors.
     competitors = _truncate_competitors(
-        candidate.get("comparable_competitors"),
+        candidate.get("comparable_competitors_json")
+        or candidate.get("comparable_competitors"),
         keep=competitor_keep,
         truncate_descriptions=truncate_descriptions,
     )
@@ -316,9 +356,24 @@ def _candidate_known_numbers(candidate: dict[str, Any]) -> set[str]:
     """Collect numeric tokens from the candidate's feature_snapshot and
     score_breakdown for the soft spot-check."""
     known: set[str] = set()
-    known |= _flatten_numbers(candidate.get("feature_snapshot"))
-    known |= _flatten_numbers(candidate.get("score_breakdown"))
-    known |= _flatten_numbers(candidate.get("realized_demand"))
+    known |= _flatten_numbers(
+        candidate.get("feature_snapshot_json")
+        or candidate.get("feature_snapshot")
+    )
+    known |= _flatten_numbers(
+        candidate.get("score_breakdown_json")
+        or candidate.get("score_breakdown")
+    )
+    # Realized demand lives inside the feature snapshot.
+    fs = (
+        candidate.get("feature_snapshot_json")
+        or candidate.get("feature_snapshot")
+        or {}
+    )
+    if isinstance(fs, dict):
+        known |= _flatten_numbers(fs.get("realized_demand_30d"))
+        known |= _flatten_numbers(fs.get("realized_demand_branches"))
+        known |= _flatten_numbers(fs.get("realized_demand_district_median"))
     return known
 
 
@@ -501,30 +556,10 @@ def _validate_rerank_response(
                 f"(min {_MIN_COMPARISON_CHARS} chars)"
             ]
 
-    # Check 12 (HARD): forbidden causal phrases (word-boundary, case-insensitive).
-    for item in reranked:
-        reason = item.get("rerank_reason")
-        if not isinstance(reason, dict):
-            continue
-        pid = item["parcel_id"]
-        # summary + comparison (strings)
-        for field in ("summary", "comparison_to_displaced_candidate"):
-            hit = _find_forbidden_phrase(reason.get(field, ""))
-            if hit:
-                return False, [
-                    f"forbidden_phrase: '{hit}' in {field} of {pid}"
-                ]
-        # positives_cited + negatives_cited (lists of strings)
-        for field in ("positives_cited", "negatives_cited"):
-            entries = reason.get(field) or []
-            if not isinstance(entries, list):
-                continue
-            for entry in entries:
-                hit = _find_forbidden_phrase(entry if isinstance(entry, str) else "")
-                if hit:
-                    return False, [
-                        f"forbidden_phrase: '{hit}' in {field} of {pid}"
-                    ]
+    # Check 12 (forbidden causal phrases) is now handled per-candidate in
+    # _scrub_forbidden_phrases(), called after validation passes. Moved
+    # out of hard-fail so that a single bad reason only reverts its own
+    # permutation cycle instead of discarding the entire rerank.
 
     # Check 11 (SOFT): anti-hallucination spot-check. Log warnings only.
     for item in reranked:
@@ -544,6 +579,106 @@ def _validate_rerank_response(
             )
 
     return True, []
+
+
+# ---------------------------------------------------------------------------
+# Forbidden-phrase scrub (per-candidate, cycle-aware)
+# ---------------------------------------------------------------------------
+
+
+def _reason_has_forbidden_phrase(reason: dict[str, Any]) -> str | None:
+    """Return the first forbidden phrase found in any text field of a
+    ``rerank_reason`` dict, or ``None``."""
+    for field in ("summary", "comparison_to_displaced_candidate"):
+        hit = _find_forbidden_phrase(reason.get(field, ""))
+        if hit:
+            return hit
+    for field in ("positives_cited", "negatives_cited"):
+        entries = reason.get(field) or []
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, str):
+                hit = _find_forbidden_phrase(entry)
+                if hit:
+                    return hit
+    return None
+
+
+def _scrub_forbidden_phrases(reranked: list[dict[str, Any]]) -> int:
+    """Per-candidate forbidden-phrase check with cycle-aware revert.
+
+    Identifies moved candidates whose ``rerank_reason`` contains a
+    forbidden causal phrase, then reverts the *entire permutation cycle*
+    containing each offending candidate.  Reverting a full cycle is
+    necessary to maintain a valid rank permutation ({1..N} with no
+    gaps or duplicates).  Modifies ``reranked`` in place.
+
+    Returns the number of candidates whose moves were reverted.
+    """
+    n = len(reranked)
+    if n == 0:
+        return 0
+
+    # 1. Identify tainted candidates.
+    tainted_pids: set[str] = set()
+    for item in reranked:
+        if item["new_rank"] == item["original_rank"]:
+            continue
+        reason = item.get("rerank_reason")
+        if not isinstance(reason, dict):
+            continue
+        hit = _reason_has_forbidden_phrase(reason)
+        if hit:
+            logger.warning(
+                "rerank forbidden-phrase hit: reverting parcel_id=%s, "
+                "phrase='%s'",
+                item["parcel_id"],
+                hit,
+            )
+            tainted_pids.add(item["parcel_id"])
+
+    if not tainted_pids:
+        return 0
+
+    # 2. Decompose the rank permutation into disjoint cycles and revert
+    #    every cycle that contains at least one tainted candidate.
+    by_orig_rank: dict[int, dict[str, Any]] = {
+        item["original_rank"]: item for item in reranked
+    }
+    perm: dict[int, int] = {
+        item["original_rank"]: item["new_rank"] for item in reranked
+    }
+
+    visited: set[int] = set()
+    reverted = 0
+
+    for start_rank in range(1, n + 1):
+        if start_rank in visited:
+            continue
+        # Trace one cycle.
+        cycle_ranks: list[int] = []
+        r = start_rank
+        while r not in visited:
+            visited.add(r)
+            cycle_ranks.append(r)
+            r = perm[r]
+
+        # Fixed points (length-1 cycles) never need reverting.
+        if len(cycle_ranks) <= 1:
+            continue
+
+        cycle_items = [by_orig_rank[cr] for cr in cycle_ranks]
+        if not any(it["parcel_id"] in tainted_pids for it in cycle_items):
+            continue
+
+        # Revert the entire cycle.
+        for item in cycle_items:
+            item["new_rank"] = item["original_rank"]
+            item["rerank_reason"] = None
+            reverted += 1
+
+    return reverted
 
 
 def generate_rerank(
@@ -647,7 +782,7 @@ def generate_rerank(
         )
         return None
 
-    # 7. Validate (hard-fail on any violation, discard the entire rerank).
+    # 7. Validate (hard-fail on structural violations).
     ok, reasons = _validate_rerank_response(parsed, shortlist, max_move)
     if not ok:
         logger.warning(
@@ -657,6 +792,15 @@ def generate_rerank(
             content[:1000],
         )
         return None
+
+    # 7b. Per-candidate forbidden-phrase scrub. Reverts offending
+    #     candidates (and their permutation-cycle partners) in place.
+    reverted = _scrub_forbidden_phrases(parsed["reranked"])
+    if reverted:
+        logger.info(
+            "rerank forbidden-phrase scrub reverted %d candidate(s)",
+            reverted,
+        )
 
     # 8. Record cost against the shared daily tracker.
     usage = getattr(response, "usage", None)

--- a/tests/test_expansion_rerank.py
+++ b/tests/test_expansion_rerank.py
@@ -254,11 +254,14 @@ def test_moved_candidate_with_null_reason_discarded(_rerank_enabled):
 
 
 # ---------------------------------------------------------------------------
-# 9. Validation failure: forbidden phrase in summary
+# 9. Forbidden phrase: per-candidate revert (cycle-aware), not whole-response
 # ---------------------------------------------------------------------------
-def test_forbidden_phrase_in_summary_discarded(_rerank_enabled, caplog):
-    shortlist = _shortlist(5)
-    decisions = _unchanged_decisions(5)
+def test_forbidden_phrase_reverts_cycle_only(_rerank_enabled, caplog):
+    """A forbidden phrase in one candidate reverts that candidate's entire
+    permutation cycle but preserves independent clean swaps."""
+    shortlist = _shortlist(6)
+    decisions = _unchanged_decisions(6)
+    # Tainted swap: p1 <-> p2, p1 has "due to" in summary.
     decisions[0] = {
         "parcel_id": "p1", "original_rank": 1, "new_rank": 2,
         "rerank_reason": _ok_reason(
@@ -267,7 +270,22 @@ def test_forbidden_phrase_in_summary_discarded(_rerank_enabled, caplog):
     }
     decisions[1] = {
         "parcel_id": "p2", "original_rank": 2, "new_rank": 1,
-        "rerank_reason": _ok_reason(),
+        "rerank_reason": _ok_reason(
+            summary="promoted after reweighing frontage and landlord signal",
+            comparison="the displaced candidate has a weaker overall fit"),
+    }
+    # Clean swap: p3 <-> p4 (no forbidden phrases).
+    decisions[2] = {
+        "parcel_id": "p3", "original_rank": 3, "new_rank": 4,
+        "rerank_reason": _ok_reason(
+            summary="moved down after reweighing frontage and landlord signal",
+            comparison="the displaced candidate has a weaker overall fit"),
+    }
+    decisions[3] = {
+        "parcel_id": "p4", "original_rank": 4, "new_rank": 3,
+        "rerank_reason": _ok_reason(
+            summary="promoted after reweighing frontage and landlord signal",
+            comparison="the displaced candidate has a weaker overall fit"),
     }
     mock_client = MagicMock()
     mock_client.chat.completions.create.return_value = _make_mock_response(
@@ -276,9 +294,22 @@ def test_forbidden_phrase_in_summary_discarded(_rerank_enabled, caplog):
     with patch.object(expansion_rerank, "_get_client", return_value=mock_client), \
          caplog.at_level(logging.WARNING, logger="app.services.expansion_rerank"):
         result = generate_rerank(shortlist, {})
-    assert result is None
+    # The tainted cycle (p1 <-> p2) is reverted; clean cycle preserved.
+    assert result is not None
+    by_pid = {d["parcel_id"]: d for d in result}
+    # p1 and p2 reverted to original ranks.
+    assert by_pid["p1"]["new_rank"] == 1
+    assert by_pid["p1"]["rerank_reason"] is None
+    assert by_pid["p2"]["new_rank"] == 2
+    assert by_pid["p2"]["rerank_reason"] is None
+    # p3 <-> p4 swap preserved.
+    assert by_pid["p3"]["new_rank"] == 4
+    assert isinstance(by_pid["p3"]["rerank_reason"], dict)
+    assert by_pid["p4"]["new_rank"] == 3
+    assert isinstance(by_pid["p4"]["rerank_reason"], dict)
+    # Warning logged for the tainted candidate.
     assert any(
-        "forbidden_phrase" in r.getMessage() and "due to" in r.getMessage()
+        "forbidden-phrase" in r.getMessage() and "due to" in r.getMessage()
         for r in caplog.records
     )
 


### PR DESCRIPTION
## Summary
Changed the forbidden-phrase validation from a hard-fail that discards the entire rerank response to a per-candidate check that reverts only the affected permutation cycle. This allows clean candidate swaps to be preserved even when other candidates contain forbidden phrases.

## Key Changes

- **Moved forbidden-phrase check out of hard validation**: Removed the check from `_validate_rerank_response()` so it no longer causes the entire rerank to be discarded. Instead, it's now applied after validation passes.

- **Implemented cycle-aware revert logic**: Added `_scrub_forbidden_phrases()` function that:
  - Identifies candidates with forbidden phrases in their `rerank_reason`
  - Decomposes the rank permutation into disjoint cycles
  - Reverts entire cycles containing tainted candidates (necessary to maintain valid rank permutation)
  - Preserves independent clean swaps unaffected by forbidden phrases

- **Added helper function**: `_reason_has_forbidden_phrase()` extracts the forbidden-phrase detection logic for reuse in the new per-candidate scrub.

- **Updated candidate payload handling**: Enhanced `_candidate_payload()` and `_candidate_known_numbers()` to support both search-service format (`_json`-suffixed keys like `score_breakdown_json`) and test helper format (bare names). Also improved handling of realized demand by extracting it from the feature snapshot and surfacing it at the top level.

- **Updated test**: Changed `test_forbidden_phrase_in_summary_discarded()` to `test_forbidden_phrase_reverts_cycle_only()` to verify that:
  - A tainted cycle (p1 ↔ p2) is reverted when one candidate has a forbidden phrase
  - Independent clean cycles (p3 ↔ p4) are preserved
  - The result is not discarded entirely

## Implementation Details

The cycle decomposition algorithm traces permutation cycles starting from each unvisited rank, identifying which candidates are involved in each cycle. Only cycles containing at least one tainted candidate are reverted, restoring all candidates in that cycle to their original ranks and clearing their rerank reasons. This maintains the invariant that the final rank list is a valid permutation of {1..N}.

https://claude.ai/code/session_01YSEwJiv8ZrunPxtbk3PagC