### PR TITLE
Change Expansion Advisor data delivery schedule to daily

### DIFF
--- a/.github/workflows/expansion-advisor-data-delivery-sccc.yml
+++ b/.github/workflows/expansion-advisor-data-delivery-sccc.yml
@@ -2,7 +2,7 @@ name: "Expansion Advisor Data — Delivery (SCCC)"
 
 on:
   schedule:
-    - cron: "0 5 * * 3"  # Weekly on Wednesday at 05:00 UTC
+    - cron: "0 5 * * *"  # Daily at 05:00 UTC (08:00 AST)
   workflow_dispatch:
     inputs:
       platforms:


### PR DESCRIPTION
## Summary
Updated the scheduled workflow for Expansion Advisor data delivery to run daily instead of weekly.

## Changes
- Modified the cron schedule from `"0 5 * * 3"` (weekly on Wednesday at 05:00 UTC) to `"0 5 * * *"` (daily at 05:00 UTC)
- Updated the schedule comment to reflect the new frequency and include AST timezone reference (08:00 AST)

## Details
The workflow will now execute every day at 05:00 UTC instead of only on Wednesdays, enabling more frequent data delivery updates for the SCCC platform.

https://claude.ai/code/session_0136XwGsTHuDzWNJHxMfvDKB