### PR TITLE
Coerce commercial_unit_id to string at emission boundaries

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -7612,8 +7612,21 @@ def compare_candidates(db: Session, search_id: str, candidate_ids: list[str]) ->
             "population_reach": row.get("population_reach"),
             "landuse_label": row.get("landuse_label"),
             "rank_position": row.get("rank_position"),
-            "source_type": row.get("source_type"),
-            "commercial_unit_id": row.get("commercial_unit_id"),
+            # Same defensive coercion as get_candidate_memo: commercial_unit_id
+            # is a string identifier per the API contract, but the DB column
+            # may yield an int for numeric Aqar IDs. Keep both emission paths
+            # symmetric so a future consumer declaring either field strictly
+            # doesn't reintroduce the memo-endpoint 500.
+            "source_type": (
+                str(row.get("source_type"))
+                if row.get("source_type") is not None
+                else None
+            ),
+            "commercial_unit_id": (
+                str(row.get("commercial_unit_id"))
+                if row.get("commercial_unit_id") is not None
+                else None
+            ),
             "listing_url": row.get("listing_url"),
             "image_url": row.get("image_url"),
             "unit_price_sar_annual": row.get("unit_price_sar_annual"),
@@ -7856,8 +7869,22 @@ def get_candidate_memo(db: Session, candidate_id: str) -> dict[str, Any] | None:
             # expose them on the same nested `candidate` shape so the memo
             # quick-facts row (Area, Street width) and any listing-card UI
             # render the same values shown in the candidate list.
-            "source_type": candidate.get("source_type"),
-            "commercial_unit_id": candidate.get("commercial_unit_id"),
+            # commercial_unit_id is a string identifier in the API contract, but
+            # the underlying DB column (Text) can hold numeric Aqar IDs that
+            # SQLAlchemy surfaces as int. Coerce here so Pydantic's str | None
+            # validator on CandidateMemoCandidateResponse does not 500 on real
+            # rows. source_type gets the same treatment defensively for any
+            # future ingestion path that writes non-string codes.
+            "source_type": (
+                str(candidate.get("source_type"))
+                if candidate.get("source_type") is not None
+                else None
+            ),
+            "commercial_unit_id": (
+                str(candidate.get("commercial_unit_id"))
+                if candidate.get("commercial_unit_id") is not None
+                else None
+            ),
             "listing_url": candidate.get("listing_url"),
             "image_url": candidate.get("image_url"),
             "unit_price_sar_annual": candidate.get("unit_price_sar_annual"),

--- a/tests/test_expansion_advisor_phase3_chunk1.py
+++ b/tests/test_expansion_advisor_phase3_chunk1.py
@@ -335,6 +335,71 @@ def test_get_candidate_memo_candidate_shape_matches_frontend_consumers():
 
 
 # ---------------------------------------------------------------------------
+# 5c. Regression for production 500: Aqar listing IDs are numeric in the DB
+#     (the Text column holds strings like "6606767", but SQLAlchemy can
+#     surface them as int when the column was written via an earlier int
+#     path). CandidateMemoCandidateResponse declares commercial_unit_id as
+#     str | None, so an int value blows up Pydantic validation and FastAPI
+#     returns 500. The list endpoint hides this because
+#     ExpansionCandidateResponse does not declare commercial_unit_id — it
+#     sails through as extra="allow". Fix: coerce at the emission boundary.
+# ---------------------------------------------------------------------------
+def test_get_candidate_memo_coerces_int_commercial_unit_id_to_string():
+    from app.api.expansion_advisor import CandidateMemoResponse
+
+    memo_row = {
+        "candidate_id": "c-int-cuid",
+        "search_id": "s-int-cuid",
+        "brand_name": "Brand X",
+        "category": "qsr",
+        "service_model": "qsr",
+        "parcel_id": "p-int-cuid",
+        "district": "Olaya",
+        "area_m2": None,
+        "landuse_label": "Commercial",
+        "final_score": 80,
+        "economics_score": 72,
+        "cannibalization_score": 35,
+        "confidence_grade": "A",
+        "rank_position": 1,
+        "deterministic_rank": 1,
+        "final_rank": 1,
+        "rerank_applied": False,
+        "rerank_reason": None,
+        "rerank_delta": 0,
+        "rerank_status": "flag_off",
+        # Production shape: Aqar listing ID is an integer on the row even
+        # though the column type is Text. Before the coercion fix this
+        # raised ValidationError on CandidateMemoResponse.model_validate.
+        "source_type": "commercial_unit",
+        "commercial_unit_id": 6606767,
+        "listing_url": "https://example.test/listing/6606767",
+        "image_url": "https://example.test/listing/6606767.jpg",
+        "unit_price_sar_annual": 180000,
+        "unit_area_sqm": 140,
+        "unit_street_width_m": 15,
+        "unit_neighborhood": "Olaya",
+        "unit_listing_type": "for_rent",
+    }
+    db = FakeDB(memo_row=memo_row)
+    memo = get_candidate_memo(db, "c-int-cuid")
+    assert memo is not None
+
+    cand = memo["candidate"]
+    # Coerced to string at the emission boundary.
+    assert cand["commercial_unit_id"] == "6606767"
+    assert isinstance(cand["commercial_unit_id"], str)
+    assert cand["source_type"] == "commercial_unit"
+    assert isinstance(cand["source_type"], str)
+
+    # End-to-end Pydantic validation must succeed — this is the actual
+    # production 500 being reproduced. If the coercion is reverted, the
+    # next line raises ValidationError and the test fails.
+    validated = CandidateMemoResponse.model_validate(memo)
+    assert validated.candidate.commercial_unit_id == "6606767"
+
+
+# ---------------------------------------------------------------------------
 # 6. Pre-warm background task — flag off is a no-op.
 # ---------------------------------------------------------------------------
 def test_prewarm_flag_off_is_noop(monkeypatch):


### PR DESCRIPTION
## Summary
Fix a production 500 error where numeric Aqar listing IDs stored in the database were surfaced as integers by SQLAlchemy, causing Pydantic validation to fail when the API contract declares `commercial_unit_id` as `str | None`.

## Changes
- **`get_candidate_memo()`**: Added defensive coercion of `commercial_unit_id` and `source_type` to strings before emission, ensuring Pydantic validation succeeds on `CandidateMemoResponse`
- **`compare_candidates()`**: Applied the same coercion pattern to keep both emission paths symmetric and prevent future regressions if consumers declare these fields strictly
- **Test coverage**: Added regression test `test_get_candidate_memo_coerces_int_commercial_unit_id_to_string()` that reproduces the production scenario with an integer `commercial_unit_id` and validates end-to-end Pydantic validation succeeds

## Implementation Details
The fix coerces values at the emission boundary (where data leaves the service layer) rather than at the database layer, ensuring:
- The API contract is honored (both fields are strings)
- Pydantic validation passes without errors
- The pattern is consistent across all endpoints that emit these fields
- Null values are preserved (only non-null values are coerced)

https://claude.ai/code/session_01KbahekvGSaMxYsNxPMTtHH