### PR TITLE
feat(expansion-advisor): reorganise decision memo drawer (chunk 3b)

### DIFF
--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.test.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+import "../../i18n";
+import i18n from "../../i18n";
+import en from "../../i18n/en.json";
+import ExpansionMemoPanel from "./ExpansionMemoPanel";
+
+beforeEach(async () => {
+  if (i18n.language !== "en") await i18n.changeLanguage("en");
+});
+
+function renderPanel() {
+  return renderToStaticMarkup(
+    <ExpansionMemoPanel
+      loading={false}
+      memo={{
+        recommendation: { verdict: "go", headline: "GO headline" },
+        candidate: {
+          final_score: 78,
+          confidence_grade: "B",
+          score_breakdown_json: {
+            final_score: 78,
+            weights: {},
+            inputs: {},
+            weighted_components: { demand_potential: 0.72 },
+          },
+          gate_status: { overall_pass: true },
+        },
+        market_research: {},
+        brand_profile: {},
+      }}
+    />,
+  );
+}
+
+describe("ExpansionMemoPanel chunk 3b reorganisation", () => {
+  it("renders the verdict row above the score-breakdown disclosure", () => {
+    const html = renderPanel();
+    const verdictRowIdx = html.indexOf("ea-memo-verdict-row");
+    const breakdownIdx = html.indexOf("ea-memo-full-breakdown");
+    expect(verdictRowIdx).toBeGreaterThan(-1);
+    expect(breakdownIdx).toBeGreaterThan(-1);
+    expect(verdictRowIdx).toBeLessThan(breakdownIdx);
+  });
+
+  it("keeps the quick-facts row above the score-breakdown disclosure", () => {
+    const html = renderPanel();
+    const keyNumbersIdx = html.indexOf("ea-memo-key-numbers");
+    const breakdownIdx = html.indexOf("ea-memo-full-breakdown");
+    expect(keyNumbersIdx).toBeGreaterThan(-1);
+    expect(breakdownIdx).toBeGreaterThan(-1);
+    expect(keyNumbersIdx).toBeLessThan(breakdownIdx);
+  });
+
+  it("renders the score-breakdown details closed by default (no `open` attribute)", () => {
+    const html = renderPanel();
+    // Extract the opening tag of the ea-memo-full-breakdown <details>.
+    const match = html.match(/<details[^>]*ea-memo-full-breakdown[^>]*>/);
+    expect(match).not.toBeNull();
+    const openingTag = match![0];
+    expect(openingTag.includes(" open")).toBe(false);
+  });
+
+  it("uses the resolved i18n text (not the raw key) in the disclosure <summary>", () => {
+    const html = renderPanel();
+    const expected = en.expansionAdvisor.showScoreBreakdown;
+    expect(expected).toBe("Show score breakdown");
+    expect(html).toContain(expected);
+    // And make sure the legacy "Show full score breakdown" label is gone.
+    expect(html).not.toContain(en.decisionMemo.showFullBreakdown);
+    // And make sure we didn't accidentally emit the raw key.
+    expect(html).not.toContain("expansionAdvisor.showScoreBreakdown");
+  });
+
+  it("promotes verdict badge and confidence badge out of the summary card", () => {
+    const html = renderPanel();
+    const verdictRowIdx = html.indexOf("ea-memo-verdict-row");
+    const summaryCardIdx = html.indexOf("ea-memo-summary-card");
+    // Verdict row sits above the fold — i.e. before the summary card, which
+    // now lives inside the collapsed <details>.
+    expect(verdictRowIdx).toBeGreaterThan(-1);
+    expect(summaryCardIdx).toBeGreaterThan(-1);
+    expect(verdictRowIdx).toBeLessThan(summaryCardIdx);
+
+    // Verdict badge renders inside the promoted row, not the summary card.
+    const rowMatch = html.match(
+      /<div class="ea-memo-verdict-row">([\s\S]*?)<\/div>\s*<div class="ea-memo-key-numbers">/,
+    );
+    expect(rowMatch).not.toBeNull();
+    expect(rowMatch![1]).toContain("ea-memo-verdict-badge");
+    expect(rowMatch![1]).toContain("ea-badge");
+  });
+
+  it("hides the verdict row entirely when verdict and confidence grade are both absent", () => {
+    const html = renderToStaticMarkup(
+      <ExpansionMemoPanel
+        loading={false}
+        memo={{
+          recommendation: {},
+          candidate: {},
+          market_research: {},
+          brand_profile: {},
+        }}
+      />,
+    );
+    expect(html).not.toContain("ea-memo-verdict-row");
+  });
+});

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
@@ -137,6 +137,18 @@ export default function ExpansionMemoPanel({
                   />
                 )}
 
