### PR TITLE
fix(expansion-advisor): align risks shape with server contract (chunk 3a hotfix)

### DIFF
--- a/frontend/src/features/expansion-advisor/DecisionMemoNarrative.structured.test.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionMemoNarrative.structured.test.tsx
@@ -14,6 +14,7 @@ import type {
   GeneratedDecisionMemo,
   LLMDecisionMemo,
   StructuredMemo,
+  StructuredMemoRisk,
 } from "../../lib/api/expansionAdvisor";
 
 /* ── Fixtures ── */
@@ -43,11 +44,31 @@ function makeStructured(overrides: Partial<StructuredMemo> = {}): StructuredMemo
         polarity: "negative",
       },
     ],
-    risks: ["Nearby branch of competitor brand", "Parking availability untested"],
+    risks: [
+      { risk: "Nearby branch of competitor brand", mitigation: null },
+      { risk: "Parking availability untested" },
+    ],
     comparison: "Beats runner-up #3 on revenue index but trails on visibility.",
     bottom_line: "Proceed to landlord outreach.",
     ...overrides,
   };
+}
+
+function makeStructuredWithObjectRisks(
+  overrides: Partial<StructuredMemo> = {},
+): StructuredMemo {
+  return makeStructured({
+    risks: [
+      {
+        risk: "Insufficient parking may limit customer access.",
+        mitigation:
+          "Exploring alternative parking solutions or locations nearby could be considered.",
+      },
+      { risk: "Dense competitor grid.", mitigation: null },
+      { risk: "Weather exposure on south-facing frontage." },
+    ],
+    ...overrides,
+  });
 }
 
 function makeLegacy(overrides: Partial<LLMDecisionMemo> = {}): LLMDecisionMemo {
@@ -212,6 +233,87 @@ describe("DecisionMemoNarrative malformed structured memo", () => {
       isValidStructuredMemo(makeStructured({ risks: [], comparison: "", key_evidence: [] })),
     ).toBe(true);
   });
+
+  it("isValidStructuredMemo returns true for the production object-risks shape", () => {
+    expect(isValidStructuredMemo(makeStructuredWithObjectRisks())).toBe(true);
+  });
+
+  it("isValidStructuredMemo returns false when any risks item is a plain string", () => {
+    const memo = makeStructured();
+    (memo as unknown as { risks: unknown }).risks = [
+      "plain string risk",
+    ];
+    expect(isValidStructuredMemo(memo)).toBe(false);
+  });
+
+  it("isValidStructuredMemo returns false when a risks item is missing the `risk` field", () => {
+    const memo = makeStructured();
+    (memo as unknown as { risks: unknown }).risks = [
+      { mitigation: "only has mitigation" },
+    ];
+    expect(isValidStructuredMemo(memo)).toBe(false);
+  });
+
+  it("isValidStructuredMemo returns false when risks is not an array", () => {
+    const memo = makeStructured();
+    (memo as unknown as { risks: unknown }).risks = null;
+    expect(isValidStructuredMemo(memo)).toBe(false);
+  });
+});
+
+/* ── 5b. Object-shape risks render ── */
+
+describe("DecisionMemoNarrative object-shape risks render", () => {
+  it("renders each risk's text in the output", () => {
+    const memo = makeStructuredWithObjectRisks();
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+    for (const r of memo.risks as StructuredMemoRisk[]) {
+      expect(html).toContain(r.risk);
+    }
+  });
+
+  it("renders the mitigation span when mitigation is present and non-empty", () => {
+    const memo = makeStructuredWithObjectRisks();
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+    expect(html).toContain(
+      "Exploring alternative parking solutions or locations nearby could be considered.",
+    );
+    expect(html).toContain("ea-memo-structured__risks-mitigation");
+  });
+
+  it("does NOT render a mitigation span when mitigation is null", () => {
+    const memo = makeStructured({
+      risks: [{ risk: "Solo risk, no mitigation", mitigation: null }],
+    });
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+    expect(html).toContain("Solo risk, no mitigation");
+    expect(html).not.toContain("ea-memo-structured__risks-mitigation");
+  });
+
+  it("does NOT render a mitigation span when mitigation is undefined", () => {
+    const memo = makeStructured({
+      risks: [{ risk: "Risk without mitigation key" }],
+    });
+    const html = renderToStaticMarkup(<StructuredNarrative memo={memo} lang="en" />);
+    expect(html).toContain("Risk without mitigation key");
+    expect(html).not.toContain("ea-memo-structured__risks-mitigation");
+  });
+
+  it("does NOT render a mitigation span when mitigation is an empty or whitespace-only string", () => {
+    const memoEmpty = makeStructured({
+      risks: [{ risk: "Empty mitigation", mitigation: "" }],
+    });
+    expect(
+      renderToStaticMarkup(<StructuredNarrative memo={memoEmpty} lang="en" />),
+    ).not.toContain("ea-memo-structured__risks-mitigation");
+
+    const memoWhitespace = makeStructured({
+      risks: [{ risk: "Whitespace mitigation", mitigation: "   " }],
+    });
+    expect(
+      renderToStaticMarkup(<StructuredNarrative memo={memoWhitespace} lang="en" />),
+    ).not.toContain("ea-memo-structured__risks-mitigation");
+  });
 });
 
 /* ── 6. Arabic locale ── */
