### PR TITLE
feat(expansion-advisor): structured decision memo rendering (Phase 3 chunk 3a)

### DIFF
--- a/frontend/src/features/expansion-advisor/DecisionMemoNarrative.structured.test.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionMemoNarrative.structured.test.tsx
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+import "../../i18n";
+import i18n from "../../i18n";
+import en from "../../i18n/en.json";
+import ar from "../../i18n/ar.json";
+import {
+  StructuredNarrative,
+  LegacyNarrative,
+  isValidStructuredMemo,
+} from "./DecisionMemoNarrative";
+import type {
+  GeneratedDecisionMemo,
+  LLMDecisionMemo,
+  StructuredMemo,
+} from "../../lib/api/expansionAdvisor";
+
+/* ── Fixtures ── */
+
+function makeStructured(overrides: Partial<StructuredMemo> = {}): StructuredMemo {
+  return {
+    headline_recommendation: "Strong case for expanding into Al Olaya",
+    ranking_explanation:
+      "Ranks #2 because provider density is sparse and rent is below brand ceiling.",
+    key_evidence: [
+      {
+        signal: "Distance to nearest branch",
+        value: 3200,
+        implication: "Low cannibalisation risk at this radius.",
+        polarity: "positive",
+      },
+      {
+        signal: "Estimated rent",
+        value: "SAR 1,450 / m² / year",
+        implication: "Within brand-fit ceiling.",
+        polarity: "neutral",
+      },
+      {
+        signal: "Street frontage",
+        value: "narrow",
+        implication: "Walk-in capture may be weaker than adjacent parcels.",
+        polarity: "negative",
+      },
+    ],
+    risks: ["Nearby branch of competitor brand", "Parking availability untested"],
+    comparison: "Beats runner-up #3 on revenue index but trails on visibility.",
+    bottom_line: "Proceed to landlord outreach.",
+    ...overrides,
+  };
+}
+
+function makeLegacy(overrides: Partial<LLMDecisionMemo> = {}): LLMDecisionMemo {
+  return {
+    headline: "Legacy headline: solid pursuit",
+    fit_summary: "Legacy fit summary explaining the rationale.",
+    top_reasons_to_pursue: ["Legacy positive 1", "Legacy positive 2"],
+    top_risks: ["Legacy risk A", "Legacy risk B"],
+    recommended_next_action: "Call the broker",
+    rent_context: "Rent lands near market median for the district.",
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  // Default locale back to English so Arabic assertions don't leak across tests.
+  if (i18n.language !== "en") await i18n.changeLanguage("en");
+});
+
+/* ── 1. Structured memo present renders all six sections ── */
+
+describe("DecisionMemoNarrative structured render", () => {
+  it("renders headline, ranking, evidence, risks, comparison, bottom line", () => {
+    const memo = makeStructured();
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+
+    // Root container + dir
+    expect(html).toContain("ea-memo-structured");
+    expect(html).toContain('dir="ltr"');
+
+    // Headline
+    expect(html).toContain("Strong case for expanding into Al Olaya");
+    expect(html).toContain("ea-memo-structured__headline");
+    expect(html).toContain(en.expansionAdvisor.theRecommendation);
+
+    // Ranking explanation
+    expect(html).toContain("Ranks #2 because provider density is sparse");
+
+    // Key evidence section
+    expect(html).toContain(en.expansionAdvisor.keyEvidence);
+    for (const item of memo.key_evidence) {
+      expect(html).toContain(item.signal);
+      expect(html).toContain(String(item.value));
+      expect(html).toContain(item.implication);
+    }
+
+    // Risks
+    expect(html).toContain(en.expansionAdvisor.risksToWatch);
+    expect(html).toContain("Nearby branch of competitor brand");
+    expect(html).toContain("Parking availability untested");
+
+    // Comparison
+    expect(html).toContain(en.expansionAdvisor.howItCompares);
+    expect(html).toContain("Beats runner-up #3 on revenue index");
+
+    // Bottom line
+    expect(html).toContain(en.expansionAdvisor.bottomLine);
+    expect(html).toContain("Proceed to landlord outreach.");
+  });
+});
+
+/* ── 2. Empty risks array omits the section ── */
+
+describe("DecisionMemoNarrative empty risks", () => {
+  it("does not render the risks section when risks array is empty", () => {
+    const memo = makeStructured({ risks: [] });
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+
+    expect(html).not.toContain(en.expansionAdvisor.risksToWatch);
+    expect(html).not.toContain("ea-memo-structured__section--risks");
+    expect(html).not.toContain("ea-memo-structured__risks-list");
+  });
+});
+
+/* ── 3. Empty comparison string omits the section ── */
+
+describe("DecisionMemoNarrative empty comparison", () => {
+  it("does not render the comparison section when comparison is empty", () => {
+    const memo = makeStructured({ comparison: "" });
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+
+    expect(html).not.toContain(en.expansionAdvisor.howItCompares);
+    expect(html).not.toContain("ea-memo-structured__section--comparison");
+    expect(html).not.toContain("ea-memo-structured__comparison");
+  });
+
+  it("does not render the comparison section when comparison is only whitespace", () => {
+    const memo = makeStructured({ comparison: "   " });
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+
+    expect(html).not.toContain(en.expansionAdvisor.howItCompares);
+  });
+});
+
+/* ── 4. Legacy render: byte-identical regression check ── */
+
+describe("DecisionMemoNarrative legacy render", () => {
+  it("renders headline, fit_summary, top_reasons_to_pursue, top_risks, recommended_next_action, rent_context", () => {
+    const memo = makeLegacy();
+    const html = renderToStaticMarkup(<LegacyNarrative memo={memo} lang="en" />);
+
+    expect(html).toContain(memo.headline);
+    expect(html).toContain(memo.fit_summary);
+    for (const reason of memo.top_reasons_to_pursue) {
+      expect(html).toContain(reason);
+    }
+    for (const risk of memo.top_risks) {
+      expect(html).toContain(risk);
+    }
+    expect(html).toContain(memo.recommended_next_action);
+    expect(html).toContain(memo.rent_context);
+
+    // Existing CSS hooks still present.
+    expect(html).toContain("ea-memo-narrative__headline");
+    expect(html).toContain("ea-memo-narrative__summary");
+    expect(html).toContain("ea-memo-narrative__section-title--positive");
+    expect(html).toContain("ea-memo-narrative__section-title--risk");
+    expect(html).toContain("ea-memo-narrative__callout");
+    expect(html).toContain("ea-memo-narrative__rent-context");
+
+    // Locale dir
+    expect(html).toContain('dir="ltr"');
+
+    // Section-title strings from decisionMemo namespace.
+    expect(html).toContain(en.decisionMemo.whyPursue);
+    expect(html).toContain(en.decisionMemo.risksToWeigh);
+    expect(html).toContain(en.decisionMemo.nextAction);
+  });
+});
+
+/* ── 5. Malformed structured memo ── */
+
+describe("DecisionMemoNarrative malformed structured memo", () => {
+  it("isValidStructuredMemo returns false when headline_recommendation is empty", () => {
+    const memo = makeStructured({ headline_recommendation: "" });
+    expect(isValidStructuredMemo(memo)).toBe(false);
+  });
+
+  it("isValidStructuredMemo returns false when headline is whitespace only", () => {
+    const memo = makeStructured({ headline_recommendation: "   " });
+    expect(isValidStructuredMemo(memo)).toBe(false);
+  });
+
+  it("isValidStructuredMemo returns false when key_evidence is not an array", () => {
+    const memo = makeStructured();
+    // Deliberately corrupt the shape to model a malformed server response.
+    (memo as unknown as { key_evidence: unknown }).key_evidence = null;
+    expect(isValidStructuredMemo(memo)).toBe(false);
+  });
+
+  it("isValidStructuredMemo returns false for null input", () => {
+    expect(isValidStructuredMemo(null)).toBe(false);
+    expect(isValidStructuredMemo(undefined)).toBe(false);
+  });
+
+  it("isValidStructuredMemo returns true for a well-formed memo", () => {
+    expect(isValidStructuredMemo(makeStructured())).toBe(true);
+  });
+
+  it("isValidStructuredMemo returns true even if optional arrays are empty", () => {
+    expect(
+      isValidStructuredMemo(makeStructured({ risks: [], comparison: "", key_evidence: [] })),
+    ).toBe(true);
+  });
+});
+
+/* ── 6. Arabic locale ── */
+
+describe("DecisionMemoNarrative Arabic locale", () => {
+  it("renders container with dir='rtl' and Arabic section headings", async () => {
+    await i18n.changeLanguage("ar");
+    const memo = makeStructured({
+      headline_recommendation: "توصية قوية بالتوسع في منطقة العليا",
+      ranking_explanation: "ترتيب رقم ٢ بسبب كثافة منخفضة للمنافسين.",
+      key_evidence: [
+        {
+          signal: "المسافة إلى أقرب فرع",
+          value: "3200 م",
+          implication: "مخاطر تآكل منخفضة.",
+          polarity: "positive",
+        },
+      ],
+      risks: ["فرع منافس قريب"],
+      comparison: "يتفوق على المرشح الثالث في مؤشر الإيرادات.",
+      bottom_line: "الانتقال إلى التفاوض مع المالك.",
+    });
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="ar" />);
+
+    expect(html).toContain('dir="rtl"');
+    expect(html).toContain(ar.expansionAdvisor.theRecommendation);
+    expect(html).toContain(ar.expansionAdvisor.keyEvidence);
+    expect(html).toContain(ar.expansionAdvisor.risksToWatch);
+    expect(html).toContain(ar.expansionAdvisor.howItCompares);
+    expect(html).toContain(ar.expansionAdvisor.bottomLine);
+    expect(html).toContain("توصية قوية بالتوسع في منطقة العليا");
+    expect(html).toContain("فرع منافس قريب");
+  });
+});
+
+/* ── 7. Polarity rendering ── */
+
+describe("DecisionMemoNarrative polarity rendering", () => {
+  it("renders distinguishable markers for positive / negative / neutral / missing", () => {
+    const memo = makeStructured({
+      key_evidence: [
+        { signal: "sig-p", value: "v", implication: "imp", polarity: "positive" },
+        { signal: "sig-n", value: "v", implication: "imp", polarity: "negative" },
+        { signal: "sig-x", value: "v", implication: "imp", polarity: "neutral" },
+        { signal: "sig-missing", value: "v", implication: "imp" },
+      ],
+    });
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+
+    expect(html).toContain('data-polarity="positive"');
+    expect(html).toContain('data-polarity="negative"');
+    // Both neutral and missing-polarity items render as neutral.
+    const neutralMatches = html.match(/data-polarity="neutral"/g) ?? [];
+    expect(neutralMatches.length).toBeGreaterThanOrEqual(2);
+
+    expect(html).toContain("ea-memo-structured__polarity--positive");
+    expect(html).toContain("ea-memo-structured__polarity--negative");
+    expect(html).toContain("ea-memo-structured__polarity--neutral");
+  });
+
+  it("renders neutral marker when polarity is missing", () => {
+    const memo = makeStructured({
+      key_evidence: [{ signal: "s", value: "v", implication: "i" }],
+    });
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+
+    expect(html).toContain('data-polarity="neutral"');
+    expect(html).not.toContain('data-polarity="positive"');
+    expect(html).not.toContain('data-polarity="negative"');
+  });
+});
+
+/* ── 8. Cache behaviour (Map data-structure check under SSR constraints) ── */
+
+describe("DecisionMemoNarrative cache behaviour", () => {
+  /*
+   * renderToStaticMarkup does not fire useEffect, so we cannot exercise the
+   * full mount → fetch → unmount → remount sequence without a DOM. Instead,
+   * verify the narrower invariant that the orchestrating component's first
+   * render is side-effect-free (generateDecisionMemo mock is not called on
+   * SSR), which is what guards against accidental server-side fetches.
+   */
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("does not invoke generateDecisionMemo during renderToStaticMarkup", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      memo: makeLegacy(),
+      memo_text: null,
+      memo_json: makeStructured(),
+    } satisfies GeneratedDecisionMemo);
+
+    vi.doMock("../../lib/api/expansionAdvisor", async () => {
+      const actual = await vi.importActual<
+        typeof import("../../lib/api/expansionAdvisor")
+      >("../../lib/api/expansionAdvisor");
+      return { ...actual, generateDecisionMemo: fetchSpy };
+    });
+
+    const { default: DecisionMemoNarrative } = await import("./DecisionMemoNarrative");
+    const candidate = { id: "c1" };
+    const brief = {};
+
+    // First render.
+    renderToStaticMarkup(<DecisionMemoNarrative candidate={candidate} brief={brief} lang="en" />);
+    // Second render with same candidate_id.
+    renderToStaticMarkup(<DecisionMemoNarrative candidate={candidate} brief={brief} lang="en" />);
+
+    // SSR never fires effects, so the fetcher must never be called.
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+
+    vi.doUnmock("../../lib/api/expansionAdvisor");
+  });
+});

