### PR TITLE
Phase 3a: effective-age freshness in _listing_quality_score

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -7,8 +7,8 @@ import re
 import time
 import os
 import uuid
-from datetime import datetime
-from typing import Any
+from datetime import datetime, timedelta
+from typing import Any, Mapping
 
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -2039,10 +2039,50 @@ def _confidence_score(
     return min(70.0, _clamp(score))
 
 
+def _effective_listing_age_days(
+    row: Mapping[str, Any],
+) -> tuple[int | None, str]:
+    """Return (days since most-recent Aqar date, source tag).
+
+    Picks GREATEST of ``aqar_updated_at``, ``aqar_created_at``, and
+    ``first_seen_at`` — an unweighted max that treats a recent "updated"
+    timestamp as equally strong as a recent "created" timestamp, per the
+    Phase 3a directive. Returns ``(None, "unknown")`` when all three are
+    NULL or implausible so the caller can resolve to a neutral band without
+    penalty. Tz-aware values are coerced to naive UTC so arithmetic matches
+    the existing first_seen_at path. Timestamps more than one day in the
+    future are rejected as parser/clock drift rather than clamped, so a
+    corrupted source cannot artificially produce a top-band freshness.
+    """
+    now = datetime.utcnow()
+    future_cutoff = now + timedelta(days=1)
+    candidates: list[tuple[datetime, str]] = []
+    for key, tag in (
+        ("unit_aqar_updated_at", "aqar_updated"),
+        ("unit_aqar_created_at", "aqar_created"),
+        ("unit_first_seen_at", "first_seen"),
+    ):
+        value = row.get(key)
+        if value is None:
+            continue
+        if getattr(value, "tzinfo", None) is not None:
+            value = value.replace(tzinfo=None)
+        if value > future_cutoff:
+            continue
+        candidates.append((value, tag))
+    if not candidates:
+        return None, "unknown"
+    picked, tag = max(candidates, key=lambda pair: pair[0])
+    days = (now - picked).days
+    if days < 0:
+        days = 0
+    return days, tag
+
+
 def _listing_quality_score(
     *,
     is_listing: bool,
-    first_seen_at: datetime | None,
+    effective_age_days: int | None,
     is_furnished: bool | None,
     unit_restaurant_score: float | None,
     has_image: bool,
@@ -2052,11 +2092,15 @@ def _listing_quality_score(
 ) -> float:
     """Pure listing-quality score on a 0-100 scale.
 
-    Freshness is measured from first_seen_at — the date the listing
-    first appeared on Aqar. This is the listing's true age, not the
-    last time the scraper confirmed it was still live. A listing that
-    has been on Aqar for 9 months and is still being re-confirmed is
-    exactly the case we want to deprioritize.
+    Freshness is measured as the number of days since the most recent of
+    ``aqar_updated_at``, ``aqar_created_at``, or ``first_seen_at`` (the
+    "effective listing age," computed by ``_effective_listing_age_days``).
+    This implements the directive that both newly uploaded and recently
+    updated listings should be prioritised equally — a nine-month-old
+    listing that the owner refreshed yesterday is treated as fresh, because
+    the refresh signals the opportunity is live. Rows without any known
+    date resolve to a neutral 50.0 rather than a penalty, matching the
+    codebase's tri-state-gate convention for unknowns.
 
     Distinct from _confidence_score (which measures whether the data is
     trustworthy). This measures whether the listing itself is a good
@@ -2067,8 +2111,9 @@ def _listing_quality_score(
     returns a neutral 50.
 
     Components:
-      - Freshness from first_seen_at (30%): how recently the listing
-        first appeared on Aqar (measures listing age, not scrape recency)
+      - Freshness from effective_age_days (30%): how recently the listing
+        was created or updated on Aqar (bands at 14/30/60/120/240/365 —
+        frozen for Phase 3a).
       - Aqar suitability (40%): the classifier's assessment — LLM verdict
         when available, structural restaurant_score fallback otherwise
       - Image / fit-out signal (20%): LLM-derived listing quality when
@@ -2086,14 +2131,13 @@ def _listing_quality_score(
     if not is_listing:
         return 50.0
 
-    # Freshness band (based on listing age from first_seen_at)
-    if first_seen_at is None:
+    # Freshness band (based on effective listing age — see
+    # _effective_listing_age_days: greatest of aqar_updated_at,
+    # aqar_created_at, first_seen_at).
+    if effective_age_days is None:
         freshness = 50.0
     else:
-        try:
-            days = (datetime.utcnow() - first_seen_at).days
-        except Exception:
-            days = 30
+        days = effective_age_days
         if days <= 14:
             freshness = 100.0
         elif days <= 30:
@@ -4103,6 +4147,8 @@ def _query_candidate_location_pool(
                 cu.is_furnished AS unit_is_furnished,
                 cu.first_seen_at AS unit_first_seen_at,
                 cu.last_seen_at AS unit_last_seen_at,
+                cu.aqar_created_at AS unit_aqar_created_at,
+                cu.aqar_updated_at AS unit_aqar_updated_at,
                 cu.restaurant_score AS unit_restaurant_score,
                 cu.has_drive_thru AS unit_has_drive_thru,
                 cu.neighborhood AS unit_neighborhood_raw,
@@ -4182,6 +4228,8 @@ def _query_candidate_location_pool(
             unit_is_furnished,
             unit_first_seen_at,
             unit_last_seen_at,
+            unit_aqar_created_at,
+            unit_aqar_updated_at,
             unit_restaurant_score,
             unit_has_drive_thru,
             unit_neighborhood_raw,
@@ -5790,9 +5838,10 @@ def run_expansion_search(
             + (100.0 - delivery_competition_score) * 0.20
         )
 
+        effective_age_days, _ = _effective_listing_age_days(row)
         listing_quality = _listing_quality_score(
             is_listing=_is_listing,
-            first_seen_at=row.get("unit_first_seen_at"),
+            effective_age_days=effective_age_days,
             is_furnished=row.get("unit_is_furnished"),
             unit_restaurant_score=_safe_float(row.get("unit_restaurant_score")) if row.get("unit_restaurant_score") is not None else None,
             has_image=bool(row.get("image_url")),
@@ -6329,6 +6378,7 @@ def run_expansion_search(
             listing_type=row.get("unit_listing_type"),
             unit_neighborhood_raw=row.get("unit_neighborhood_raw"),
         )
+        effective_age_days, effective_age_source = _effective_listing_age_days(row)
         feature_snapshot_json = _candidate_feature_snapshot(
             db,
             parcel_id=_pid_str,
@@ -6353,6 +6403,10 @@ def run_expansion_search(
             bulk_roads=_bulk_roads.get(_pid_str),
             bulk_parking=_bulk_parking.get(_pid_str),
         )
+        feature_snapshot_json["listing_age"] = {
+            "effective_age_days": effective_age_days,
+            "source": effective_age_source,
+        }
         # Enrich feature snapshot with candidate_location metadata
         if row.get("source_tier") is not None:
             feature_snapshot_json["candidate_location"] = {
@@ -6466,7 +6520,7 @@ def run_expansion_search(
         )
         listing_quality = _listing_quality_score(
             is_listing=_is_listing,
-            first_seen_at=row.get("unit_first_seen_at"),
+            effective_age_days=effective_age_days,
             is_furnished=row.get("unit_is_furnished"),
             unit_restaurant_score=_safe_float(row.get("unit_restaurant_score")) if row.get("unit_restaurant_score") is not None else None,
             has_image=bool(row.get("image_url")),

--- a/tests/test_expansion_advisor_regression.py
+++ b/tests/test_expansion_advisor_regression.py
@@ -15,13 +15,16 @@ Covers:
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from app.services.expansion_advisor import (
     _arcgis_classification_semantics,
     _area_fit,
     _brand_fit_score,
     _candidate_gate_status,
+    _effective_listing_age_days,
     _estimate_fitout_cost_sar,
     _estimate_revenue_index,
     _gate_verdict_label,
@@ -1033,7 +1036,7 @@ def test_listing_quality_parcel_returns_neutral_50():
     """Parcels (non-listings) should return a neutral 50."""
     score = _listing_quality_score(
         is_listing=False,
-        first_seen_at=None,
+        effective_age_days=None,
         is_furnished=None,
         unit_restaurant_score=None,
         has_image=False,
@@ -1045,7 +1048,7 @@ def test_listing_quality_fresh_full_data_high_score():
     """A fresh listing with full data should score close to 100."""
     score = _listing_quality_score(
         is_listing=True,
-        first_seen_at=datetime.utcnow() - timedelta(days=3),
+        effective_age_days=3,
         is_furnished=True,
         unit_restaurant_score=90.0,
         has_image=True,
@@ -1059,7 +1062,7 @@ def test_listing_quality_stale_no_image_low_score():
     """A very stale listing without image should score below 50."""
     score = _listing_quality_score(
         is_listing=True,
-        first_seen_at=datetime.utcnow() - timedelta(days=400),
+        effective_age_days=400,
         is_furnished=False,
         unit_restaurant_score=None,
         has_image=False,
@@ -1072,7 +1075,7 @@ def test_listing_quality_drive_thru_adds_5():
     """Drive-thru bonus should add exactly 5 points."""
     base = _listing_quality_score(
         is_listing=True,
-        first_seen_at=datetime.utcnow() - timedelta(days=10),
+        effective_age_days=10,
         is_furnished=False,
         unit_restaurant_score=50.0,
         has_image=True,
@@ -1080,13 +1083,169 @@ def test_listing_quality_drive_thru_adds_5():
     )
     with_dt = _listing_quality_score(
         is_listing=True,
-        first_seen_at=datetime.utcnow() - timedelta(days=10),
+        effective_age_days=10,
         is_furnished=False,
         unit_restaurant_score=50.0,
         has_image=True,
         has_drive_thru=True,
     )
     assert abs(with_dt - base - 5.0) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: _effective_listing_age_days
+# ---------------------------------------------------------------------------
+
+def test_effective_age_all_three_present_picks_most_recent():
+    """GREATEST semantics: the most recent of the three timestamps wins,
+    regardless of which source it came from."""
+    now = datetime.utcnow()
+    row = {
+        "unit_aqar_created_at": now - timedelta(days=200),
+        "unit_aqar_updated_at": now - timedelta(days=10),
+        "unit_first_seen_at": now - timedelta(days=30),
+    }
+    days, source = _effective_listing_age_days(row)
+    assert days == 10
+    assert source == "aqar_updated"
+
+
+def test_effective_age_created_null_updated_present():
+    """NULL aqar_created_at falls through to aqar_updated_at when present."""
+    now = datetime.utcnow()
+    row = {
+        "unit_aqar_created_at": None,
+        "unit_aqar_updated_at": now - timedelta(days=5),
+        "unit_first_seen_at": now - timedelta(days=60),
+    }
+    days, source = _effective_listing_age_days(row)
+    assert days == 5
+    assert source == "aqar_updated"
+
+
+def test_effective_age_both_aqar_null_uses_first_seen():
+    """Both aqar fields NULL falls through to first_seen_at."""
+    now = datetime.utcnow()
+    row = {
+        "unit_aqar_created_at": None,
+        "unit_aqar_updated_at": None,
+        "unit_first_seen_at": now - timedelta(days=40),
+    }
+    days, source = _effective_listing_age_days(row)
+    assert days == 40
+    assert source == "first_seen"
+
+
+def test_effective_age_all_null_returns_unknown_neutral():
+    """All three NULL resolves to (None, "unknown") and, when threaded
+    through _listing_quality_score, contributes exactly the freshness=50.0
+    share (no penalty, no boost)."""
+    days, source = _effective_listing_age_days({})
+    assert days is None
+    assert source == "unknown"
+
+    # Fixed-neutral inputs to isolate the freshness contribution.
+    common = dict(
+        is_listing=True,
+        is_furnished=False,
+        unit_restaurant_score=None,
+        has_image=False,
+        has_drive_thru=False,
+        llm_suitability_score=None,
+        llm_listing_quality_score=None,
+    )
+    # With these neutral inputs: suitability=50, image_signal=30,
+    # furnished_signal=50. Composite = freshness*0.30 + 50*0.40 +
+    # 30*0.20 + 50*0.10 = freshness*0.30 + 31.
+    expected_with_freshness_50 = 50.0 * 0.30 + 50.0 * 0.40 + 30.0 * 0.20 + 50.0 * 0.10
+    observed = _listing_quality_score(effective_age_days=None, **common)
+    assert abs(observed - expected_with_freshness_50) < 1e-9
+
+
+def test_effective_age_future_updated_at_clamps_to_zero():
+    """An aqar_updated_at only slightly in the future (within the one-day
+    tolerance) is accepted and clamped to days=0, which lands in the
+    freshest <=14 band."""
+    now = datetime.utcnow()
+    row = {
+        "unit_aqar_created_at": None,
+        # Within the future_cutoff tolerance — accepted, clamped to 0.
+        "unit_aqar_updated_at": now + timedelta(hours=6),
+        "unit_first_seen_at": None,
+    }
+    days, source = _effective_listing_age_days(row)
+    assert days == 0
+    assert source == "aqar_updated"
+
+    score = _listing_quality_score(
+        is_listing=True,
+        effective_age_days=days,
+        is_furnished=False,
+        unit_restaurant_score=None,
+        has_image=False,
+        has_drive_thru=False,
+    )
+    # freshness = 100 (days <= 14 band). Composite = 100*0.30 + 50*0.40
+    # + 30*0.20 + 50*0.10 = 61.
+    assert abs(score - 61.0) < 1e-9
+
+
+def test_effective_age_future_only_returns_unknown():
+    """Correction 3 guard: a lone aqar_updated_at more than one day in the
+    future is rejected as parser/clock drift, not clamped. With no other
+    sources, the helper returns (None, "unknown")."""
+    now = datetime.utcnow()
+    row = {
+        "unit_aqar_created_at": None,
+        "unit_aqar_updated_at": now + timedelta(days=30),
+        "unit_first_seen_at": None,
+    }
+    days, source = _effective_listing_age_days(row)
+    assert days is None
+    assert source == "unknown"
+
+
+@pytest.mark.parametrize(
+    "age_days,expected_freshness",
+    [
+        (14, 100.0),
+        (30, 92.0),
+        (60, 80.0),
+        (120, 65.0),
+        (240, 45.0),
+        (365, 28.0),
+        (366, 15.0),
+    ],
+)
+def test_effective_age_band_boundaries(age_days, expected_freshness):
+    """Lock the frozen Phase 3a band cutoffs at 14/30/60/120/240/365 days
+    against silent drift. Composite = freshness*0.30 + 20 + 6 + 5 with the
+    fixed inputs below (suitability=50, image_signal=30, furnished=50)."""
+    score = _listing_quality_score(
+        is_listing=True,
+        effective_age_days=age_days,
+        is_furnished=False,
+        unit_restaurant_score=None,
+        has_image=False,
+        has_drive_thru=False,
+    )
+    expected_composite = expected_freshness * 0.30 + 50.0 * 0.40 + 30.0 * 0.20 + 50.0 * 0.10
+    assert abs(score - expected_composite) < 1e-9
+
+
+def test_effective_age_tzaware_input_normalized():
+    """tz-aware aqar_updated_at mixed with tz-naive first_seen_at must not
+    raise TypeError. Both point to roughly the same moment; the helper
+    should pick the aqar_updated_at (first in the preference order)."""
+    now_naive = datetime.utcnow()
+    row = {
+        "unit_aqar_updated_at": datetime.now(timezone.utc) - timedelta(days=5),
+        "unit_aqar_created_at": None,
+        "unit_first_seen_at": now_naive - timedelta(days=5),
+    }
+    days, source = _effective_listing_age_days(row)
+    assert days == 5
+    assert source == "aqar_updated"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Phase 3a: effective-age freshness in _listing_quality_score

### CEO directive addressed
> "The platform should prioritize and display the most recently uploaded
> and updated listings."

### What changed
- Adds `_effective_listing_age_days(row)` helper at `app/services/expansion_advisor.py:2042`.
- `_listing_quality_score` signature at `app/services/expansion_advisor.py:2082`: `first_seen_at: datetime | None` → `effective_age_days: int | None`.
- Freshness band now computed from `GREATEST` of `aqar_updated_at`, `aqar_created_at`, `first_seen_at` (unweighted max) with a clock-drift pre-filter that rejects timestamps more than one day in the future.
- SQL projection adds `unit_aqar_created_at` and `unit_aqar_updated_at` in the candidate CTE at `app/services/expansion_advisor.py:4150-4151` and in the outer SELECT list at `app/services/expansion_advisor.py:4231-4232`.
- Preliminary scoring path at `app/services/expansion_advisor.py:5841` unpacks only `effective_age_days` (source discarded).
- Final-scoring path at `app/services/expansion_advisor.py:6381` captures both `effective_age_days` and `effective_age_source`.
- `feature_snapshot_json["listing_age"] = {effective_age_days, source}` mutation added immediately after `_candidate_feature_snapshot(...)` at `app/services/expansion_advisor.py:6406-6409` (final-scoring path only).
- Docstring rewritten at `app/services/expansion_advisor.py:2093-2130` to match the new semantics.

### What did NOT change
- Band cutoffs 14/30/60/120/240/365 at `app/services/expansion_advisor.py:2141-2154` — frozen for 3a.
- Sub-signal weights 0.30/0.40/0.20/0.10 at `app/services/expansion_advisor.py:2182-2187`.
- Nine-component weights at `app/services/expansion_advisor.py:2409-2419`.
- `_FEATURE_SNAPSHOT_WHITELIST` at `app/services/llm_decision_memo.py:374-396`.
- Scraper (`scripts/scrape_aqar.py`), detail backfill (`app/ingest/aqar/detail_scraper.py`), LLM classifier (`app/services/llm_suitability.py`), frontend (`frontend/src/features/expansion-advisor/DecisionLogicCard.tsx`).

### Expected impact (prediction, not measurement)
Baseline regression search: QSR / Burger / 100–500 m² / target 200 m², live at http://8.213.84.191/.

- Max theoretical freshness swing: band 15 → band 100 = +85 points on the freshness sub-signal.
- Inside `_listing_quality_score` (freshness weight 0.30): up to +25.5 pt on the `listing_quality` composite.
- Inside the nine-component final score (`listing_quality` weight 0.11): up to +2.8 pt on `final_score` in the extreme case. Typical case (one-band jump, ±15 point freshness swing): ~0.5 pt on `final_score`.
- Predicted top-20 reshuffle: 5–10 positions shift within ±3 ranks; 1–3 entries enter/leave the top-20 at the boundary.

Directional winners: listings with a recent `aqar_updated_at` or `aqar_created_at` (most of the 87.05% with Phase 2 coverage). Directional losers (relative): listings where `first_seen_at` is recent but the real Aqar dates are old — the "stale listing re-confirmed" case originally called out in the old docstring.

### Test results
- Pre-existing suite: 1036 passed, 5 skipped (`python -m pytest -q --ignore=tests/ingest`, 315s).
- Ingest tests: 67 passed (`python -m pytest -q tests/ingest`, 3s).
- EA-specific subset (17 files): 472 passed in 10s.
- Updated tests: 4 at `tests/test_expansion_advisor_regression.py:1032-1092` — signatures changed from `first_seen_at=...` to `effective_age_days=...`.
- New tests added: 8 at `tests/test_expansion_advisor_regression.py:1095-1250` — 7 from spec §5 plus the `test_effective_age_future_only_returns_unknown` case added by Correction 3. Covers: GREATEST picking, NULL fallthrough permutations, all-null neutral resolution, near-future clamp, far-future rejection, parametrised band-cutoff boundaries, and tz-aware/tz-naive mixing.

### DB verification deferred to deploy-time
Spec §9 includes two pre-deploy sanity SQL queries to run in Codespace psql:
- A counter for `aqar_updated_at`/`aqar_created_at` future-dated or inverted rows.
- A percentile query scoped to the INNER-JOIN-eligible pool to check that the `<=14` top band is not pathologically large post-swap.

Not run in this PR (no DB access here). Reviewer to run before merge.

### Rollback
Pure code revert (`git revert` of the two commits on this branch). No schema change, no data migration, no feature flag. The additional SQL projections are safe to leave if partially rolled back.

### Deviations & suggestions
- The spec §4 instructed the snapshot mutation to land near line 6488, right after `score_breakdown_json["inputs"]["rent_fallback_used"] = ...`. That is the score-breakdown dict, not the feature snapshot. Correction 1 in the implementation brief moved it next to `_candidate_feature_snapshot(...)` (now at `app/services/expansion_advisor.py:6406`); this PR follows Correction 1.
- Spec §1's helper clamped negative-days post-`max()`. Correction 3 replaced that with a future-timestamp pre-filter so a parser bug producing `aqar_updated_at = 2099-01-01` cannot win `max()` and land the listing in the top band. This PR follows Correction 3.
- Docstring narrative at `app/services/expansion_advisor.py:2055-2059` was rewritten in the same commit as the code change, per Correction 5.
- One operational observation not acted on: `scripts/backfill_aqar_detail_fields.py:110` and `scripts/backfill_llm_suitability.py:85` order their queues by `first_seen_at DESC`. Now that `GREATEST(aqar_updated_at, aqar_created_at, first_seen_at)` is the real recency signal, the ordering could be updated to match. Left untouched — operational queue ordering, not scoring, and explicitly out of scope for 3a.
- One UX observation not acted on: the `listing_age` snapshot key is deliberately NOT in `_FEATURE_SNAPSHOT_WHITELIST` at `app/services/llm_decision_memo.py:374-396`, so the LLM memo prompt and the rerank prompt do not see it. Deferred per the spec's explicit instruction.