@@ -230,7 +332,7 @@ describe("DecisionMemoNarrative Arabic locale", () => {
           polarity: "positive",
         },
       ],
-      risks: ["فرع منافس قريب"],
+      risks: [{ risk: "فرع منافس قريب" }],
       comparison: "يتفوق على المرشح الثالث في مؤشر الإيرادات.",
       bottom_line: "الانتقال إلى التفاوض مع المالك.",
     });

--- a/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
@@ -5,6 +5,7 @@ import type {
   LLMDecisionMemo,
   StructuredMemo,
   StructuredMemoEvidence,
+  StructuredMemoRisk,
 } from "../../lib/api/expansionAdvisor";
 import { generateDecisionMemo } from "../../lib/api/expansionAdvisor";
 
@@ -22,6 +23,11 @@ export function isValidStructuredMemo(
     return false;
   }
   if (!Array.isArray(memo.key_evidence)) return false;
+  if (!Array.isArray(memo.risks)) return false;
+  for (const r of memo.risks) {
+    if (r === null || typeof r !== "object") return false;
+    if (typeof (r as StructuredMemoRisk).risk !== "string") return false;
+  }
   return true;
 }
 
@@ -126,9 +132,22 @@ export function StructuredNarrative({ memo, lang }: { memo: StructuredMemo; lang
             {t("expansionAdvisor.risksToWatch")}
           </h5>
           <ul className="ea-memo-structured__risks-list">
-            {risks.map((risk, i) => (
-              <li key={i}>{risk}</li>
-            ))}
+            {risks.map((r: StructuredMemoRisk, i: number) => {
+              const mitigation =
+                typeof r.mitigation === "string" && r.mitigation.trim() !== ""
+                  ? r.mitigation
+                  : null;
+              return (
+                <li key={i} className="ea-memo-structured__risks-item">
+                  <span className="ea-memo-structured__risks-text">{r.risk}</span>
+                  {mitigation && (
+                    <span className="ea-memo-structured__risks-mitigation">
+                      {mitigation}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </section>
       )}

--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -3981,6 +3981,25 @@
   color: var(--oak-text-dark, #333);
 }
 
+.ea-memo-structured__risks-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 6px;
+}
+
+.ea-memo-structured__risks-text {
+  font-size: var(--oak-fs-sm, 14px);
+  color: var(--oak-text-dark, #333);
+  line-height: 1.5;
+}
+
+.ea-memo-structured__risks-mitigation {
+  font-size: var(--oak-fs-xs, 12px);
+  color: var(--oak-text-light, #6b6b6b);
+  line-height: 1.45;
+}
+
 .ea-memo-structured__comparison {
   font-size: var(--oak-fs-xs, 12px);
   line-height: 1.55;

--- a/frontend/src/lib/api/expansionAdvisor.generateDecisionMemo.test.ts
+++ b/frontend/src/lib/api/expansionAdvisor.generateDecisionMemo.test.ts
@@ -17,7 +17,7 @@ const structuredMemo: StructuredMemo = {
   key_evidence: [
     { signal: "whitespace", value: 82, implication: "low saturation" },
   ],
-  risks: ["parking"],
+  risks: [{ risk: "parking", mitigation: null }],
   comparison: "Edges runner-up.",
   bottom_line: "Recommend proceed.",
 };

--- a/frontend/src/lib/api/expansionAdvisor.normalizeMemoResponse.test.ts
+++ b/frontend/src/lib/api/expansionAdvisor.normalizeMemoResponse.test.ts
@@ -12,7 +12,7 @@ const structuredMemo: StructuredMemo = {
     { signal: "whitespace", value: 82, implication: "low saturation", polarity: "positive" },
     { signal: "rent", value: "SAR 1,400/m²/yr", implication: "below district median", polarity: "positive" },
   ],
-  risks: ["Parking confirmation required"],
+  risks: [{ risk: "Parking confirmation required", mitigation: null }],
   comparison: "Edges runner-up on economics.",
   bottom_line: "Recommend proceed.",
 };

--- a/frontend/src/lib/api/expansionAdvisor.ts
+++ b/frontend/src/lib/api/expansionAdvisor.ts
@@ -92,11 +92,16 @@ export interface StructuredMemoEvidence {
   polarity?: "positive" | "negative" | "neutral";
 }
 
+export interface StructuredMemoRisk {
+  risk: string;
+  mitigation?: string | null;
+}
+
 export interface StructuredMemo {
   headline_recommendation: string;
   ranking_explanation: string;
   key_evidence: StructuredMemoEvidence[];
-  risks: string[];
+  risks: StructuredMemoRisk[];
   comparison: string;
   bottom_line: string;
 }


### PR DESCRIPTION
## Summary

With this change, the 10 pre-warmed memos on production search `3e4566df-183b-497e-a754-ee3c0c47fc5f` render correctly in the structured narrative — both the risk text and the optional mitigation line.

- Chunk 3a declared `StructuredMemo.risks` as `string[]`, but `app/services/llm_decision_memo.py`'s prompt, `render_structured_memo_as_text`, and every persisted `decision_memo_json` on the current demo search use `{ risk: string; mitigation?: string | null }[]`. The frontend drift caused React to throw "Objects are not valid as a React child" from `StructuredNarrative`'s `risks.map((r,i) => <li>{r}</li>)`, blanking the memo panel.
- Backend is the source of truth; align the frontend type, renderer, and validator to match.
- **No backend file was modified.** Server prompt, `generate_structured_memo`, `render_structured_memo_as_text`, `_decision_memo_cache_lookup`, and `POST /decision-memo` are untouched. Legacy `LLMDecisionMemo.top_risks` (string array) is unchanged.

## What changed

- `frontend/src/lib/api/expansionAdvisor.ts` — new `StructuredMemoRisk` type; `StructuredMemo.risks` retyped to `StructuredMemoRisk[]`.
- `frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx` — renders `r.risk` and a secondary-colour mitigation span when `r.mitigation` is a non-empty string after trim. `isValidStructuredMemo` now also asserts `risks` is an array of `{risk: string, mitigation?}`; drift falls through to the legacy render with a single `console.warn`.
- `frontend/src/features/expansion-advisor/expansion-advisor.css` — new `ea-memo-structured__risks-item` / `__risks-text` / `__risks-mitigation` classes using existing `--oak-fs-*` and `--oak-text-*` tokens. No new tokens, no hex values.
- Test fixtures in the three memo test files updated to the object shape. 10 new assertions cover: production-shape render, mitigation present / null / undefined / empty / whitespace-only, and validator rejection of plain-string or missing-`risk` items.

## Validation

- `npx tsc --noEmit` → clean (exit 0; only pre-existing `tsconfig.json` deprecation notices).
- `npx vitest run` on the affected suites:
  - `DecisionMemoNarrative.structured.test.tsx` — 24 passed
  - `expansionAdvisor.normalizeMemoResponse.test.ts` — 4 passed
  - `expansionAdvisor.generateDecisionMemo.test.ts` — 2 passed
  - **Total: 30 passed, 0 failed.**
- Full `npm test -- --run`: **400 passed**, 16 failed. All 16 failures live in `ExpansionAdvisorPage.test.tsx` (candidate-card badges, payload normalisation, dropdown count) and were verified to reproduce on the pre-change base commit (`git stash` + rerun → same 16 failures). Unrelated to this patch.

## Test plan

- [ ] Deploy to staging
- [ ] Open search `3e4566df-183b-497e-a754-ee3c0c47fc5f`
- [ ] Click "Decision Memo" on candidate #1 — expect the structured narrative with risk text and the parking-mitigation subtext
- [ ] Verify no "Objects are not valid as a React child" in the console
- [ ] Spot-check candidates #2 and #3 for correct mitigation rendering when absent

## Risk

Low. Frontend-only; no schema, cache, or regeneration changes. Legacy fallback path stays intact for any future drift.

https://claude.ai/code/session_01Su7vXrhMqRfpYvc2tqeuaM