--- a/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import type { LLMDecisionMemo } from "../../lib/api/expansionAdvisor";
+import type {
+  GeneratedDecisionMemo,
+  LLMDecisionMemo,
+  StructuredMemo,
+  StructuredMemoEvidence,
+} from "../../lib/api/expansionAdvisor";
 import { generateDecisionMemo } from "../../lib/api/expansionAdvisor";
 
 type Props = {
@@ -9,70 +14,148 @@ type Props = {
   lang: string;
 };
 
-export default function DecisionMemoNarrative({ candidate, brief, lang }: Props) {
+export function isValidStructuredMemo(
+  memo: StructuredMemo | null | undefined,
+): memo is StructuredMemo {
+  if (!memo) return false;
+  if (typeof memo.headline_recommendation !== "string" || memo.headline_recommendation.trim() === "") {
+    return false;
+  }
+  if (!Array.isArray(memo.key_evidence)) return false;
+  return true;
+}
+
+function PolarityMarker({ polarity }: { polarity?: "positive" | "negative" | "neutral" }) {
+  const resolved = polarity === "positive" || polarity === "negative" ? polarity : "neutral";
+  const cls = `ea-memo-structured__polarity ea-memo-structured__polarity--${resolved}`;
+  if (resolved === "positive") {
+    return (
+      <span className={cls} data-polarity={resolved} aria-hidden="true">
+        <svg viewBox="0 0 16 16" width="12" height="12" focusable="false">
+          <path
+            d="M13.5 4.5 6.25 11.75 2.5 8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    );
+  }
+  if (resolved === "negative") {
+    return (
+      <span className={cls} data-polarity={resolved} aria-hidden="true">
+        <svg viewBox="0 0 16 16" width="12" height="12" focusable="false">
+          <path
+            d="M4 4 12 12 M12 4 4 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      </span>
+    );
+  }
+  return (
+    <span className={cls} data-polarity={resolved} aria-hidden="true">
+      <svg viewBox="0 0 16 16" width="12" height="12" focusable="false">
+        <circle cx="8" cy="8" r="3" fill="currentColor" />
+      </svg>
+    </span>
+  );
+}
+
+export function StructuredNarrative({ memo, lang }: { memo: StructuredMemo; lang: string }) {
   const { t } = useTranslation();
-  const [memo, setMemo] = useState<LLMDecisionMemo | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const dir = lang === "ar" ? "rtl" : "ltr";
+  const risks = Array.isArray(memo.risks) ? memo.risks : [];
+  const comparison = typeof memo.comparison === "string" ? memo.comparison.trim() : "";
+  const bottomLine = typeof memo.bottom_line === "string" ? memo.bottom_line.trim() : "";
+  const rankingExplanation =
+    typeof memo.ranking_explanation === "string" ? memo.ranking_explanation.trim() : "";
 
-  // Cache by candidate id so re-renders don't re-fetch
-  const cacheRef = useRef<Map<string, LLMDecisionMemo>>(new Map());
-  const candidateId = String((candidate as Record<string, unknown>).id ?? "");
+  return (
+    <div className="ea-memo-narrative ea-memo-structured" dir={dir}>
+      <section
+        className="ea-memo-structured__headline-section"
+        aria-label={t("expansionAdvisor.theRecommendation")}
+      >
+        <h3 className="ea-memo-structured__headline">{memo.headline_recommendation}</h3>
+      </section>
 
-  useEffect(() => {
-    if (!candidateId) return;
+      {rankingExplanation && (
+        <p className="ea-memo-structured__ranking">{rankingExplanation}</p>
+      )}
 
-    const cached = cacheRef.current.get(candidateId);
-    if (cached) {
-      setMemo(cached);
-      setError(null);
-      return;
-    }
+      {memo.key_evidence.length > 0 && (
+        <section className="ea-memo-structured__section ea-memo-structured__section--evidence">
+          <h5 className="ea-memo-structured__section-title">
+            {t("expansionAdvisor.keyEvidence")}
+          </h5>
+          <ul className="ea-memo-structured__evidence-list">
+            {memo.key_evidence.map((item: StructuredMemoEvidence, i: number) => (
+              <li key={i} className="ea-memo-structured__evidence-item">
+                <PolarityMarker polarity={item.polarity} />
+                <div className="ea-memo-structured__evidence-body">
+                  <div className="ea-memo-structured__evidence-head">
+                    <span className="ea-memo-structured__evidence-signal">{item.signal}</span>
+                    <span
+                      className={
+                        typeof item.value === "number"
+                          ? "ea-memo-structured__evidence-value ea-memo-structured__evidence-value--numeric"
+                          : "ea-memo-structured__evidence-value"
+                      }
+                    >
+                      {String(item.value)}
+                    </span>
+                  </div>
+                  <div className="ea-memo-structured__evidence-implication">{item.implication}</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    setMemo(null);
+      {risks.length > 0 && (
+        <section className="ea-memo-structured__section ea-memo-structured__section--risks">
+          <h5 className="ea-memo-structured__section-title ea-memo-structured__section-title--risk">
+            {t("expansionAdvisor.risksToWatch")}
+          </h5>
+          <ul className="ea-memo-structured__risks-list">
+            {risks.map((risk, i) => (
+              <li key={i}>{risk}</li>
+            ))}
+          </ul>
+        </section>
+      )}
 
-    generateDecisionMemo(candidate, brief, lang)
-      .then((result) => {
-        if (cancelled) return;
-        cacheRef.current.set(candidateId, result.memo);
-        setMemo(result.memo);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setError(t("decisionMemo.error"));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+      {comparison && (
+        <section className="ea-memo-structured__section ea-memo-structured__section--comparison">
+          <h5 className="ea-memo-structured__section-title">
+            {t("expansionAdvisor.howItCompares")}
+          </h5>
+          <p className="ea-memo-structured__comparison">{comparison}</p>
+        </section>
+      )}
 
-    return () => { cancelled = true; };
-  }, [candidateId]); // eslint-disable-line react-hooks/exhaustive-deps
+      {bottomLine && (
+        <section
+          className="ea-memo-structured__bottom-line"
+          aria-label={t("expansionAdvisor.bottomLine")}
+        >
+          <p className="ea-memo-structured__bottom-line-text">{bottomLine}</p>
+        </section>
+      )}
+    </div>
+  );
+}
 
-  if (loading) {
-    return (
-      <div className="ea-memo-narrative ea-memo-narrative--loading">
-        <div className="ea-skeleton ea-skeleton--headline" />
-        <div className="ea-skeleton ea-skeleton--paragraph" />
-        <div className="ea-skeleton ea-skeleton--list" />
-        <div className="ea-skeleton ea-skeleton--list" />
-        <p className="ea-memo-narrative__loading-text">{t("decisionMemo.loading")}</p>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="ea-memo-narrative ea-memo-narrative--error">
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (!memo) return null;
-
+export function LegacyNarrative({ memo, lang }: { memo: LLMDecisionMemo; lang: string }) {
+  const { t } = useTranslation();
   return (
     <div className="ea-memo-narrative" dir={lang === "ar" ? "rtl" : "ltr"}>
       {/* Headline */}
@@ -123,4 +206,93 @@ export default function DecisionMemoNarrative({ candidate, brief, lang }: Props)
       )}
     </div>
   );
+}
+
+export default function DecisionMemoNarrative({ candidate, brief, lang }: Props) {
+  const { t } = useTranslation();
+  const [result, setResult] = useState<GeneratedDecisionMemo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Cache by candidate id so re-renders don't re-fetch. The cache stores the
+  // full GeneratedDecisionMemo wrapper so both structured and legacy shapes
+  // survive candidate switching.
+  const cacheRef = useRef<Map<string, GeneratedDecisionMemo>>(new Map());
+  const candidateId = String((candidate as Record<string, unknown>).id ?? "");
+
+  useEffect(() => {
+    if (!candidateId) return;
+
+    const cached = cacheRef.current.get(candidateId);
+    if (cached) {
+      setResult(cached);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    generateDecisionMemo(candidate, brief, lang)
+      .then((fetched) => {
+        if (cancelled) return;
+        cacheRef.current.set(candidateId, fetched);
+        setResult(fetched);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError(t("decisionMemo.error"));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [candidateId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (loading) {
+    return (
+      <div className="ea-memo-narrative ea-memo-narrative--loading">
+        <div className="ea-skeleton ea-skeleton--headline" />
+        <div className="ea-skeleton ea-skeleton--paragraph" />
+        <div className="ea-skeleton ea-skeleton--list" />
+        <div className="ea-skeleton ea-skeleton--list" />
+        <p className="ea-memo-narrative__loading-text">{t("decisionMemo.loading")}</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="ea-memo-narrative ea-memo-narrative--error">
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!result) return null;
+
+  const structured = result.memo_json;
+  const legacy = result.memo;
+
+  if (structured) {
+    if (isValidStructuredMemo(structured)) {
+      return <StructuredNarrative memo={structured} lang={lang} />;
+    }
+    // Malformed structured memo — warn once and fall through to legacy.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[DecisionMemoNarrative] malformed decision_memo_json; falling back to legacy render (candidate_id=${candidateId})`,
+    );
+  }
+
+  if (legacy) {
+    return <LegacyNarrative memo={legacy} lang={lang} />;
+  }
+
+  return null;
 }

--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -3853,6 +3853,157 @@
   100% { background-position: -200% 0; }
 }
 
+/* ── Structured Decision Memo (Phase 3 chunk 3a) ── */
+
+.ea-memo-structured {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.ea-memo-structured__headline-section {
+  margin: 0;
+}
+
+.ea-memo-structured__headline {
+  font-size: var(--oak-fs-lg, 18px);
+  font-weight: 700;
+  line-height: 1.35;
+  margin: 0;
+  color: var(--oak-text-dark, #171717);
+}
+
+.ea-memo-structured__ranking {
+  font-size: var(--oak-fs-sm, 14px);
+  line-height: 1.55;
+  margin: 0;
+  color: var(--oak-text-dark, #333);
+}
+
+.ea-memo-structured__section {
+  margin: 0;
+}
+
+.ea-memo-structured__section-title {
+  font-size: var(--oak-fs-xs, 12px);
+  font-weight: 600;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--oak-text-light, #6b6b6b);
+}
+
+.ea-memo-structured__section-title--risk {
+  color: var(--oak-error, #d4183d);
+}
+
+.ea-memo-structured__evidence-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ea-memo-structured__evidence-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 0;
+}
+
+.ea-memo-structured__polarity {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  flex: 0 0 auto;
+  line-height: 1;
+}
+
+.ea-memo-structured__polarity--positive {
+  color: var(--oak-success, #16a34a);
+}
+
+.ea-memo-structured__polarity--negative {
+  color: var(--oak-error, #d4183d);
+}
+
+.ea-memo-structured__polarity--neutral {
+  color: #9ca3af;
+}
+
+.ea-memo-structured__evidence-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.ea-memo-structured__evidence-head {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.ea-memo-structured__evidence-signal {
+  font-size: var(--oak-fs-xs, 12px);
+  font-weight: 600;
+  color: var(--oak-text-dark, #171717);
+}
+
+.ea-memo-structured__evidence-value {
+  font-size: var(--oak-fs-sm, 14px);
+  color: var(--oak-text-dark, #333);
+}
+
+.ea-memo-structured__evidence-value--numeric {
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.ea-memo-structured__evidence-implication {
+  font-size: var(--oak-fs-xs, 12px);
+  color: var(--oak-text-light, #6b6b6b);
+  line-height: 1.45;
+}
+
+.ea-memo-structured__risks-list {
+  margin: 0;
+  padding-inline-start: 18px;
+  font-size: var(--oak-fs-sm, 14px);
+  line-height: 1.55;
+  color: var(--oak-text-dark, #333);
+}
+
+.ea-memo-structured__comparison {
+  font-size: var(--oak-fs-xs, 12px);
+  line-height: 1.55;
+  margin: 0;
+  color: var(--oak-text-light, #6b6b6b);
+}
+
+.ea-memo-structured__bottom-line {
+  border-inline-start: 3px solid var(--oak-primary, #14312c);
+  background: #F5F8F7;
+  padding: 10px 14px;
+  border-radius: var(--oak-radius, 8px);
+  margin: 0;
+}
+
+.ea-memo-structured__bottom-line-text {
+  font-size: var(--oak-fs-sm, 14px);
+  font-weight: 600;
+  line-height: 1.5;
+  margin: 0;
+  color: var(--oak-text-dark, #171717);
+}
+
 /* ── Key Numbers Strip ── */
 
 .ea-memo-key-numbers {


### PR DESCRIPTION
## Summary

Phase 3 chunk 3a — the first, smallest piece of the chunk-3 UI work.
`DecisionMemoNarrative` now renders the six-section structured narrative
whenever `decision_memo_json` is present, and falls back to a
byte-identical legacy render when it is null or malformed. No feature
flag, no new component wiring — the chunk-1 pre-warm pipeline and the
chunk-2 data plumbing already shipped, so structured-when-present is
the contract as of this deploy.

## What changed

- `frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx`
  - Cache now stores the full `GeneratedDecisionMemo` wrapper
    (`memo`, `memo_text`, `memo_json`) in the existing `Map` ref, so
    switching between candidates keeps both shapes warm.
  - Render-time branch: valid `memo_json` → `StructuredNarrative`;
    otherwise → `LegacyNarrative` (existing JSX, intact).
  - New `StructuredNarrative` renders the six sections in order:
    headline · ranking_explanation · key_evidence · risks · comparison
    · bottom_line. Risks and comparison sections are skipped when
    empty. Bottom line uses a left-border pull-quote.
  - `PolarityMarker` renders inline SVG markers with `data-polarity`
    hooks for positive / negative / neutral. Missing polarity
    renders as neutral (no inference from text).
  - `isValidStructuredMemo` gate: empty headline or non-array
    `key_evidence` → single `console.warn` + legacy fallback.
  - Arabic handled via the existing `lang` prop + `dir="rtl"`;
    translations come from the chunk-2 stub keys under
    `expansionAdvisor.{theRecommendation, keyEvidence, risksToWatch,
    howItCompares, bottomLine}`.
- `frontend/src/features/expansion-advisor/expansion-advisor.css`
  - New `ea-memo-structured-*` classes using existing `oak-*` tokens
    only (`--oak-fs-*`, `--oak-success`, `--oak-error`, `--oak-radius`,
    `--oak-text-dark`, `--oak-text-light`, `--oak-primary`). No new
    tokens introduced.
- `frontend/src/features/expansion-advisor/DecisionMemoNarrative.structured.test.tsx`
  - Fifteen new tests (Vitest + `renderToStaticMarkup`, no
    `@testing-library/react`).

## Deliverables checklist

- [x] Updated `DecisionMemoNarrative.tsx`
- [x] New CSS in `expansion-advisor.css` (`ea-memo-structured-*`)
- [x] New test file `DecisionMemoNarrative.structured.test.tsx`
- [x] Legacy render is **byte-identical** to main (regression
      invariance — see snippet below)
- [x] **Full HTML string** of the structured render for the
      `makeStructured()` fixture (see below)
- [x] Only `DecisionMemoNarrative.tsx`, `expansion-advisor.css`, and
      the new test file were modified (`git diff --stat`: 2 files
      changed + 1 new test file)
- [x] `npm test` — **391 passed / 16 failed**. All 16 failures are
      pre-existing in `ExpansionAdvisorPage.test.tsx` and are
      explicitly out of scope per the chunk-3a prompt. Every other
      test file passes. The new test file passes 15/15.
- [x] `npx tsc --noEmit` — clean (no output).

## Byte-identical legacy render (regression invariance)

Same fixture rendered against `main` and this branch produces the
exact same HTML:

```html
<!-- main -->
<div class="ea-memo-narrative" dir="ltr"><h3 class="ea-memo-narrative__headline">Hl</h3><p class="ea-memo-narrative__summary">FS</p><div class="ea-memo-narrative__section"><h5 class="ea-memo-narrative__section-title ea-memo-narrative__section-title--positive">Why pursue</h5><ul class="ea-memo-narrative__list"><li>r1</li><li>r2</li></ul></div><div class="ea-memo-narrative__section"><h5 class="ea-memo-narrative__section-title ea-memo-narrative__section-title--risk">Risks to weigh</h5><ul class="ea-memo-narrative__list"><li>k1</li></ul></div><div class="ea-memo-narrative__callout"><span class="ea-memo-narrative__callout-label">Recommended next action</span><span>na</span></div><p class="ea-memo-narrative__rent-context">rc</p></div>

<!-- this branch (LegacyNarrative) -->
<div class="ea-memo-narrative" dir="ltr"><h3 class="ea-memo-narrative__headline">Hl</h3><p class="ea-memo-narrative__summary">FS</p><div class="ea-memo-narrative__section"><h5 class="ea-memo-narrative__section-title ea-memo-narrative__section-title--positive">Why pursue</h5><ul class="ea-memo-narrative__list"><li>r1</li><li>r2</li></ul></div><div class="ea-memo-narrative__section"><h5 class="ea-memo-narrative__section-title ea-memo-narrative__section-title--risk">Risks to weigh</h5><ul class="ea-memo-narrative__list"><li>k1</li></ul></div><div class="ea-memo-narrative__callout"><span class="ea-memo-narrative__callout-label">Recommended next action</span><span>na</span></div><p class="ea-memo-narrative__rent-context">rc</p></div>
```

The regression-invariance test (`"DecisionMemoNarrative legacy render"`)
additionally locks these assertions in place for future chunks.

## Full structured render — `makeStructured()` fixture, English locale

Produced by `renderToStaticMarkup(<StructuredNarrative memo={makeStructured()} lang="en" />)`
against the exact same fixture the test file uses. **Raw, unmodified, single-line output** exactly as React serialises it:

```html
<div class="ea-memo-narrative ea-memo-structured" dir="ltr"><section class="ea-memo-structured__headline-section" aria-label="The recommendation"><h3 class="ea-memo-structured__headline">Strong case for expanding into Al Olaya</h3></section><p class="ea-memo-structured__ranking">Ranks #2 because provider density is sparse and rent is below brand ceiling.</p><section class="ea-memo-structured__section ea-memo-structured__section--evidence"><h5 class="ea-memo-structured__section-title">Key evidence</h5><ul class="ea-memo-structured__evidence-list"><li class="ea-memo-structured__evidence-item"><span class="ea-memo-structured__polarity ea-memo-structured__polarity--positive" data-polarity="positive" aria-hidden="true"><svg viewBox="0 0 16 16" width="12" height="12" focusable="false"><path d="M13.5 4.5 6.25 11.75 2.5 8" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg></span><div class="ea-memo-structured__evidence-body"><div class="ea-memo-structured__evidence-head"><span class="ea-memo-structured__evidence-signal">Distance to nearest branch</span><span class="ea-memo-structured__evidence-value ea-memo-structured__evidence-value--numeric">3200</span></div><div class="ea-memo-structured__evidence-implication">Low cannibalisation risk at this radius.</div></div></li><li class="ea-memo-structured__evidence-item"><span class="ea-memo-structured__polarity ea-memo-structured__polarity--neutral" data-polarity="neutral" aria-hidden="true"><svg viewBox="0 0 16 16" width="12" height="12" focusable="false"><circle cx="8" cy="8" r="3" fill="currentColor"></circle></svg></span><div class="ea-memo-structured__evidence-body"><div class="ea-memo-structured__evidence-head"><span class="ea-memo-structured__evidence-signal">Estimated rent</span><span class="ea-memo-structured__evidence-value">SAR 1,450 / m² / year</span></div><div class="ea-memo-structured__evidence-implication">Within brand-fit ceiling.</div></div></li><li class="ea-memo-structured__evidence-item"><span class="ea-memo-structured__polarity ea-memo-structured__polarity--negative" data-polarity="negative" aria-hidden="true"><svg viewBox="0 0 16 16" width="12" height="12" focusable="false"><path d="M4 4 12 12 M12 4 4 12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path></svg></span><div class="ea-memo-structured__evidence-body"><div class="ea-memo-structured__evidence-head"><span class="ea-memo-structured__evidence-signal">Street frontage</span><span class="ea-memo-structured__evidence-value">narrow</span></div><div class="ea-memo-structured__evidence-implication">Walk-in capture may be weaker than adjacent parcels.</div></div></li></ul></section><section class="ea-memo-structured__section ea-memo-structured__section--risks"><h5 class="ea-memo-structured__section-title ea-memo-structured__section-title--risk">Risks to watch</h5><ul class="ea-memo-structured__risks-list"><li>Nearby branch of competitor brand</li><li>Parking availability untested</li></ul></section><section class="ea-memo-structured__section ea-memo-structured__section--comparison"><h5 class="ea-memo-structured__section-title">How it compares</h5><p class="ea-memo-structured__comparison">Beats runner-up #3 on revenue index but trails on visibility.</p></section><section class="ea-memo-structured__bottom-line" aria-label="Bottom line"><p class="ea-memo-structured__bottom-line-text">Proceed to landlord outreach.</p></section></div>
```

### Pretty-printed for easier reading

```html
<div class="ea-memo-narrative ea-memo-structured" dir="ltr">

  <section class="ea-memo-structured__headline-section" aria-label="The recommendation">
    <h3 class="ea-memo-structured__headline">Strong case for expanding into Al Olaya</h3>
  </section>

  <p class="ea-memo-structured__ranking">
    Ranks #2 because provider density is sparse and rent is below brand ceiling.
  </p>

  <section class="ea-memo-structured__section ea-memo-structured__section--evidence">
    <h5 class="ea-memo-structured__section-title">Key evidence</h5>
    <ul class="ea-memo-structured__evidence-list">

      <li class="ea-memo-structured__evidence-item">
        <span class="ea-memo-structured__polarity ea-memo-structured__polarity--positive"
              data-polarity="positive" aria-hidden="true">
          <svg viewBox="0 0 16 16" width="12" height="12" focusable="false">
            <path d="M13.5 4.5 6.25 11.75 2.5 8" fill="none" stroke="currentColor"
                  stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
          </svg>
        </span>
        <div class="ea-memo-structured__evidence-body">
          <div class="ea-memo-structured__evidence-head">
            <span class="ea-memo-structured__evidence-signal">Distance to nearest branch</span>
            <span class="ea-memo-structured__evidence-value ea-memo-structured__evidence-value--numeric">3200</span>
          </div>
          <div class="ea-memo-structured__evidence-implication">
            Low cannibalisation risk at this radius.
          </div>
        </div>
      </li>

      <li class="ea-memo-structured__evidence-item">
        <span class="ea-memo-structured__polarity ea-memo-structured__polarity--neutral"
              data-polarity="neutral" aria-hidden="true">
          <svg viewBox="0 0 16 16" width="12" height="12" focusable="false">
            <circle cx="8" cy="8" r="3" fill="currentColor"></circle>
          </svg>
        </span>
        <div class="ea-memo-structured__evidence-body">
          <div class="ea-memo-structured__evidence-head">
            <span class="ea-memo-structured__evidence-signal">Estimated rent</span>
            <span class="ea-memo-structured__evidence-value">SAR 1,450 / m² / year</span>
          </div>
          <div class="ea-memo-structured__evidence-implication">Within brand-fit ceiling.</div>
        </div>
      </li>

      <li class="ea-memo-structured__evidence-item">
        <span class="ea-memo-structured__polarity ea-memo-structured__polarity--negative"
              data-polarity="negative" aria-hidden="true">
          <svg viewBox="0 0 16 16" width="12" height="12" focusable="false">
            <path d="M4 4 12 12 M12 4 4 12" fill="none" stroke="currentColor"
                  stroke-width="2" stroke-linecap="round"></path>
          </svg>
        </span>
        <div class="ea-memo-structured__evidence-body">
          <div class="ea-memo-structured__evidence-head">
            <span class="ea-memo-structured__evidence-signal">Street frontage</span>
            <span class="ea-memo-structured__evidence-value">narrow</span>
          </div>
          <div class="ea-memo-structured__evidence-implication">
            Walk-in capture may be weaker than adjacent parcels.
          </div>
        </div>
      </li>

    </ul>
  </section>

  <section class="ea-memo-structured__section ea-memo-structured__section--risks">
    <h5 class="ea-memo-structured__section-title ea-memo-structured__section-title--risk">Risks to watch</h5>
    <ul class="ea-memo-structured__risks-list">
      <li>Nearby branch of competitor brand</li>
      <li>Parking availability untested</li>
    </ul>
  </section>

  <section class="ea-memo-structured__section ea-memo-structured__section--comparison">
    <h5 class="ea-memo-structured__section-title">How it compares</h5>
    <p class="ea-memo-structured__comparison">
      Beats runner-up #3 on revenue index but trails on visibility.
    </p>
  </section>

  <section class="ea-memo-structured__bottom-line" aria-label="Bottom line">
    <p class="ea-memo-structured__bottom-line-text">Proceed to landlord outreach.</p>
  </section>

</div>
```

### Answering the three layout questions

**1. Does the `ranking_explanation` paragraph visually separate from the
headline without a label?**

Yes. The root container is `display: flex; flex-direction: column;
gap: 14px`, so every direct child (headline section, ranking `<p>`,
each `<section>`, bottom-line) gets the same 14px vertical gap. The
headline itself is `font-size: var(--oak-fs-lg)` / `font-weight: 700`;
the ranking `<p>` is `var(--oak-fs-sm)` / regular weight with
`line-height: 1.55` and `color: var(--oak-text-dark, #333)`. Size
contrast + flex gap is what separates them — there is no label and
no heading hierarchy change between them, matching the spec ("a
paragraph of prose. No heading label"). The `theRecommendation`
string is attached as `aria-label` on the headline section only (for
screen readers), not rendered visually.

**2. Do the polarity markers stay aligned when implication text
wraps to two lines?**

Yes. Each `.ea-memo-structured__evidence-item` is a 2-column flex
row: the polarity span (`flex: 0 0 auto`, `width: 16px`, fixed size)
sits top-aligned with `align-items: flex-start` + `margin-top: 2px`
to optically align with the first line of the signal, and the body
(`flex: 1 1 auto`, `min-width: 0`) grows to fill the remaining width
and wraps its implication across as many lines as needed. The marker
does not shift when the implication wraps because the marker is in a
sibling flex track, not an inline sibling of the wrapping text. The
signal + value are in their own `__evidence-head` row with
`align-items: baseline; flex-wrap: wrap`, so at ~420px the value can
drop under the signal if needed without disturbing the marker.

**3. Does the bottom-line pull-quote read as a pull-quote (with the
left border accent) rather than a generic blockquote?**

Yes. The bottom-line is a standalone `<section>` (not `<blockquote>`)
with `border-inline-start: 3px solid var(--oak-primary, #14312c)`,
a subtle background (`#F5F8F7`), `padding: 10px 14px`, and
`border-radius: var(--oak-radius, 8px)`. The text inside is
`var(--oak-fs-sm)` / `font-weight: 600` (bold emphasis), not
italic. Using `border-inline-start` (not `border-left`) means the
accent flips to the right in RTL/Arabic. That combination —
bold + left/start-edge coloured border + tinted background +
rounded corners — reads as a highlighted callout / pull-quote,
not as a generic grey-bar blockquote.

## Test coverage

`DecisionMemoNarrative.structured.test.tsx` (15 passing):

1. Structured memo → renders headline, ranking, all key_evidence
   items, risks, comparison, bottom line.
2. Empty risks array → section is completely omitted.
3. Empty comparison string (incl. whitespace-only) → section is
   completely omitted.
4. Legacy render → all six legacy fields present; existing `ea-memo-
   narrative__*` classes all present (regression-invariance anchor).
5. Malformed structured memo (empty headline, whitespace headline,
   non-array `key_evidence`, null, undefined) →
   `isValidStructuredMemo` returns false; well-formed returns true
   (including with empty optional arrays).
6. Arabic locale → `dir="rtl"`; Arabic section headings pulled from
   `ar.json`; Arabic memo body strings pass through.
7. Polarity rendering → distinguishable markers for
   positive / negative / neutral (via `data-polarity` + class);
   missing polarity renders neutral (no inference).
8. Cache behaviour (narrowed to SSR constraints) — `renderToStaticMarkup`
   does not fire `useEffect`, so the full `mount → fetch → unmount →
   remount` cannot be simulated without jsdom/`@testing-library/react`
   (both excluded by the chunk-3a prompt). The test verifies the
   narrower SSR-safety invariant: `generateDecisionMemo` is not called
   on `renderToStaticMarkup`, which is what guards against accidental
   server-side fetches. The in-mount cache logic itself is unchanged
   from main (still `useRef<Map<string, …>>`, still keyed by
   `candidateId`, still checks `.get` before fetching).

## Test plan

- [x] `npm test` in `frontend/` — 391 passed / 16 pre-existing
      failures in `ExpansionAdvisorPage.test.tsx` (out of scope).
- [x] `npx tsc --noEmit` — clean.
- [x] Legacy render regression invariance — byte-identical (see
      snippet above).
- [x] Only three files touched (`git diff --stat` + new untracked
      test file).

## Stop conditions honoured

- Did not touch `ExpansionMemoPanel`, `ScoreBreakdownCompact`,
  `GateSummary`, `normalizeMemoResponse`, `generateDecisionMemo`, or
  the `/v1/expansion-advisor/decision-memo` endpoint.
- No feature flag added.
- No new i18n keys added — only the five chunk-2 stubs are used
  (`theRecommendation`, `keyEvidence`, `risksToWatch`, `howItCompares`,
  `bottomLine`).
- No new `oak-*` CSS tokens introduced — reused existing ones.
- Did not start chunk 3b (panel reorg), 3c (DecisionLogicCard), or
  3d (scroll-to-section ref wiring).

https://claude.ai/code/session_018GagqB4BdALkqrMdCcF4bX