### PR TITLE
Guard neighborhood field against scraper-garbage values

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -3434,6 +3434,23 @@ def _rent_burden_confidence(source_label: str | None, n_comparable: int | None) 
     return 1.0
 
 
+def _is_plausible_neighborhood(value: str | None) -> bool:
+    """Reject scraper-garbage neighborhood values that cause false-positive
+    comp pool matches. Currently observed garbage in commercial_unit:
+    pure-digit strings like "2", "3", "4" (87 rows across 600 active
+    listings). The conservative rule: require at least one non-digit,
+    non-whitespace character AND >=3 chars after strip.
+    """
+    if not value:
+        return False
+    stripped = value.strip()
+    if len(stripped) < 3:
+        return False
+    if stripped.isdigit():
+        return False
+    return True
+
+
 def _percentile_rent_burden(
     db: Session,
     *,
@@ -3523,13 +3540,16 @@ def _percentile_rent_burden(
     # unit_neighborhood_raw value is in the same English namespace as the
     # comparable set's neighborhood column, so the match works directly.
     neighborhood_match_value: str | None = None
-    if unit_neighborhood_raw:
+    if unit_neighborhood_raw and _is_plausible_neighborhood(unit_neighborhood_raw):
         neighborhood_match_value = unit_neighborhood_raw.strip().lower()
-    elif district_norm:
+    elif district_norm and _is_plausible_neighborhood(district_norm):
         # Fallback: try the Arabic-normalized district, which only matches
         # the rare commercial_unit rows whose neighborhood happens to be
         # stored in Arabic. Almost always returns zero, but cheap to try.
         neighborhood_match_value = district_norm
+    # If both fail the plausibility check, neighborhood_match_value stays None;
+    # the district tier chains short-circuit and the function falls to the
+    # city_band_type tier (correctly damped at confidence 0.25 by PR #1114).
 
     if neighborhood_match_value:
         chains.append((

--- a/scripts/cleanup_garbage_neighborhoods.sql
+++ b/scripts/cleanup_garbage_neighborhoods.sql
@@ -1,0 +1,32 @@
+-- Cleanup: set commercial_unit.neighborhood = NULL where the value is pure
+-- digits (scraper garbage). Confirmed scope at run time: 87 rows across
+-- values "2" (25), "3" (31), "4" (31). Does not touch any other row.
+--
+-- Run once manually via:
+--   PGPASSWORD='...' psql -h ... -U oaktree -d oaktree \
+--     --set=sslmode=require -f scripts/cleanup_garbage_neighborhoods.sql
+--
+-- After this runs, _percentile_rent_burden() will fail the plausibility
+-- check on these rows' neighborhood field and correctly fall through to
+-- the citywide tier (damped to 0.25 confidence by PR #1114).
+
+BEGIN;
+
+-- Dry-run inspection: show what would be updated.
+SELECT neighborhood, COUNT(*) AS n
+FROM commercial_unit
+WHERE neighborhood ~ '^[0-9]+$'
+GROUP BY neighborhood
+ORDER BY n DESC;
+
+-- Actual cleanup.
+UPDATE commercial_unit
+SET neighborhood = NULL
+WHERE neighborhood ~ '^[0-9]+$';
+
+-- Verify: should return zero rows.
+SELECT COUNT(*) AS remaining_garbage
+FROM commercial_unit
+WHERE neighborhood ~ '^[0-9]+$';
+
+COMMIT;

--- a/tests/test_expansion_advisor_regression.py
+++ b/tests/test_expansion_advisor_regression.py
@@ -25,6 +25,7 @@ from app.services.expansion_advisor import (
     _estimate_fitout_cost_sar,
     _estimate_revenue_index,
     _gate_verdict_label,
+    _is_plausible_neighborhood,
     _landuse_fit,
     _listing_quality_score,
     _percentile_rent_burden,
@@ -1445,3 +1446,21 @@ def test_score_breakdown_listing_quality_contributes():
     # With 11% weight, the difference should be (95-20)*0.11 = 8.25 points
     diff = high["final_score"] - low["final_score"]
     assert abs(diff - 8.25) < 0.1
+
+
+# ---------------------------------------------------------------------------
+# Neighborhood plausibility guard rejects scraper-garbage values
+# ---------------------------------------------------------------------------
+
+def test_is_plausible_neighborhood_rejects_garbage_accepts_real_names():
+    # Scraper-garbage / empty values must be rejected so the rent-burden
+    # comp pool doesn't match on pure-digit neighborhood strings.
+    assert _is_plausible_neighborhood("3") is False
+    assert _is_plausible_neighborhood("12") is False
+    assert _is_plausible_neighborhood("  ") is False
+    assert _is_plausible_neighborhood("") is False
+    assert _is_plausible_neighborhood(None) is False
+    # Real neighborhood names (English and Arabic) must be accepted.
+    assert _is_plausible_neighborhood("Olaya") is True
+    assert _is_plausible_neighborhood("العليا") is True
+    assert _is_plausible_neighborhood("An Nadhim") is True


### PR DESCRIPTION
## Summary
Add validation to reject scraper-garbage neighborhood values (pure-digit strings like "2", "3", "4") that cause false-positive matches in the rent-burden comparable pool. This prevents incorrect confidence scoring when neighborhood data is corrupted.

## Changes
- **New validation function** `_is_plausible_neighborhood()` that rejects:
  - Empty/None values
  - Strings shorter than 3 characters after stripping whitespace
  - Pure-digit strings (the primary garbage pattern observed in production)
  
- **Updated `_percentile_rent_burden()`** to apply plausibility checks before using neighborhood values for comparable pool matching. When both the raw neighborhood and district fallback fail validation, the function correctly chains to the city-wide tier (with 0.25 confidence damping per PR #1114).

- **Database cleanup script** (`scripts/cleanup_garbage_neighborhoods.sql`) to retroactively set 87 affected rows' neighborhood field to NULL, with inspection and verification queries.

- **Test coverage** for the new validation function, confirming rejection of garbage values while accepting legitimate English and Arabic neighborhood names.

## Implementation Details
The plausibility check is conservative and focused: it targets the specific observed garbage pattern (pure digits) while preserving legitimate short names that contain non-digit characters. The validation is applied at the point of use in the comparable pool matching logic, ensuring graceful fallback to broader geographic tiers when neighborhood data is unreliable.

https://claude.ai/code/session_01TNXvRFvzLYUioUpqXP2boD