### PR TITLE
Remove "due to" and "because of" from forbidden phrase blocklist

### DIFF
--- a/app/services/expansion_rerank.py
+++ b/app/services/expansion_rerank.py
@@ -59,6 +59,7 @@ Hard rules (violations cause your output to be discarded):
    a. Do NOT assert causal relationships between facts unless the causation is directly supported by the data. Forbidden phrases when joining unrelated facts: "due to", "because of", "as a result of", "leading to", "causing". If two facts are both true but not causally linked, report them separately.
    b. Every numerical claim with units in positives_cited or negatives_cited (e.g., "rent 18% below median", "realized_demand_30d=1400") must be directly derivable from the candidate's feature_snapshot or score_breakdown. Do not invent percentages, dollar amounts, or counts. If you don't have a number for a claim, phrase it qualitatively without inventing one.
    c. Do not use the phrases "overall", "appears to be", "could potentially", or "generally speaking".
+   d. Do NOT use causal connective phrases like "as a result of", "leading to", or "causing" in your reasons. Describe what you observed in the candidate, not a claim about cause-and-effect. Good: "Higher economics score and stronger parking signal." Bad: "Promoted as a result of stronger economics."
 
 Output: a single JSON object with one top-level key "reranked", whose value is an array of exactly N objects (one per shortlist candidate, in any order). Each object has:
 {{
@@ -296,12 +297,13 @@ _REQUIRED_REASON_FIELDS: tuple[str, ...] = (
 )
 
 # Case-insensitive word-boundary matches. Spaces between words are matched
-# literally; leading/trailing \b prevents "introduced to" from matching
-# "due to" (no word boundary inside "introduced") and "undue toll" from
-# matching because "d" is preceded by a word char.
+# literally; leading/trailing \b prevents partial-word false positives
+# (e.g. "undue toll" matching "due to" because "d" would be preceded by a
+# word char). "due to" and "because of" were intentionally dropped from
+# this list: the LLM uses them reflexively as plain English connectives,
+# so reverting on them caused every rerank to end with moved=0. The
+# remaining phrases still flag speculative causal-chain reasoning.
 _FORBIDDEN_PHRASES: tuple[str, ...] = (
-    "due to",
-    "because of",
     "as a result of",
     "leading to",
     "causing",

--- a/tests/test_expansion_rerank.py
+++ b/tests/test_expansion_rerank.py
@@ -261,11 +261,11 @@ def test_forbidden_phrase_reverts_cycle_only(_rerank_enabled, caplog):
     permutation cycle but preserves independent clean swaps."""
     shortlist = _shortlist(6)
     decisions = _unchanged_decisions(6)
-    # Tainted swap: p1 <-> p2, p1 has "due to" in summary.
+    # Tainted swap: p1 <-> p2, p1 has "as a result of" in summary.
     decisions[0] = {
         "parcel_id": "p1", "original_rank": 1, "new_rank": 2,
         "rerank_reason": _ok_reason(
-            summary="moved down due to weaker realized demand signal",
+            summary="moved down as a result of weaker realized demand signal",
             comparison="the displaced candidate has a weaker overall fit"),
     }
     decisions[1] = {
@@ -309,7 +309,7 @@ def test_forbidden_phrase_reverts_cycle_only(_rerank_enabled, caplog):
     assert isinstance(by_pid["p4"]["rerank_reason"], dict)
     # Warning logged for the tainted candidate.
     assert any(
-        "forbidden-phrase" in r.getMessage() and "due to" in r.getMessage()
+        "forbidden-phrase" in r.getMessage() and "as a result of" in r.getMessage()
         for r in caplog.records
     )
 
@@ -391,17 +391,19 @@ def test_cost_recorded_on_success(_rerank_enabled):
 # ---------------------------------------------------------------------------
 def test_forbidden_phrase_case_and_boundary_variants():
     # All three case variants must hit.
-    assert _find_forbidden_phrase("moved up due to realized demand") == "due to"
-    assert _find_forbidden_phrase("moved up Due To realized demand") == "due to"
-    assert _find_forbidden_phrase("moved up DUE TO realized demand") == "due to"
+    assert _find_forbidden_phrase("moved up as a result of realized demand") == "as a result of"
+    assert _find_forbidden_phrase("moved up As A Result Of realized demand") == "as a result of"
+    assert _find_forbidden_phrase("moved up AS A RESULT OF realized demand") == "as a result of"
 
-    # Non-matches (word-boundary + substring-neighbor guards).
+    # Non-matches (word-boundary + substring-neighbor guards). "due to"
+    # and "because of" were intentionally removed from the blocklist
+    # because the LLM uses them reflexively as plain English connectives.
+    assert _find_forbidden_phrase("moved up due to realized demand") is None
+    assert _find_forbidden_phrase("strong frontage because of the corner") is None
     assert _find_forbidden_phrase("introduced to the market") is None
-    assert _find_forbidden_phrase("undue toll on the budget") is None
     assert _find_forbidden_phrase("introducing to market") is None
 
     # Other forbidden phrases covered too.
-    assert _find_forbidden_phrase("strong frontage Because Of the corner") == "because of"
     assert _find_forbidden_phrase("high signal leading to approval") == "leading to"
     assert _find_forbidden_phrase("changes AS A RESULT OF the audit") == "as a result of"
     assert _find_forbidden_phrase("latency issues causing churn") == "causing"


### PR DESCRIPTION
## Summary
Removed "due to" and "because of" from the forbidden phrase detection in reranking reasons. These phrases were causing excessive false positives because the LLM uses them reflexively as plain English connectives rather than as causal claims.

## Key Changes
- **Removed phrases from blocklist**: "due to" and "because of" are no longer flagged as forbidden phrases in `_FORBIDDEN_PHRASES`
- **Retained stricter phrases**: "as a result of", "leading to", and "causing" remain in the blocklist to catch more explicit causal-chain reasoning
- **Updated prompt guidance**: Added clarification (section d) in the LLM prompt to discourage causal connectives while allowing descriptive observations
- **Updated test cases**: Modified `test_forbidden_phrase_case_and_boundary_variants()` to reflect the new blocklist and added explanatory comments about why the removed phrases were problematic

## Implementation Details
The change addresses a practical issue where reverting on "due to" and "because of" caused nearly every rerank to end with `moved=0` (no changes), since the LLM naturally uses these common English connectives when explaining relationships between facts. The remaining forbidden phrases ("as a result of", "leading to", "causing") are more explicit indicators of speculative causal reasoning and are less likely to appear in straightforward descriptive text.

The prompt guidance was enhanced to clarify the distinction: candidates should be described by their observed characteristics and scores, not by causal claims about why they were promoted or demoted.

https://claude.ai/code/session_0117zxLuEMUybPmB2JBUBCpM