### PR TITLE
Treat road distance sentinel as unknown instead of penalizing

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -37,6 +37,12 @@ _EA_DELIVERY_TABLE = settings.EXPANSION_DELIVERY_TABLE
 _EA_RENT_TABLE = settings.EXPANSION_RENT_TABLE
 _EA_COMPETITOR_TABLE = settings.EXPANSION_COMPETITOR_TABLE
 
+# Sentinel returned by the road-distance COALESCE fallbacks when no
+# is_major_road segment exists within the 700 m ST_DWithin search radius.
+# Any value >= this sentinel should be treated as "unknown", not as a real
+# distance — see _road_signal_from_context.
+_ROAD_DISTANCE_SENTINEL_M = 5000.0
+
 # ---------------------------------------------------------------------------
 # Gate-key to human-readable label mapping (change #4)
 # ---------------------------------------------------------------------------
@@ -1661,7 +1667,7 @@ def _candidate_feature_snapshot(db: Session, *, parcel_id: str, lat: float, lon:
                                  WHERE erc.is_major_road = TRUE
                                    AND erc.geom IS NOT NULL
                                    AND ST_DWithin(erc.geom::geography, p.geom::geography, 700)),
-                                5000
+                                {_ROAD_DISTANCE_SENTINEL_M}
                             ) AS nearest_major_road_distance_m,
                             COALESCE((
                                 SELECT COUNT(*)
@@ -1712,7 +1718,7 @@ def _candidate_feature_snapshot(db: Session, *, parcel_id: str, lat: float, lon:
                                     l.highway IN ('motorway','trunk','primary','secondary')
                                     OR NULLIF(l.name, '') IS NOT NULL
                                   )
-                            ), 5000) AS nearest_major_road_distance_m,
+                            ), {_ROAD_DISTANCE_SENTINEL_M}) AS nearest_major_road_distance_m,
                             COALESCE((
                                 SELECT COUNT(*)
                                 FROM planet_osm_line l
@@ -2929,7 +2935,10 @@ def _road_signal_from_context(road_context: dict | None) -> float:
         normalized so 0m -> 1.0, 500m+ -> 0.0.
 
     Returns 0.5 (neutral) when road_context is missing, so candidates
-    without enrichment data are not penalized.
+    without enrichment data are not penalized. A distance at or above
+    _ROAD_DISTANCE_SENTINEL_M is also treated as unknown, since it is the
+    COALESCE fallback emitted when no major road was found within the
+    700 m search radius — not a real measurement.
     """
     if not road_context:
         return 0.5
@@ -2944,7 +2953,9 @@ def _road_signal_from_context(road_context: dict | None) -> float:
     else:
         try:
             d = float(distance_m)
-            if d <= 0:
+            if d >= _ROAD_DISTANCE_SENTINEL_M:
+                distance_component = 0.5
+            elif d <= 0:
                 distance_component = 1.0
             elif d >= 500:
                 distance_component = 0.0
@@ -5935,7 +5946,7 @@ def run_expansion_search(
                                  WHERE erc.is_major_road = TRUE AND erc.geom IS NOT NULL
                                    AND ST_DWithin(erc.geom::geography,
                                        ST_SetSRID(ST_MakePoint(pids.lon, pids.lat), 4326)::geography, 700)),
-                                5000
+                                {_ROAD_DISTANCE_SENTINEL_M}
                             ) AS nearest_major_road_distance_m,
                             COALESCE((
                                 SELECT COUNT(*) FROM {_EA_ROADS_TABLE} erc
@@ -5966,7 +5977,7 @@ def run_expansion_search(
                                        OR NULLIF(l.name, '') IS NOT NULL)
                                   AND ST_DWithin(l.way::geography,
                                       ST_SetSRID(ST_MakePoint(pids.lon, pids.lat), 4326)::geography, 700)
-                            ), 5000) AS nearest_major_road_distance_m,
+                            ), {_ROAD_DISTANCE_SENTINEL_M}) AS nearest_major_road_distance_m,
                             COALESCE((
                                 SELECT COUNT(*) FROM planet_osm_line l
                                 WHERE l.way IS NOT NULL AND l.highway IS NOT NULL

--- a/tests/test_expansion_advisor.py
+++ b/tests/test_expansion_advisor.py
@@ -1,4 +1,7 @@
+import pytest
+
 from app.services.expansion_advisor import (
+    _ROAD_DISTANCE_SENTINEL_M,
     _candidate_feature_snapshot,
     _candidate_gate_status,
     _confidence_grade,
@@ -14,6 +17,7 @@ from app.services.expansion_advisor import (
     _nonnegative_int,
     _parking_evidence_band,
     _road_evidence_band,
+    _road_signal_from_context,
     clear_expansion_caches,
 )
 from app.services.aqar_district_match import (
@@ -159,6 +163,76 @@ def test_road_evidence_band_moderate():
 
 def test_road_evidence_band_strong():
     assert _road_evidence_band(6, False) == "strong"
+
+
+def _road_signal_distance_component(distance_m, *, touches: bool = False) -> float:
+    """Recover the distance_component of _road_signal_from_context.
+
+    The scorer returns touches_component * 0.70 + distance_component * 0.30.
+    With touches=False, touches_component is 0 and the whole signal equals
+    distance_component * 0.30, so distance_component = signal / 0.30.
+    """
+    signal = _road_signal_from_context(
+        {"touches_road": touches, "nearest_major_road_distance_m": distance_m}
+    )
+    return signal / 0.30
+
+
+def test_road_signal_distance_none_is_neutral():
+    # Missing distance — unknown, neutral component.
+    assert _road_signal_distance_component(None) == pytest.approx(0.5, abs=1e-3)
+
+
+def test_road_signal_distance_sentinel_is_neutral():
+    # 5000 is the COALESCE fallback for "no major road within 700 m" and
+    # must be treated as unknown, not penalised. Previously returned 0.0.
+    assert _road_signal_distance_component(_ROAD_DISTANCE_SENTINEL_M) == pytest.approx(
+        0.5, abs=1e-3
+    )
+    # Any distance at or beyond the sentinel is equally bogus.
+    assert _road_signal_distance_component(_ROAD_DISTANCE_SENTINEL_M + 1.0) == pytest.approx(
+        0.5, abs=1e-3
+    )
+
+
+def test_road_signal_distance_close_is_reward():
+    # 50 m from an arterial — strong proximity reward unchanged.
+    assert _road_signal_distance_component(50.0) > 0.9
+
+
+def test_road_signal_distance_near_threshold_unchanged():
+    # 699 m — below the 700 m search radius and below the sentinel, so the
+    # real falloff still applies (capped at 500 m → 0.0, but strictly > 0
+    # for d < 500). Use a value just under the 500 m cap.
+    assert _road_signal_distance_component(499.0) > 0.0
+    # At 699 m we are past the 500 m falloff cap, so component is 0.0.
+    assert _road_signal_distance_component(699.0) == pytest.approx(0.0, abs=1e-3)
+
+
+def test_road_signal_sentinel_lifts_score_vs_old_behaviour():
+    # Regression guard: a parcel that touches a side street but has no
+    # arterial in range (sentinel distance) should now score ≈ +0.09 higher
+    # than under the old logic (0.0 penalty on the 30% distance component).
+    ctx = {
+        "touches_road": True,
+        "nearest_major_road_distance_m": _ROAD_DISTANCE_SENTINEL_M,
+    }
+    new_signal = _road_signal_from_context(ctx)
+    # Old behaviour: distance_component = 0.0 → 1.0*0.70 + 0.0*0.30 = 0.70
+    old_signal = 1.0 * 0.70 + 0.0 * 0.30
+    # New behaviour: distance_component = 0.5 → 1.0*0.70 + 0.5*0.30 = 0.85
+    expected_new = 1.0 * 0.70 + 0.5 * 0.30
+    assert new_signal == pytest.approx(expected_new, abs=1e-3)
+    assert new_signal > old_signal
+    # Lock direction: the lift is ~0.15 on the composite [0,1] signal,
+    # which feeds a rent multiplier with 0.20 weight and later gets scaled
+    # into the 0.70–1.35 range. Keep the direction-of-change assertion
+    # conservative — we only care that sentinel is no longer harsher than
+    # "unknown".
+    neutral_signal = _road_signal_from_context(
+        {"touches_road": True, "nearest_major_road_distance_m": None}
+    )
+    assert new_signal == pytest.approx(neutral_signal, abs=1e-3)
 
 
 def test_candidate_gate_status_exposes_advisory_failures_without_blocking():


### PR DESCRIPTION
## Summary
This PR fixes a scoring bug where parcels with no major road within the 700m search radius were incorrectly penalized. The database queries use a sentinel value (5000m) as a COALESCE fallback when no major road is found, but this was being treated as a real distance measurement rather than an "unknown" indicator.

## Key Changes
- **Introduced `_ROAD_DISTANCE_SENTINEL_M` constant** (5000.0) to explicitly document and centralize the sentinel value used by database queries
- **Updated `_road_signal_from_context()`** to treat distances at or above the sentinel as unknown (neutral 0.5 score) instead of applying distance penalties
- **Replaced hardcoded `5000` values** in three SQL query locations with the new constant for consistency and maintainability
- **Added comprehensive test coverage** with 5 new test cases validating:
  - Sentinel and None distances both return neutral 0.5 component
  - Close distances (50m) still receive proximity rewards
  - Distances near the 700m search boundary behave correctly
  - Regression guard: sentinel now lifts scores by ~0.15 compared to old behavior (0.85 vs 0.70 composite signal)

## Implementation Details
The fix modifies the distance component calculation in `_road_signal_from_context()` to check if `distance_m >= _ROAD_DISTANCE_SENTINEL_M` before applying the distance falloff curve. When true, it returns 0.5 (neutral) instead of 0.0 (penalty). This aligns sentinel handling with missing/None distances, ensuring candidates without enrichment data or without nearby major roads are not unfairly penalized in the expansion scoring algorithm.

https://claude.ai/code/session_0121iCZDqbh8yRFuCmHbuzy4