### PR TITLE
Improve risk text formatting in expansion advisor summary

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -3723,11 +3723,16 @@ def _decision_summary(
         risk_text = (
             "execution risk should be managed during leasing and design"
         )
-    return (
+    summary = (
         f"This {area_label} candidate in {district_label} scores {final_score:.1f}/100 overall with an economics score of {economics_score:.1f}/100. "
-        f"It is a practical first-pass option for {_recommended_use_case(service_model, area_m2)}. "
-        f"The biggest commercial risk is {risk_text.lower()}."
+        f"It is a practical first-pass option for {_recommended_use_case(service_model, area_m2)}."
     )
+    risk_sentence = risk_text.strip().rstrip(".").strip()
+    if risk_sentence:
+        if not risk_sentence[0].isupper():
+            risk_sentence = risk_sentence[0].upper() + risk_sentence[1:]
+        summary = f"{summary} Biggest commercial risk: {risk_sentence}."
+    return summary
 
 
 def persist_existing_branches(db: Session, search_id: str, existing_branches: list[dict[str, Any]]) -> None:


### PR DESCRIPTION
## Summary
Refactored the risk text handling in the `_decision_summary` method to improve formatting and readability of the generated summary text.

## Key Changes
- Separated the summary construction into two parts: base summary and risk sentence
- Improved risk text formatting by:
  - Stripping whitespace and trailing periods from risk text
  - Ensuring the risk sentence starts with a capital letter
  - Conditionally appending the risk sentence only if it contains content
- Changed the risk sentence presentation from inline ("The biggest commercial risk is...") to a separate sentence ("Biggest commercial risk:...")
- Enhanced readability by making the risk component more prominent and properly formatted

## Implementation Details
- The risk text is now processed to remove leading/trailing whitespace and periods before being used
- Capitalization is automatically applied if the first character is lowercase
- The risk sentence is only included in the summary if it's non-empty after processing
- The new format provides clearer separation between the main summary and risk information

https://claude.ai/code/session_01GjrmAEPDtgRpbBvAzuyRDd