### PR TITLE
Improve rerank error logging with parcel IDs and full response

### DIFF
--- a/app/services/expansion_rerank.py
+++ b/app/services/expansion_rerank.py
@@ -777,10 +777,11 @@ def generate_rerank(
         parsed = json.loads(content)
     except json.JSONDecodeError as exc:
         logger.warning(
-            "rerank JSON parse failed (candidates=%d, error=%s, raw=%r)",
+            "rerank JSON parse failed (candidates=%d, error=%s, shortlist_pids=%r, raw_full=%r)",
             shortlist_size,
             exc,
-            content[:1000],
+            [c.get("parcel_id") or c.get("id") for c in shortlist],
+            content,
         )
         return None
 
@@ -788,10 +789,11 @@ def generate_rerank(
     ok, reasons = _validate_rerank_response(parsed, shortlist, max_move)
     if not ok:
         logger.warning(
-            "rerank validation failed (candidates=%d, reasons=%s, raw=%r)",
+            "rerank validation failed (candidates=%d, reasons=%s, shortlist_pids=%r, raw_full=%r)",
             shortlist_size,
             reasons,
-            content[:1000],
+            [c.get("parcel_id") or c.get("id") for c in shortlist],
+            content,
         )
         return None
 


### PR DESCRIPTION
## Summary
Enhanced error logging in the rerank generation service to provide more actionable debugging information when JSON parsing or validation fails.

## Key Changes
- **Expanded log context**: Updated two warning log messages to include parcel IDs from the shortlist, making it easier to identify which parcels were involved in failed rerank operations
- **Full response logging**: Changed from logging truncated response content (first 1000 chars) to logging the complete raw response, ensuring no diagnostic information is lost
- **Better field naming**: Renamed log field names from generic `raw` to `raw_full` and added new `shortlist_pids` field for clarity

## Implementation Details
- Both JSON parse failure and validation failure log statements were updated consistently
- Parcel IDs are extracted from shortlist items using `c.get("parcel_id") or c.get("id")` to handle both possible field names
- This change improves observability for debugging rerank failures in production environments without changing any functional behavior

https://claude.ai/code/session_01BjcqTLnKin3QyBNnthfPm4