### PR TITLE
feat(expansion-advisor): "Why #N" chip on candidate cards (chunk 4)

### DIFF
--- a/frontend/src/features/expansion-advisor/ExpansionAdvisorPage.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionAdvisorPage.tsx
@@ -662,7 +662,7 @@ export default function ExpansionAdvisorPage({
           localSortActive={localSortActive}
           onSelectCandidate={(candidate) => { void handleSelectCandidate(candidate); void trackEvent("ui_expansion_candidate_opened", { meta: { candidate_id: candidate.id } }); }}
           onToggleCompare={(candidateId) => setCompareIds((cur) => getNextCompareIds(cur, candidateId))}
-          onOpenMemo={(candidateId) => void handleOpenMemoById(candidateId)}
+          onOpenMemo={(candidateId, options) => void handleOpenMemoById(candidateId, options)}
           onShowOnMap={(candidate) => {
             onSelectedCandidateChange(candidate);
             setSelectedCandidate(candidate);

--- a/frontend/src/features/expansion-advisor/ExpansionCandidateCard.test.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionCandidateCard.test.tsx
@@ -1,0 +1,224 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+import "../../i18n";
+import i18n from "../../i18n";
+import ExpansionCandidateCard from "./ExpansionCandidateCard";
+import type { ExpansionCandidate, RerankStatus } from "../../lib/api/expansionAdvisor";
+
+beforeEach(async () => {
+  if (i18n.language !== "en") await i18n.changeLanguage("en");
+});
+
+function baseCandidate(overrides: Partial<ExpansionCandidate> = {}): ExpansionCandidate {
+  return {
+    id: "cand_1",
+    search_id: "search_1",
+    parcel_id: "parcel_1",
+    lat: 24.7,
+    lon: 46.7,
+    final_rank: 3,
+    deterministic_rank: 3,
+    rerank_applied: false,
+    rerank_delta: 0,
+    rerank_status: null,
+    rerank_reason: null,
+    ...overrides,
+  };
+}
+
+function renderCard(
+  candidate: ExpansionCandidate,
+  opts: { onOpenMemo?: (options?: unknown) => void } = {},
+) {
+  const onOpenMemo = "onOpenMemo" in opts ? opts.onOpenMemo : () => undefined;
+  return renderToStaticMarkup(
+    <ExpansionCandidateCard
+      candidate={candidate}
+      selected={false}
+      shortlisted={false}
+      compared={false}
+      onSelect={() => undefined}
+      onCompareToggle={() => undefined}
+      onOpenMemo={onOpenMemo as never}
+    />,
+  );
+}
+
+describe("ExpansionCandidateCard — Why #N chip (chunk 4)", () => {
+  it("renders the base label when final_rank is present and no rerank applied", () => {
+    const html = renderCard(baseCandidate({ final_rank: 3 }));
+    expect(html).toContain("ea-candidate__why-chip");
+    expect(html).toContain("Why #3");
+    expect(html).not.toContain("↑");
+    expect(html).not.toContain("↓");
+  });
+
+  it("renders the up-arrow + magnitude when rerank_applied and delta < 0", () => {
+    const html = renderCard(
+      baseCandidate({
+        final_rank: 2,
+        rerank_applied: true,
+        rerank_status: "applied",
+        rerank_delta: -2,
+        rerank_reason: {
+          summary: "Strong demand signals lifted this candidate.",
+          positives_cited: [],
+          negatives_cited: [],
+          comparison_to_displaced_candidate: "",
+        },
+      }),
+    );
+    expect(html).toContain("Why #2");
+    expect(html).toContain("↑2");
+  });
+
+  it("renders the down-arrow + magnitude when rerank_applied and delta > 0", () => {
+    const html = renderCard(
+      baseCandidate({
+        final_rank: 5,
+        rerank_applied: true,
+        rerank_status: "applied",
+        rerank_delta: 3,
+        rerank_reason: {
+          summary: "Negative risk factors outweighed the score.",
+          positives_cited: [],
+          negatives_cited: [],
+          comparison_to_displaced_candidate: "",
+        },
+      }),
+    );
+    expect(html).toContain("Why #5");
+    expect(html).toContain("↓3");
+  });
+
+  it.each<RerankStatus | null>([
+    "unchanged",
+    "outside_rerank_cap",
+    "flag_off",
+    "shortlist_below_minimum",
+    "llm_failed",
+    null,
+  ])("does NOT render an arrow when rerank_status is %s", (status) => {
+    const html = renderCard(
+      baseCandidate({
+        final_rank: 4,
+        rerank_applied: true,
+        rerank_status: status,
+        rerank_delta: -2,
+        rerank_reason: {
+          summary: "x",
+          positives_cited: [],
+          negatives_cited: [],
+          comparison_to_displaced_candidate: "",
+        },
+      }),
+    );
+    expect(html).toContain("Why #4");
+    expect(html).not.toContain("↑");
+    expect(html).not.toContain("↓");
+  });
+
+  it("does NOT render an arrow when rerank_delta is 0 even if applied", () => {
+    const html = renderCard(
+      baseCandidate({
+        final_rank: 2,
+        rerank_applied: true,
+        rerank_status: "applied",
+        rerank_delta: 0,
+      }),
+    );
+    expect(html).toContain("Why #2");
+    expect(html).not.toContain("↑");
+    expect(html).not.toContain("↓");
+  });
+
+  it("does NOT render the chip at all when final_rank is null", () => {
+    const html = renderCard(baseCandidate({ final_rank: null }));
+    expect(html).not.toContain("ea-candidate__why-chip");
+    expect(html).not.toContain("Why #");
+  });
+
+  it("does NOT render the chip at all when final_rank is undefined", () => {
+    const c = baseCandidate();
+    delete (c as { final_rank?: number | null }).final_rank;
+    const html = renderCard(c);
+    expect(html).not.toContain("ea-candidate__why-chip");
+    expect(html).not.toContain("Why #");
+  });
+
+  it("sets the title attribute to rerank_reason.summary when the arrow is rendered", () => {
+    const html = renderCard(
+      baseCandidate({
+        final_rank: 1,
+        rerank_applied: true,
+        rerank_status: "applied",
+        rerank_delta: -1,
+        rerank_reason: {
+          summary: "Better fit than the deterministic winner.",
+          positives_cited: [],
+          negatives_cited: [],
+          comparison_to_displaced_candidate: "",
+        },
+      }),
+    );
+    expect(html).toMatch(/title="Better fit than the deterministic winner\."/);
+  });
+
+  it("omits the title attribute when the arrow is not rendered", () => {
+    const html = renderCard(
+      baseCandidate({
+        final_rank: 3,
+        rerank_applied: false,
+        rerank_reason: {
+          summary: "Unused because no arrow.",
+          positives_cited: [],
+          negatives_cited: [],
+          comparison_to_displaced_candidate: "",
+        },
+      }),
+    );
+    // The chip exists but has no title attribute — scope the check to the chip element.
+    const match = html.match(/<button[^>]*ea-candidate__why-chip[^>]*>/);
+    expect(match).not.toBeNull();
+    expect(match![0]).not.toContain("title=");
+  });
+
+  it("renders the chip as a <button> so it's keyboard-accessible (not a <div>)", () => {
+    const html = renderCard(baseCandidate({ final_rank: 3 }));
+    expect(html).toMatch(/<button[^>]*ea-candidate__why-chip/);
+  });
+
+  it("renders the chip as disabled with aria-disabled='true' when onOpenMemo is undefined", () => {
+    const html = renderCard(baseCandidate({ final_rank: 3 }), { onOpenMemo: undefined });
+    const match = html.match(/<button[^>]*ea-candidate__why-chip[^>]*>/);
+    expect(match).not.toBeNull();
+    expect(match![0]).toContain('aria-disabled="true"');
+    expect(match![0]).toContain("disabled");
+    expect(match![0]).toContain("ea-candidate__why-chip--disabled");
+  });
+
+  it("is nested inside the card root (not identical to it) so card-level taps remain reachable", () => {
+    const html = renderCard(baseCandidate({ final_rank: 3 }));
+    const rootIdx = html.indexOf('<div class="ea-candidate');
+    const chipIdx = html.indexOf("ea-candidate__why-chip");
+    expect(rootIdx).toBeGreaterThan(-1);
+    expect(chipIdx).toBeGreaterThan(rootIdx);
+  });
+
+  it("renders the English label 'Why' under English locale", () => {
+    const html = renderCard(baseCandidate({ final_rank: 7 }));
+    expect(html).toContain("Why #7");
+  });
+
+  it("renders the Arabic label 'لماذا' under Arabic locale", async () => {
+    await i18n.changeLanguage("ar");
+    try {
+      const html = renderCard(baseCandidate({ final_rank: 7 }));
+      expect(html).toContain("لماذا");
+      expect(html).toContain("#7");
+    } finally {
+      await i18n.changeLanguage("en");
+    }
+  });
+});

--- a/frontend/src/features/expansion-advisor/ExpansionCandidateCard.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionCandidateCard.tsx
@@ -3,6 +3,7 @@ import type { ExpansionCandidate } from "../../lib/api/expansionAdvisor";
 import ScorePill from "./ScorePill";
 import TierBadge from "./TierBadge";
 import { fmtSARCompact, fmtM2, fmtMeters, candidateDistrictLabel, getDisplayScore } from "./formatHelpers";
+import type { MemoDrawerSection } from "./ExpansionMemoPanel";
 
 type Props = {
   candidate: ExpansionCandidate;
@@ -13,7 +14,7 @@ type Props = {
   localSortActive?: boolean;
   onSelect: () => void;
   onCompareToggle: () => void;
-  onOpenMemo?: () => void;
+  onOpenMemo?: (options?: { section?: MemoDrawerSection }) => void;
   onShowOnMap?: () => void;
   /** Retained for backward compatibility with tests and saved-study restoration;
    *  Patch 16 removed the in-card shortlist button so this is never invoked. */
@@ -72,6 +73,39 @@ export default function ExpansionCandidateCard({
     .filter(Boolean)
     .join(" ");
 
+  // "Why #N" chip — jumps to the Decision Memo's Ranking-logic card.
+  // Rendered only when final_rank is a usable number; a fallback "Why #?"
+  // is worse than no chip.
+  const finalRank = candidate.final_rank;
+  const hasFinalRank = typeof finalRank === "number" && Number.isFinite(finalRank);
+  const rerankDelta = typeof candidate.rerank_delta === "number" ? candidate.rerank_delta : 0;
+  const showDelta =
+    candidate.rerank_applied === true &&
+    candidate.rerank_status === "applied" &&
+    rerankDelta !== 0;
+  const whyChipArrow = showDelta ? (rerankDelta < 0 ? "↑" : "↓") : "";
+  const whyChipMagnitude = showDelta ? Math.abs(rerankDelta) : 0;
+  const whyChipLabel = hasFinalRank
+    ? showDelta
+      ? t("expansionAdvisor.whyRankMoved", {
+          rank: finalRank,
+          arrow: whyChipArrow,
+          delta: whyChipMagnitude,
+        })
+      : t("expansionAdvisor.whyRank", { rank: finalRank })
+    : "";
+  const whyChipTitle = showDelta ? candidate.rerank_reason?.summary || undefined : undefined;
+  const whyChipDisabled = !onOpenMemo;
+  const whyChipClass = [
+    "oak-btn",
+    "oak-btn--xs",
+    "oak-btn--tertiary",
+    "ea-candidate__why-chip",
+    whyChipDisabled && "ea-candidate__why-chip--disabled",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <div className={cls} onClick={onSelect} role="button" tabIndex={0} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onSelect(); }} data-candidate-id={candidate.id}>
       {/* Top row: rank + district + badges */}
@@ -95,6 +129,27 @@ export default function ExpansionCandidateCard({
           )}
         </div>
       </div>
+
+      {/* "Why #N" chip — opens Decision Memo scrolled to Ranking logic. */}
+      {hasFinalRank && (
+        <div className="ea-candidate__why-row" onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            className={whyChipClass}
+            title={whyChipTitle}
+            aria-disabled={whyChipDisabled ? "true" : undefined}
+            disabled={whyChipDisabled}
+            onClick={whyChipDisabled
+              ? undefined
+              : (e) => {
+                  e.stopPropagation();
+                  onOpenMemo?.({ section: "decision-logic" });
+                }}
+          >
+            {whyChipLabel}
+          </button>
+        </div>
+      )}
 
       {/* Tier badge + listing link */}
       <TierBadge
@@ -171,7 +226,7 @@ export default function ExpansionCandidateCard({
 
       {/* Actions — icon buttons on hover, memo stays as text */}
       <div className="ea-candidate__actions" onClick={(e) => e.stopPropagation()}>
-        <button type="button" className="oak-btn oak-btn--sm oak-btn--primary" onClick={onOpenMemo || onSelect}>
+        <button type="button" className="oak-btn oak-btn--sm oak-btn--primary" onClick={() => (onOpenMemo ? onOpenMemo() : onSelect())}>
           {t("expansionAdvisor.viewDecisionMemo")}
         </button>
         <div className="ea-candidate__icon-actions">

--- a/frontend/src/features/expansion-advisor/ExpansionResultsPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionResultsPanel.tsx
@@ -1,5 +1,6 @@
 import type { ExpansionCandidate } from "../../lib/api/expansionAdvisor";
 import ExpansionCandidateCard from "./ExpansionCandidateCard";
+import type { MemoDrawerSection } from "./ExpansionMemoPanel";
 
 export default function ExpansionResultsPanel(props: {
   items: ExpansionCandidate[];
@@ -10,7 +11,7 @@ export default function ExpansionResultsPanel(props: {
   localSortActive?: boolean;
   onSelectCandidate: (candidate: ExpansionCandidate) => void;
   onToggleCompare: (candidateId: string) => void;
-  onOpenMemo?: (candidateId: string) => void;
+  onOpenMemo?: (candidateId: string, options?: { section?: MemoDrawerSection }) => void;
   onShowOnMap?: (candidate: ExpansionCandidate) => void;
   /** Retained for backward compatibility with tests. Patch 16 removed the
    *  in-card shortlist button so this callback is never invoked. */
@@ -29,7 +30,7 @@ export default function ExpansionResultsPanel(props: {
           localSortActive={props.localSortActive}
           onSelect={() => props.onSelectCandidate(item)}
           onCompareToggle={() => props.onToggleCompare(item.id)}
-          onOpenMemo={props.onOpenMemo ? () => props.onOpenMemo!(item.id) : undefined}
+          onOpenMemo={props.onOpenMemo ? (options) => props.onOpenMemo!(item.id, options) : undefined}
           onShowOnMap={props.onShowOnMap ? () => props.onShowOnMap!(item) : undefined}
         />
       ))}

--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -304,6 +304,25 @@
   padding: 1px 6px;
 }
 
+.ea-candidate__why-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-block-start: 4px;
+}
+
+.ea-candidate__why-chip {
+  font-size: 11px;
+  padding-inline: 8px;
+  padding-block: 2px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+.ea-candidate__why-chip--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .ea-candidate__insights {
   display: grid;
   gap: 4px;


### PR DESCRIPTION
## Pre-patch investigation summary

1. **DOM / insertion point.** The handoff's line-89-to-96 hint was close but slightly stale. `ExpansionCandidateCard.tsx` has a `.ea-candidate__top` block (identity column + `.ea-candidate__badges` column, the latter holding `ScorePill` + the optional nearest-branch pill). The card root itself has `onClick={onSelect} role="button" tabIndex={0}`. The cleanest place for the chip is a new `.ea-candidate__why-row` rendered immediately after `.ea-candidate__top` and before the TierBadge block — right-aligned (`justify-content: flex-end`) so it lines up under the badges column on desktop and wraps naturally on ~420px mobile.

2. **`onOpenMemo` prop signature.** On the card it was literally `onOpenMemo?: () => void` (zero args — the candidate id is closured in by the parent). On `ExpansionResultsPanel` it was `onOpenMemo?: (candidateId: string) => void`. `handleOpenMemoById` in `ExpansionAdvisorPage.tsx` already accepts `(candidateId, options?: { section?: MemoDrawerSection })` thanks to chunk 3d. So chunk 4 only needs to widen two links in the chain: the card (`onOpenMemo?: (options?: { section?: MemoDrawerSection }) => void`) and the results panel (add the same trailing `options` param). The page-level call site was updated in place to thread `options` through — no other consumer had to change.

3. **Rerank data on the list candidate.** Confirmed all six fields are on `ExpansionCandidate` at `frontend/src/lib/api/expansionAdvisor.ts:189-194`: `deterministic_rank`, `final_rank`, `rerank_applied`, `rerank_reason`, `rerank_delta`, `rerank_status`. The chip uses `final_rank` for the label and `rerank_applied` + `rerank_status === "applied"` + `rerank_delta !== 0` for the arrow gate — consistent with chunk 3c's bucketing.

4. **i18n keys.** `expansionAdvisor.whyRank` and `expansionAdvisor.whyRankMoved` already exist in both `en.json` and `ar.json` with the exact templates chunk 4 needs (`Why #{{rank}}` and `Why #{{rank}} {{arrow}}{{delta}}` + Arabic equivalents). The handoff proposed a new `whyRankWithDelta` key; I reused `whyRankMoved` instead — identical semantics, no duplication. No new keys added. Arabic interpolation works because `{{arrow}}` is a Unicode ↑/↓ which renders correctly under RTL.

5. **Closest visual sibling.** `.oak-btn--xs` + `.oak-btn--tertiary` is the established small-button pattern on this card (see the existing finalists-tile actions). The chip uses those as base classes and adds a `.ea-candidate__why-chip` modifier for compactness (11px font, 8px/2px padding, `white-space: nowrap`). Disabled state adds `--disabled` modifier (50% opacity, `cursor: not-allowed`). No new design tokens, no new color vocabulary.

6. **Tap-target / stopPropagation.** The card root has a tap handler that opens the detail panel. The existing `.ea-candidate__actions` row already uses `onClick={(e) => e.stopPropagation()}` as its pattern. The new `.ea-candidate__why-row` wrapper follows the same pattern; the chip button also calls `e.stopPropagation()` in its own `onClick` before invoking `onOpenMemo({ section: "decision-logic" })`, so the card-level handler doesn't fire after it.

## Label format — all four rerank_status states

| state | rerank_applied | rerank_delta | rerank_status | rendered label (final_rank = 3) |
| --- | --- | --- | --- | --- |
| applied, moved up | `true` | `-2` | `"applied"` | `Why #3 ↑2` |
| applied, moved down | `true` | `+2` | `"applied"` | `Why #3 ↓2` |
| unchanged / reviewed-no-op | `true` | `0` or any | `"unchanged"` | `Why #3` |
| flag off / outside window / other | `false` | any | `"flag_off"`, `"outside_rerank_cap"`, `null`, etc. | `Why #3` |

`final_rank == null` → chip is not rendered at all.

## Layout — before / after

Desktop (rough ASCII):

```
BEFORE:
┌───────────────────────────────────────────────┐
│ #3  Al Olaya                 [72] [1.2 km]    │   ← .ea-candidate__top
│ [tier badge / listing link]                   │
│ [hero image if commercial unit]               │
│ 450 m²   SAR 380k/yr   SAR 1.2M               │
│ + strength  ! risk                            │
│ [ Decision Memo ]        [📍] [⇆]             │   ← .ea-candidate__actions
└───────────────────────────────────────────────┘

AFTER:
┌───────────────────────────────────────────────┐
│ #3  Al Olaya                 [72] [1.2 km]    │
│                                 [ Why #3 ]    │   ← new .ea-candidate__why-row
│ [tier badge / listing link]                   │
│ [hero image if commercial unit]               │
│ 450 m²   SAR 380k/yr   SAR 1.2M               │
│ + strength  ! risk                            │
│ [ Decision Memo ]        [📍] [⇆]             │
└───────────────────────────────────────────────┘
```

Mobile (~420px):

```
┌──────────────────────────────┐
│ #3  Al Olaya       [72] [1.2]│
│                   [ Why #3 ] │
│ [tier badge]                 │
│ 450 m²  SAR 380k/yr          │
│ + strength                   │
│ ! risk                       │
│ [ Decision Memo ]     [📍][⇆]│
└──────────────────────────────┘
```

With rerank applied (delta = -2): the chip reads `Why #3 ↑2` and gets `title="…"` sourced from `rerank_reason.summary` as a native hover tooltip (no new tooltip component).

## Scope / non-goals confirmations

- **Chunks 3a / 3a-hotfix / 3b / 3c / 3d untouched.** `DecisionMemoNarrative.tsx`, `DecisionLogicCard.tsx`, and `ExpansionMemoPanel.tsx` were not modified. The `MemoDrawerSection` type is only *imported* for the widened prop signature.
- **No consumer of `ExpansionCandidateCard` had to change its call site.** The only producers of `onOpenMemo` on the card are `ExpansionResultsPanel` (widened to add `options` passthrough) and the page-level handler (updated to thread `options`, which it was already prepared to accept via `handleOpenMemoById`). `FinalistsWorkspace`, `NextStepsStrip`, and `ShortlistTray` do not render `ExpansionCandidateCard` — they render their own tile / row components — so they are correctly out of scope for the type chain.
- No new component file, no new API field, no backend changes, no telemetry, no tooltip library, no animation library, no new CSS variables. Logical CSS properties (`margin-block-start`, `padding-inline`) used throughout to keep RTL correct.

## Validation

```
$ npx tsc --noEmit
(only pre-existing TS5107 deprecation warnings on tsconfig.json —
 no errors introduced by this patch)

$ npx vitest run src/features/expansion-advisor/ExpansionCandidateCard.test.tsx
✓ 19 tests passed

$ npx vitest run src/features/expansion-advisor/
Test Files  1 failed | 8 passed (9)
     Tests  16 failed | 404 passed (420)
(the 16 failures are entirely in ExpansionAdvisorPage.test.tsx and
 match the chunk-3d baseline — confirmed unchanged)
```

## Post-merge validation plan

Against production at http://8.213.84.191/ with QSR burger / Al Olaya:

1. Every candidate card now shows **Why #N** under the ScorePill.
2. Tapping the chip on candidate #1 opens the Decision Memo scrolled to the Ranking-logic card (top of drawer viewport, per chunk 3d).
3. Tapping a different card (say #3) opens that candidate's drawer scrolled to Ranking logic.
4. Because `EXPANSION_LLM_RERANK_ENABLED` is false in prod, no chip should show an arrow — every chip should read plain **Why #N**. This confirms the status-gate is correct (no false-positive arrows).
5. Arabic locale: chip reads **لماذا #N** and lays out correctly in RTL.

https://claude.ai/code/session_01Tm8pKJjJUvKkTkfd7Y66He