+                {/* ══ Section 1b: Verdict + confidence (always visible, compact) ══ */}
+                {(rec.verdict || cand.confidence_grade) && (
+                  <div className="ea-memo-verdict-row">
+                    {rec.verdict && (
+                      <span className={`ea-memo-verdict-badge ea-badge ea-badge--${verdictColor}`}>
+                        {rec.verdict}
+                      </span>
+                    )}
+                    <ConfidenceBadge grade={cand.confidence_grade as string | undefined} />
+                  </div>
+                )}
+
                 {/* ══ Section 2: 4 Key Numbers (always visible) ══ */}
                 <div className="ea-memo-key-numbers">
                   <div className="ea-memo-key-numbers__item">
@@ -168,7 +180,7 @@ export default function ExpansionMemoPanel({
                 {/* ══ Section 3: Full Score Breakdown (collapsed by default) ══ */}
                 <details className="ea-memo-full-breakdown">
                   <summary className="ea-memo-full-breakdown__toggle">
-                    {t("decisionMemo.showFullBreakdown")}
+                    {t("expansionAdvisor.showScoreBreakdown")}
                   </summary>
 
                   <div className="ea-memo-full-breakdown__content">
@@ -178,12 +190,6 @@ export default function ExpansionMemoPanel({
                         <div className="ea-memo-summary-card__score-donut">
                           <ScorePill value={(breakdown?.display_score as number | undefined) ?? (cand.final_score as number | undefined)} large />
                         </div>
-                        {rec.verdict && (
-                          <span className={`ea-memo-verdict-badge ea-badge ea-badge--${verdictColor}`}>
-                            {rec.verdict}
-                          </span>
-                        )}
-                        <ConfidenceBadge grade={cand.confidence_grade as string | undefined} />
                       </div>
                       {rec.headline && <p className="ea-memo-summary-card__headline">{rec.headline}</p>}
                     </div>

--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -4025,6 +4025,14 @@
 
 /* ── Key Numbers Strip ── */
 
+.ea-memo-verdict-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-block-end: 12px;
+}
+
 .ea-memo-key-numbers {
   display: grid;
   grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
## Summary

Reorganises the Decision Memo drawer so the narrative reads first, a compact verdict/confidence row sits immediately under it, the quick-facts grid stays as the numerical snapshot, and the score breakdown is the thing that's collapsed behind a "Show score breakdown" disclosure.

## Pre-patch investigation (with path corrections)

The prompt referenced `frontend/src/components/expansion/ExpansionMemoPanel.tsx`; in this repo the live file is at **`frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx`** and the CSS at `frontend/src/features/expansion-advisor/expansion-advisor.css`. Flagged before patching per the "trust the repo" instruction; everything below refers to the real paths.

**1. Current DOM order inside `.ea-drawer__body`** (pre-patch):

1. `DecisionMemoNarrative` — outside any `<details>`, top-most.
2. `.ea-memo-key-numbers` quick-facts grid (Final score / Area / Annual rent / Street width) — already outside any `<details>`.
3. `<details class="ea-memo-full-breakdown">`, `<summary>` = `t("decisionMemo.showFullBreakdown")` ("Show full score breakdown"), closed by default. Contained `.ea-memo-summary-card` (ScorePill + verdict badge + ConfidenceBadge + `rec.headline`), the tabs, a nested score-breakdown `<details>`, and the technical-details `<details>`.
4. `CopySummaryBlock` (conditional).

I flagged that the prompt's statement ("the summary/quick-facts card is inside a collapsed `<details>` and the narrative has to compete with it") only partially matched the repo — the quick-facts grid was already outside `<details>`. The `.ea-memo-summary-card` (verdict + headline + ConfidenceBadge) was the thing still trapped inside.

**2. CSS classes styling the current collapsed wrapper**

- `.ea-memo-full-breakdown` (`expansion-advisor.css:4060`)
- `.ea-memo-full-breakdown__toggle` (`:4066`) — hides default marker, prepends ▸ / ▾
- `.ea-memo-full-breakdown__content` (`:4088`)

All use physical-neutral properties, so RTL-safe as-is. This PR keeps those classes and only adds a new sibling class `.ea-memo-verdict-row`.

**3. i18n key for the new disclosure label**

**`expansionAdvisor.showScoreBreakdown`** — already defined from chunk 2.
- EN: `"Show score breakdown"` (`en.json:987`)
- AR: `"عرض تفاصيل الدرجات"` (`ar.json:934`)

The sibling `hideScoreBreakdown` was not needed (native `<details>` doesn't swap summary text on open). The previously-used key `decisionMemo.showFullBreakdown` ("Show full score breakdown") remains defined for back-compat; it's no longer referenced by this panel.

**4. Existing tests that asserted on current DOM order**

- `DecisionMemoNarrative.structured.test.tsx` — targets `DecisionMemoNarrative` directly. Not touched by this PR; 24/24 still pass.
- `ExpansionAdvisorPage.test.tsx` has two renders of `ExpansionMemoPanel`: "memo panel renders gate reasons positives and risks" (line 249, already in the 16 baseline failures) and "memo/report panels handle sparse payloads" (line 337, passes). Neither asserts on narrative-vs-breakdown ordering or on `.ea-memo-full-breakdown*` / `.ea-memo-key-numbers` class names.
- No dedicated `ExpansionMemoPanel.test.tsx` existed prior.

## Duplication checks before patching

Two separate duplication checks were done before writing code:

1. **Headline source.** `.ea-memo-summary-card__headline` renders `rec.headline` from `CandidateMemoResponse.recommendation.headline` (`expansionAdvisor.ts:283`). The narrative renders `memo_json.headline_recommendation` (structured) or `memo.headline` (legacy) from the separate `generateDecisionMemo` call. Different endpoints, semantically similar. Promoting the card as-is would put two recommendation headlines above the fold. → headline stays inside the `<details>`, not promoted.
2. **Score source.** The quick-facts "Final score" cell uses `(breakdown?.display_score as number | undefined) ?? (cand.final_score as number | undefined)` passed to `<ScorePill … large />`. The summary-card ScorePill uses the identical expression with the same `large` prop. Adjacency would render the same large pill twice. → ScorePill stays inside the `<details>`; verdict-row promotes only the verdict badge and ConfidenceBadge.

## DOM order — before vs. after

**Before** (inside `.ea-drawer__body`):

1. `DecisionMemoNarrative` — SSR-empty, client-populated.
2. `.ea-memo-key-numbers` (Final score / Area / Annual rent / Street width).
3. `<details class="ea-memo-full-breakdown">` labelled "Show full score breakdown", wrapping the summary card (ScorePill + verdict + confidence + headline), the tabs, and the nested breakdown/tech-detail disclosures.
4. `CopySummaryBlock` (conditional).

**After**:

1. `DecisionMemoNarrative` — unchanged.
2. **New** `.ea-memo-verdict-row` — verdict badge + ConfidenceBadge only. Rendered only when `rec.verdict` is truthy **or** `cand.confidence_grade` is present (otherwise the whole row is omitted, so no empty div).
3. `.ea-memo-key-numbers` — unchanged (still 4 cells, still outside any `<details>`; grid symmetry preserved).
4. `<details class="ea-memo-full-breakdown">` labelled **"Show score breakdown"** (via `expansionAdvisor.showScoreBreakdown`), closed by default, wrapping the summary card (now with ScorePill and headline only), the tabs, and the nested disclosures.
5. `CopySummaryBlock` (conditional).

Reading order now: narrative → our call → numbers behind it → full breakdown on demand.

## Class naming

New container: **`ea-memo-verdict-row`** (flat kebab, consistent with sibling `.ea-memo-key-numbers`). No element-level children of its own, so no `__` element suffix. Styled with logical properties (`gap`, `margin-block-end`, `flex-wrap`) so RTL is preserved. Existing `ea-memo-verdict-badge` / `ea-badge` / `ea-badge--${verdictColor}` classes are reused — no re-styling of the badge itself.

## Explicit non-regression confirmations

- **No score pill is rendered twice above the fold.** The above-fold `ScorePill (large)` lives only in `.ea-memo-key-numbers__item` (Final score cell). The summary-card's ScorePill still renders, but inside the collapsed `<details>`.
- **No recommendation headline is rendered twice above the fold.** The only above-fold headline is `DecisionMemoNarrative`'s. `rec.headline` → `.ea-memo-summary-card__headline` stays inside the collapsed `<details>` as an intentional redundant confirmation.
- **Chunk 3a (structured memo) is untouched.** `DecisionMemoNarrative.tsx` not modified; the 24 tests in `DecisionMemoNarrative.structured.test.tsx` still pass unchanged.
- **Chunk 3a hotfix (risks shape) is untouched.** Risk iteration logic inside `StructuredNarrative` (handling `{ risk, mitigation }` objects) not touched.
- **Rerank metadata rendering is untouched.** No rerank code paths were edited.
- **Memo prompt / types / backend** untouched. `expansionAdvisor.ts` types unchanged, no backend edits.
- **Tailwind / CSS modules / styled-components / `@testing-library/react`** — none introduced. Repo pattern (Vitest + `renderToStaticMarkup`) preserved.

## Test plan

- [x] `npx tsc --noEmit` — clean on my files. Pre-existing deprecation warnings (`esModuleInterop`, `moduleResolution=node10`) and pre-existing errors in `src/ui-v2/*` and `src/utils/*.test.ts` (missing `vitest` / `react-i18next` / `@heroicons/react` types) are unchanged from baseline.
- [x] `npx vitest run src/features/expansion-advisor/ExpansionMemoPanel.test.tsx` — **6/6 pass** (new file).
- [x] `npx vitest run src/features/expansion-advisor/DecisionMemoNarrative.structured.test.tsx` — **24/24 pass** (chunk 3a non-regression).
- [x] `npx vitest run src/features/expansion-advisor` — **358 passed | 16 failed**. The 16 failures are all in `ExpansionAdvisorPage.test.tsx` and match the pre-existing PR #1128 baseline exactly (verified by stash/pop — the specific test `"memo panel renders gate reasons positives and risks"` was already failing on baseline before this PR's changes).

## New test assertions

`frontend/src/features/expansion-advisor/ExpansionMemoPanel.test.tsx`:

- `"renders the verdict row above the score-breakdown disclosure"` — `.ea-memo-verdict-row` markup index < `.ea-memo-full-breakdown` markup index. (Proxy for narrative-before-breakdown, since `DecisionMemoNarrative` SSRs to `null` without a primed client-side cache — noted limitation.)
- `"keeps the quick-facts row above the score-breakdown disclosure"` — `.ea-memo-key-numbers` markup index < `.ea-memo-full-breakdown`.
- `"renders the score-breakdown details closed by default (no open attribute)"` — `<details class="... ea-memo-full-breakdown ...">` opening tag does not contain ` open`.
- `"uses the resolved i18n text (not the raw key) in the disclosure <summary>"` — `html.includes(en.expansionAdvisor.showScoreBreakdown)` and `!html.includes("expansionAdvisor.showScoreBreakdown")` and `!html.includes(en.decisionMemo.showFullBreakdown)`.
- `"promotes verdict badge and confidence badge out of the summary card"` — verdict-row precedes summary-card in source order; verdict-row contents include `ea-memo-verdict-badge` and `ea-badge`.
- `"hides the verdict row entirely when verdict and confidence grade are both absent"` — with empty `recommendation` and `candidate`, output does not contain `ea-memo-verdict-row`.

https://claude.ai/code/session_013KzrZVYSRaLvABDhh7zfh5