### PR TITLE
Phase 3b: district momentum sub-signal in _listing_quality_score

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -334,28 +334,38 @@ def _district_momentum_score(db: Session) -> dict[str, dict[str, Any]]:
                 "percentile_raw": float,        # 0-1, percentile_rank over activity_30d
                 "percentile_absolute": float,   # 0-1, percentile_rank over activity_30d / active
                 "percentile_composite": float,  # 0-1, 0.5*raw + 0.5*absolute
-                "district_label": str,          # raw TRIM(neighborhood) used for the group
+                "district_label": str,          # raw label from external_feature.properties
                 "sample_floor_applied": bool,   # always False in the returned dict
             }
         }
 
-    Aggregation source is ``commercial_unit`` directly (not
-    ``candidate_location``) because the CL-join path was empirically
-    sparse: DB verification showed a floor=20 join via candidate_location
-    qualifies only 3 districts / 25.6% of rows, whereas the direct
-    commercial_unit aggregation qualifies 37 districts / 69.08% of rows
-    while still running in ~2ms. Downstream scoring candidates keyed on
-    either ``cl.district_ar`` (primary pool) or ``cu.neighborhood``
-    (fallback pool, spatially backfilled) are both matched into this
-    dict through ``normalize_district_key``, so the momentum score
-    applies uniformly to Tier 1, 2, and 3 candidates.
+    Aggregation source is ``commercial_unit`` listings spatially joined
+    against ``external_feature`` district polygons. This produces an
+    Arabic-label key-space that matches the namespace the scoring path
+    consumes (``cl.district_ar`` on the primary pool, spatial backfill
+    from ``riyadh_parcels_arcgis_raw.district_label`` on the fallback
+    pool — both Arabic). Lookups via ``normalize_district_key`` match
+    by construction; the helper applies uniformly to Tier 1, 2, and 3
+    candidates.
+
+    Two external_feature layers are queried with a priority chain —
+    ``osm_districts`` first, ``aqar_district_hulls`` second. DISTINCT ON
+    (cu.aqar_id) ORDER BY the layer priority ensures each listing
+    resolves to exactly one district at the highest priority polygon
+    that contains its point. A third layer is not added without DB
+    verification; 'rydpolygons' does not exist in this schema.
 
     A listing counts toward ``activity_30d`` if EITHER ``aqar_created_at``
-    OR ``aqar_updated_at`` falls in the trailing window — null-safe, each
-    listing counted at most once. Districts below ``_MOMENTUM_SAMPLE_FLOOR``
-    are excluded from the returned dict so callers resolve them to neutral
-    50.0 via ``.get(district_norm)`` returning None. Blank and pure-numeric
-    ``neighborhood`` values are filtered out (see ``_is_plausible_neighborhood``).
+    OR ``aqar_updated_at`` falls in the trailing window — null-safe,
+    each listing counted at most once via the SQL OR predicate.
+    Districts below ``_MOMENTUM_SAMPLE_FLOOR`` are excluded so callers
+    resolve them to neutral 50.0 via ``.get(district_norm)`` returning
+    None.
+
+    DB verification (floor=20): 39 qualifying districts, 1,680 active
+    listings covered (71.40% of the active pool), 1,420 activity_30d
+    rows, ~36ms runtime against the 250ms budget. Indexes used:
+    ``external_feature`` GIST on geom, btree on layer_name.
 
     Returns an empty dict on any DB failure so the caller falls back to
     neutral everywhere without raising.
@@ -364,33 +374,59 @@ def _district_momentum_score(db: Session) -> dict[str, dict[str, Any]]:
         rows = db.execute(
             text(
                 """
-                WITH district_counts AS (
+                WITH listing_district AS (
+                    SELECT DISTINCT ON (cu.aqar_id)
+                        cu.aqar_id,
+                        cu.aqar_created_at,
+                        cu.aqar_updated_at,
+                        TRIM(COALESCE(ef.properties->>'district_raw',
+                                      ef.properties->>'district')) AS district_label
+                    FROM commercial_unit cu
+                    JOIN external_feature ef
+                      ON ST_Contains(
+                           ef.geom,
+                           ST_SetSRID(ST_MakePoint(cu.lon, cu.lat), 4326)
+                         )
+                    WHERE cu.lat IS NOT NULL
+                      AND cu.lon IS NOT NULL
+                      AND cu.status = 'active'
+                      AND ef.layer_name IN ('osm_districts', 'aqar_district_hulls')
+                      AND COALESCE(ef.properties->>'district_raw',
+                                   ef.properties->>'district') IS NOT NULL
+                      AND TRIM(COALESCE(ef.properties->>'district_raw',
+                                        ef.properties->>'district')) <> ''
+                    ORDER BY
+                      cu.aqar_id,
+                      CASE ef.layer_name
+                          WHEN 'osm_districts'       THEN 1
+                          WHEN 'aqar_district_hulls' THEN 2
+                          ELSE 3
+                      END
+                ),
+                district_counts AS (
                     SELECT
-                        TRIM(neighborhood) AS district_label,
-                        COUNT(*) FILTER (WHERE status = 'active') AS active_in_district,
+                        district_label,
+                        COUNT(*) AS active_in_district,
                         COUNT(*) FILTER (
-                            WHERE status = 'active'
-                              AND (
-                                  (aqar_created_at IS NOT NULL
-                                    AND aqar_created_at >= now() - (:window_days || ' days')::interval)
-                                  OR
-                                  (aqar_updated_at IS NOT NULL
-                                    AND aqar_updated_at >= now() - (:window_days || ' days')::interval)
-                              )
+                          WHERE (
+                            (aqar_created_at IS NOT NULL
+                              AND aqar_created_at >= now() - (:window_days || ' days')::interval)
+                            OR
+                            (aqar_updated_at IS NOT NULL
+                              AND aqar_updated_at >= now() - (:window_days || ' days')::interval)
+                          )
                         ) AS activity_30d
-                    FROM commercial_unit
-                    WHERE neighborhood IS NOT NULL
-                      AND TRIM(neighborhood) <> ''
-                      AND neighborhood !~ '^\\s*[0-9]+\\s*$'
-                    GROUP BY TRIM(neighborhood)
-                    HAVING COUNT(*) FILTER (WHERE status = 'active') >= :sample_floor
+                    FROM listing_district
+                    GROUP BY district_label
+                    HAVING COUNT(*) >= :sample_floor
                 ),
                 ranked AS (
                     SELECT
                         district_label,
                         activity_30d,
                         active_in_district,
-                        (activity_30d::float / NULLIF(active_in_district, 0)::float) AS momentum_raw,
+                        (activity_30d::float / NULLIF(active_in_district, 0)::float)
+                            AS momentum_raw,
                         percent_rank() OVER (ORDER BY activity_30d) AS percentile_raw,
                         percent_rank() OVER (
                             ORDER BY (activity_30d::float / NULLIF(active_in_district, 0)::float)

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -321,6 +321,122 @@ def _precompute_district_delivery_stats(
     return district_stats, city_benchmarks
 
 
+def _district_momentum_score(db: Session) -> dict[str, dict[str, Any]]:
+    """Per-search, per-district 30-day activity momentum.
+
+    Returns::
+
+        {
+            normalize_district_key(label): {
+                "momentum_score": float,        # 0-100, fed into _listing_quality_score
+                "activity_30d": int,            # creates OR updates in the last 30 days
+                "active_in_district": int,
+                "percentile_raw": float,        # 0-1, percentile_rank over activity_30d
+                "percentile_absolute": float,   # 0-1, percentile_rank over activity_30d / active
+                "percentile_composite": float,  # 0-1, 0.5*raw + 0.5*absolute
+                "district_label": str,          # raw TRIM(neighborhood) used for the group
+                "sample_floor_applied": bool,   # always False in the returned dict
+            }
+        }
+
+    Aggregation source is ``commercial_unit`` directly (not
+    ``candidate_location``) because the CL-join path was empirically
+    sparse: DB verification showed a floor=20 join via candidate_location
+    qualifies only 3 districts / 25.6% of rows, whereas the direct
+    commercial_unit aggregation qualifies 37 districts / 69.08% of rows
+    while still running in ~2ms. Downstream scoring candidates keyed on
+    either ``cl.district_ar`` (primary pool) or ``cu.neighborhood``
+    (fallback pool, spatially backfilled) are both matched into this
+    dict through ``normalize_district_key``, so the momentum score
+    applies uniformly to Tier 1, 2, and 3 candidates.
+
+    A listing counts toward ``activity_30d`` if EITHER ``aqar_created_at``
+    OR ``aqar_updated_at`` falls in the trailing window — null-safe, each
+    listing counted at most once. Districts below ``_MOMENTUM_SAMPLE_FLOOR``
+    are excluded from the returned dict so callers resolve them to neutral
+    50.0 via ``.get(district_norm)`` returning None. Blank and pure-numeric
+    ``neighborhood`` values are filtered out (see ``_is_plausible_neighborhood``).
+
+    Returns an empty dict on any DB failure so the caller falls back to
+    neutral everywhere without raising.
+    """
+    try:
+        rows = db.execute(
+            text(
+                """
+                WITH district_counts AS (
+                    SELECT
+                        TRIM(neighborhood) AS district_label,
+                        COUNT(*) FILTER (WHERE status = 'active') AS active_in_district,
+                        COUNT(*) FILTER (
+                            WHERE status = 'active'
+                              AND (
+                                  (aqar_created_at IS NOT NULL
+                                    AND aqar_created_at >= now() - (:window_days || ' days')::interval)
+                                  OR
+                                  (aqar_updated_at IS NOT NULL
+                                    AND aqar_updated_at >= now() - (:window_days || ' days')::interval)
+                              )
+                        ) AS activity_30d
+                    FROM commercial_unit
+                    WHERE neighborhood IS NOT NULL
+                      AND TRIM(neighborhood) <> ''
+                      AND neighborhood !~ '^\\s*[0-9]+\\s*$'
+                    GROUP BY TRIM(neighborhood)
+                    HAVING COUNT(*) FILTER (WHERE status = 'active') >= :sample_floor
+                ),
+                ranked AS (
+                    SELECT
+                        district_label,
+                        activity_30d,
+                        active_in_district,
+                        (activity_30d::float / NULLIF(active_in_district, 0)::float) AS momentum_raw,
+                        percent_rank() OVER (ORDER BY activity_30d) AS percentile_raw,
+                        percent_rank() OVER (
+                            ORDER BY (activity_30d::float / NULLIF(active_in_district, 0)::float)
+                        ) AS percentile_absolute
+                    FROM district_counts
+                )
+                SELECT
+                    district_label,
+                    activity_30d,
+                    active_in_district,
+                    COALESCE(percentile_raw, 0.5)      AS percentile_raw,
+                    COALESCE(percentile_absolute, 0.5) AS percentile_absolute
+                FROM ranked
+                """
+            ),
+            {
+                "window_days": _MOMENTUM_WINDOW_DAYS,
+                "sample_floor": _MOMENTUM_SAMPLE_FLOOR,
+            },
+        ).mappings().all()
+    except Exception:
+        logger.exception("_district_momentum_score failed")
+        return {}
+
+    out: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        raw = str(r["district_label"])
+        key = normalize_district_key(raw)
+        if not key:
+            continue
+        p_raw = float(r["percentile_raw"])
+        p_abs = float(r["percentile_absolute"])
+        p_composite = 0.5 * p_raw + 0.5 * p_abs
+        out[key] = {
+            "momentum_score": round(_clamp(p_composite * 100.0), 2),
+            "activity_30d": int(r["activity_30d"]),
+            "active_in_district": int(r["active_in_district"]),
+            "percentile_raw": round(p_raw, 4),
+            "percentile_absolute": round(p_abs, 4),
+            "percentile_composite": round(p_composite, 4),
+            "district_label": raw,
+            "sample_floor_applied": False,
+        }
+    return out
+
+
 def _expand_category_terms(category: str) -> list[str]:
     """Return delivery-table bucket names that match a user search category.
 
@@ -2079,6 +2195,29 @@ def _effective_listing_age_days(
     return days, tag
 
 
+# ---------------------------------------------------------------------------
+# Phase 3b — district momentum
+# ---------------------------------------------------------------------------
+
+# Kill-switch. When False, _listing_quality_score reverts to the pre-3b
+# weight tuple (0.30/0.40/0.20/0.10) and ignores district_momentum_score
+# entirely. This is the clean revert path because the 3b-rebalanced
+# weights sum to 0.85 without momentum; dropping the term without
+# reverting the weights would break the 0-100 scale.
+_MOMENTUM_ENABLED = True
+
+# Trailing window (days) over which a listing's aqar_created_at OR
+# aqar_updated_at must fall to count toward activity_30d.
+_MOMENTUM_WINDOW_DAYS = 30
+
+# Minimum active listings per district for the district to earn a
+# percentile-ranked momentum score. Districts below the floor resolve
+# to a neutral 50.0 (percentile_composite = 0.5) — tri-state "unknown",
+# not a penalty. DB verification confirmed 37 districts qualify at 20,
+# covering 69.08% of active rows.
+_MOMENTUM_SAMPLE_FLOOR = 20
+
+
 def _listing_quality_score(
     *,
     is_listing: bool,
@@ -2089,6 +2228,7 @@ def _listing_quality_score(
     has_drive_thru: bool | None = None,
     llm_suitability_score: int | None = None,
     llm_listing_quality_score: int | None = None,
+    district_momentum_score: float | None = None,
 ) -> float:
     """Pure listing-quality score on a 0-100 scale.
 
@@ -2110,23 +2250,28 @@ def _listing_quality_score(
     For parcels (or any candidate without a commercial_unit row),
     returns a neutral 50.
 
-    Components:
-      - Freshness from effective_age_days (30%): how recently the listing
+    Components (Phase 3b weight tuple when _MOMENTUM_ENABLED is True):
+      - Freshness from effective_age_days (25.50%): how recently the listing
         was created or updated on Aqar (bands at 14/30/60/120/240/365 —
         frozen for Phase 3a).
-      - Aqar suitability (40%): the classifier's assessment — LLM verdict
+      - Aqar suitability (34.00%): the classifier's assessment — LLM verdict
         when available, structural restaurant_score fallback otherwise
-      - Image / fit-out signal (20%): LLM-derived listing quality when
+      - Image / fit-out signal (17.00%): LLM-derived listing quality when
         available, binary image presence fallback otherwise
-      - Furnished (10%): faster open, lower risk, lower fitout
+      - Furnished (8.50%): faster open, lower risk, lower fitout
+      - District momentum (15.00%): percentile-ranked 30-day activity in
+        the district (blended creates + updates on commercial_unit).
+        Districts below the sample floor resolve to a neutral 50.0.
       - Drive-thru bonus: small additive (+5) when present
 
-    Patch 13 rebalance: shifted 10 points from ``freshness`` into the
-    LLM-derived sub-components (+5 suitability, +5 image_signal) so that
-    when both LLM scores are populated they carry 60% of the composite,
-    up from 50% under Patch 12.  The fallback paths use the same weights —
-    the structural stand-ins inherit the higher weight, which is fine
-    because they are direct substitutes for the missing LLM signal.
+    The four pre-3b sub-weights (0.30/0.40/0.20/0.10) are rescaled
+    multiplicatively by 0.85 so their ratios are preserved exactly while
+    making room for the 15% momentum allocation. When _MOMENTUM_ENABLED
+    is False the pre-3b tuple is used and district_momentum_score is
+    ignored.
+
+    Momentum values are always on the same 0-100 scale as the other
+    sub-signals. None (or _MOMENTUM_ENABLED=False) selects neutral 50.0.
     """
     if not is_listing:
         return 50.0
@@ -2179,12 +2324,33 @@ def _listing_quality_score(
     # Furnished: faster open, lower risk
     furnished_signal = 100.0 if is_furnished else 50.0
 
-    composite = (
-        freshness * 0.30
-        + suitability * 0.40
-        + image_signal * 0.20
-        + furnished_signal * 0.10
-    )
+    if _MOMENTUM_ENABLED:
+        # Multiplicative rebalance of the pre-3b sub-weights by 0.85 to
+        # make room for the 0.15 momentum slot. Ratios are preserved
+        # exactly (0.2550 : 0.3400 : 0.1700 : 0.0850 == 0.30 : 0.40 :
+        # 0.20 : 0.10). Unknown momentum → neutral 50.0 per the tri-state
+        # convention used by freshness and suitability above.
+        if district_momentum_score is None:
+            momentum_signal = 50.0
+        else:
+            momentum_signal = _clamp(float(district_momentum_score))
+        composite = (
+            freshness * 0.2550
+            + suitability * 0.3400
+            + image_signal * 0.1700
+            + furnished_signal * 0.0850
+            + momentum_signal * 0.1500
+        )
+    else:
+        # Pre-3b weight tuple. Used by the kill-switch revert path;
+        # district_momentum_score is intentionally ignored so the scale
+        # stays 0-100 without a 0.85 sub-weight sum.
+        composite = (
+            freshness * 0.30
+            + suitability * 0.40
+            + image_signal * 0.20
+            + furnished_signal * 0.10
+        )
 
     # Small drive-thru bonus when present (rare on Aqar but valuable for QSR)
     if has_drive_thru:
@@ -5513,6 +5679,20 @@ def run_expansion_search(
         search_id,
     )
 
+    # ── Pre-compute district momentum (Phase 3b) ──
+    # One aggregation round-trip (~2ms in DB verification) keyed by
+    # normalize_district_key(neighborhood). Districts below the sample
+    # floor are absent from the dict; scoring call sites resolve absent
+    # keys to neutral 50.0 via .get(district_norm).
+    _district_momentum = _district_momentum_score(db)
+    t_district_momentum_done = time.monotonic()
+    logger.info(
+        "expansion_search timing: district_momentum=%.3fs districts=%d search_id=%s",
+        t_district_momentum_done - t_district_stats_done,
+        len(_district_momentum),
+        search_id,
+    )
+
     # ── Pre-warm rent cache for all districts (avoids N serial DB calls in scoring loop) ──
     # Map normalized key → first raw district string seen, so _estimate_rent_sar_m2_year
     # receives the raw value (matching the scoring loop contract — the aqar fallback
@@ -5533,7 +5713,7 @@ def run_expansion_search(
     t_rent_prewarm_done = time.monotonic()
     logger.info(
         "expansion_search timing: rent_prewarm=%.2fs districts=%d search_id=%s",
-        t_rent_prewarm_done - t_district_stats_done, len(_norm_to_raw), search_id,
+        t_rent_prewarm_done - t_district_momentum_done, len(_norm_to_raw), search_id,
     )
 
     for row in rows:
@@ -5839,6 +6019,11 @@ def run_expansion_search(
         )
 
         effective_age_days, _ = _effective_listing_age_days(row)
+        # district_norm is computed at line ~5757 earlier in this loop; reuse it
+        _momentum_entry = _district_momentum.get(district_norm) if district_norm else None
+        _district_momentum_score_val = (
+            _momentum_entry["momentum_score"] if _momentum_entry else None
+        )
         listing_quality = _listing_quality_score(
             is_listing=_is_listing,
             effective_age_days=effective_age_days,
@@ -5848,6 +6033,7 @@ def run_expansion_search(
             has_drive_thru=row.get("unit_has_drive_thru"),
             llm_suitability_score=row.get("unit_llm_suitability_score"),
             llm_listing_quality_score=row.get("unit_llm_listing_quality_score"),
+            district_momentum_score=_district_momentum_score_val,
         )
         preliminary_breakdown = _score_breakdown(
             demand_score=demand_score,
@@ -6304,6 +6490,11 @@ def run_expansion_search(
             or row.get("unit_neighborhood_raw")
             or "District unknown"
         )
+        # Final-pass district_norm. The first scoring pass assigns
+        # district_norm at line ~5757 but that binding leaks across
+        # iterations of the per-row loop and does NOT track this
+        # shortlist iteration's candidate. Recompute locally.
+        district_norm_final = normalize_district_key(district) if district else None
         demand_score = prepared_item["demand_score"]
 
         # Café foot-traffic amenity bonus (applied in second pass
@@ -6407,6 +6598,26 @@ def run_expansion_search(
             "effective_age_days": effective_age_days,
             "source": effective_age_source,
         }
+        # Phase 3b — district momentum snapshot. Districts below the
+        # sample floor, blank-district candidates, and any normalization
+        # miss all resolve to the neutral fallback shape so the downstream
+        # contract is consistent (dict is always present, keys are stable).
+        _momentum_entry_final = (
+            _district_momentum.get(district_norm_final) if district_norm_final else None
+        )
+        if _momentum_entry_final is not None:
+            feature_snapshot_json["district_momentum"] = dict(_momentum_entry_final)
+        else:
+            feature_snapshot_json["district_momentum"] = {
+                "momentum_score": 50.0,
+                "activity_30d": 0,
+                "active_in_district": 0,
+                "percentile_raw": 0.5,
+                "percentile_absolute": 0.5,
+                "percentile_composite": 0.5,
+                "district_label": district if isinstance(district, str) else None,
+                "sample_floor_applied": True,
+            }
         # Enrich feature snapshot with candidate_location metadata
         if row.get("source_tier") is not None:
             feature_snapshot_json["candidate_location"] = {
@@ -6518,6 +6729,9 @@ def run_expansion_search(
             brand_profile=effective_brand_profile,
             service_model=service_model,
         )
+        _final_momentum_score_val = (
+            _momentum_entry_final["momentum_score"] if _momentum_entry_final else None
+        )
         listing_quality = _listing_quality_score(
             is_listing=_is_listing,
             effective_age_days=effective_age_days,
@@ -6527,6 +6741,7 @@ def run_expansion_search(
             has_drive_thru=row.get("unit_has_drive_thru"),
             llm_suitability_score=row.get("unit_llm_suitability_score"),
             llm_listing_quality_score=row.get("unit_llm_listing_quality_score"),
+            district_momentum_score=_final_momentum_score_val,
         )
         score_breakdown_json = _score_breakdown(
             demand_score=demand_score,

--- a/tests/services/test_realized_demand_broadcast.py
+++ b/tests/services/test_realized_demand_broadcast.py
@@ -93,6 +93,12 @@ class FakeDB:
         # here).  Return the same three seeded rows for all pool paths.
         if "FROM candidate_base" in sql:
             return _Result(self.candidate_rows)
+        # Phase 3b _district_momentum_score — spatial CTE "WITH
+        # listing_district AS". Match before the generic
+        # "FROM commercial_unit" branch so every candidate resolves to
+        # neutral 50.0 momentum in this fixture.
+        if "WITH listing_district AS" in sql:
+            return _Result([])
         if "FROM commercial_unit" in sql and "INSERT" not in sql:
             return _Result(self.candidate_rows)
         if "COUNT(*)" in sql and "candidate_location" in sql:

--- a/tests/test_expansion_advisor_regression.py
+++ b/tests/test_expansion_advisor_regression.py
@@ -565,12 +565,13 @@ class _FakeDB:
             return _Result(self.candidate_rows)
         if "COUNT(*)" in sql and "candidate_location" in sql:
             return _Result([{"count": 0}])
-        # Phase 3b _district_momentum_score — aggregates from
-        # commercial_unit via a distinctive "WITH district_counts AS"
-        # CTE. Match BEFORE the plain "FROM commercial_unit" rule so
-        # the helper gets an empty momentum dict (every candidate then
-        # resolves to neutral 50.0 through the existing contract).
-        if "WITH district_counts AS" in sql:
+        # Phase 3b _district_momentum_score — spatial aggregation
+        # against external_feature with a distinctive "WITH
+        # listing_district AS" CTE. Match BEFORE the plain
+        # "FROM commercial_unit" rule so the helper gets an empty
+        # momentum dict (every candidate then resolves to neutral 50.0
+        # through the existing contract).
+        if "WITH listing_district AS" in sql:
             return _Result([])
         if "FROM commercial_unit" in sql:
             return _Result(self.candidate_rows)
@@ -1496,6 +1497,57 @@ def test_district_momentum_blends_created_and_updated():
     out = _district_momentum_score(db)
     entry = next(iter(out.values()))
     assert entry["activity_30d"] == 10  # not 5 + 8 + 3 = 16, not 5 + 8 = 13
+
+
+def test_district_momentum_uses_external_feature_priority_chain():
+    """When the same listing point is covered by both osm_districts
+    (priority 1) and aqar_district_hulls (priority 2) polygons, the
+    helper must use the osm_districts district. Faithful DISTINCT ON
+    behaviour lives in Postgres, so at the unit level this test asserts
+    two complementary contracts:
+
+    (a) The emitted SQL contains the DISTINCT ON (cu.aqar_id) clause
+        plus the CASE ef.layer_name priority-ordering and the two
+        expected layer names. This documents the priority chain's
+        presence in the query plan.
+
+    (b) Given an already-resolved row (the SQL chose osm_districts),
+        the helper returns that label intact and does not mix in the
+        aqar_district_hulls name for the same listing.
+    """
+    rows = [
+        # SQL has already resolved this listing to the osm_districts
+        # polygon's district. An aqar_district_hulls row with a
+        # DIFFERENT label for the same aqar_id would have been
+        # suppressed by DISTINCT ON. The helper sees one row per
+        # district here (the post-DISTINCT-ON group).
+        {
+            "district_label": "العارض",  # chosen from osm_districts
+            "activity_30d": 8,
+            "active_in_district": 40,
+            "percentile_raw": 0.65,
+            "percentile_absolute": 0.55,
+        },
+    ]
+    db = _fake_db_returning(rows)
+    out = _district_momentum_score(db)
+
+    # Contract (a): SQL shape captured on the mock records the
+    # priority-chain intent.
+    emitted_sql_obj = db.execute.call_args.args[0]
+    emitted_sql = emitted_sql_obj.text if hasattr(emitted_sql_obj, "text") else str(emitted_sql_obj)
+    assert "DISTINCT ON (cu.aqar_id)" in emitted_sql
+    assert "CASE ef.layer_name" in emitted_sql
+    assert "'osm_districts'" in emitted_sql
+    assert "'aqar_district_hulls'" in emitted_sql
+    # osm_districts must sort BEFORE aqar_district_hulls in the CASE.
+    osm_pos = emitted_sql.index("'osm_districts'")
+    aqar_pos = emitted_sql.index("'aqar_district_hulls'")
+    assert osm_pos < aqar_pos
+
+    # Contract (b): the post-DISTINCT-ON label is preserved verbatim.
+    entry = next(iter(out.values()))
+    assert entry["district_label"] == "العارض"
 
 
 def test_listing_quality_scoring_callsite_two_district_delta():

--- a/tests/test_expansion_advisor_regression.py
+++ b/tests/test_expansion_advisor_regression.py
@@ -19,11 +19,14 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from unittest.mock import MagicMock
+
 from app.services.expansion_advisor import (
     _arcgis_classification_semantics,
     _area_fit,
     _brand_fit_score,
     _candidate_gate_status,
+    _district_momentum_score,
     _effective_listing_age_days,
     _estimate_fitout_cost_sar,
     _estimate_revenue_index,
@@ -562,6 +565,13 @@ class _FakeDB:
             return _Result(self.candidate_rows)
         if "COUNT(*)" in sql and "candidate_location" in sql:
             return _Result([{"count": 0}])
+        # Phase 3b _district_momentum_score — aggregates from
+        # commercial_unit via a distinctive "WITH district_counts AS"
+        # CTE. Match BEFORE the plain "FROM commercial_unit" rule so
+        # the helper gets an empty momentum dict (every candidate then
+        # resolves to neutral 50.0 through the existing contract).
+        if "WITH district_counts AS" in sql:
+            return _Result([])
         if "FROM commercial_unit" in sql:
             return _Result(self.candidate_rows)
         if "INSERT INTO expansion_candidate" in sql:
@@ -1054,7 +1064,10 @@ def test_listing_quality_fresh_full_data_high_score():
         has_image=True,
         has_drive_thru=True,
     )
-    # freshness=100*0.4 + suitability~92*0.35 + image=100*0.15 + furnished=100*0.10 + drive_thru=5
+    # Phase 3b: momentum defaults to neutral 50.0 when not passed.
+    # freshness=100, suitability=180→clamped 100, image=100, furnished=100,
+    # momentum=50. Composite ≈ 100*0.2550 + 100*0.3400 + 100*0.1700 +
+    # 100*0.0850 + 50*0.15 + 5 (drive-thru) = 25.5+34+17+8.5+7.5+5 = 97.5.
     assert score > 90.0
 
 
@@ -1067,7 +1080,9 @@ def test_listing_quality_stale_no_image_low_score():
         unit_restaurant_score=None,
         has_image=False,
     )
-    # freshness=15*0.4 + suitability=50*0.35 + image=30*0.15 + furnished=50*0.10 = 33
+    # Phase 3b: momentum defaults to neutral 50.0 when not passed.
+    # composite = 15*0.2550 + 50*0.3400 + 30*0.1700 + 50*0.0850 + 50*0.15
+    #           = 3.825 + 17.00 + 5.10 + 4.25 + 7.50 = 37.675 < 50.
     assert score < 50.0
 
 
@@ -1145,6 +1160,8 @@ def test_effective_age_all_null_returns_unknown_neutral():
     assert source == "unknown"
 
     # Fixed-neutral inputs to isolate the freshness contribution.
+    # Phase 3b: sub-weights are (0.2550, 0.3400, 0.1700, 0.0850, 0.15).
+    # district_momentum_score=None → momentum resolves to neutral 50.0.
     common = dict(
         is_listing=True,
         is_furnished=False,
@@ -1153,11 +1170,18 @@ def test_effective_age_all_null_returns_unknown_neutral():
         has_drive_thru=False,
         llm_suitability_score=None,
         llm_listing_quality_score=None,
+        district_momentum_score=None,
     )
-    # With these neutral inputs: suitability=50, image_signal=30,
-    # furnished_signal=50. Composite = freshness*0.30 + 50*0.40 +
-    # 30*0.20 + 50*0.10 = freshness*0.30 + 31.
-    expected_with_freshness_50 = 50.0 * 0.30 + 50.0 * 0.40 + 30.0 * 0.20 + 50.0 * 0.10
+    # suitability=50, image_signal=30, furnished_signal=50, momentum=50.
+    # Composite = freshness*0.2550 + 50*0.3400 + 30*0.1700 + 50*0.0850
+    #           + 50*0.15 = freshness*0.2550 + 33.85.
+    expected_with_freshness_50 = (
+        50.0 * 0.2550
+        + 50.0 * 0.3400
+        + 30.0 * 0.1700
+        + 50.0 * 0.0850
+        + 50.0 * 0.15
+    )
     observed = _listing_quality_score(effective_age_days=None, **common)
     assert abs(observed - expected_with_freshness_50) < 1e-9
 
@@ -1184,10 +1208,13 @@ def test_effective_age_future_updated_at_clamps_to_zero():
         unit_restaurant_score=None,
         has_image=False,
         has_drive_thru=False,
+        district_momentum_score=None,
     )
-    # freshness = 100 (days <= 14 band). Composite = 100*0.30 + 50*0.40
-    # + 30*0.20 + 50*0.10 = 61.
-    assert abs(score - 61.0) < 1e-9
+    # Phase 3b weights (0.2550, 0.3400, 0.1700, 0.0850, 0.15). freshness
+    # = 100 (days <= 14 band), suitability=50, image_signal=30,
+    # furnished=50, momentum=50 (None → neutral). Composite =
+    # 100*0.2550 + 50*0.3400 + 30*0.1700 + 50*0.0850 + 50*0.15 = 59.35.
+    assert abs(score - 59.35) < 1e-9
 
 
 def test_effective_age_future_only_returns_unknown():
@@ -1219,8 +1246,9 @@ def test_effective_age_future_only_returns_unknown():
 )
 def test_effective_age_band_boundaries(age_days, expected_freshness):
     """Lock the frozen Phase 3a band cutoffs at 14/30/60/120/240/365 days
-    against silent drift. Composite = freshness*0.30 + 20 + 6 + 5 with the
-    fixed inputs below (suitability=50, image_signal=30, furnished=50)."""
+    against silent drift. Phase 3b sub-weights (0.2550, 0.3400, 0.1700,
+    0.0850, 0.15); fixed inputs make suitability=50, image_signal=30,
+    furnished=50, momentum=50 (None)."""
     score = _listing_quality_score(
         is_listing=True,
         effective_age_days=age_days,
@@ -1228,8 +1256,15 @@ def test_effective_age_band_boundaries(age_days, expected_freshness):
         unit_restaurant_score=None,
         has_image=False,
         has_drive_thru=False,
+        district_momentum_score=None,
     )
-    expected_composite = expected_freshness * 0.30 + 50.0 * 0.40 + 30.0 * 0.20 + 50.0 * 0.10
+    expected_composite = (
+        expected_freshness * 0.2550
+        + 50.0 * 0.3400
+        + 30.0 * 0.1700
+        + 50.0 * 0.0850
+        + 50.0 * 0.15
+    )
     assert abs(score - expected_composite) < 1e-9
 
 
@@ -1246,6 +1281,249 @@ def test_effective_age_tzaware_input_normalized():
     days, source = _effective_listing_age_days(row)
     assert days == 5
     assert source == "aqar_updated"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3b: district momentum sub-signal and _district_momentum_score helper
+# ---------------------------------------------------------------------------
+
+
+def _lq_neutral_kwargs(**overrides):
+    """Fixed-neutral _listing_quality_score inputs. Suitability resolves
+    to 50, image_signal to 30 (no image, no LLM), furnished_signal to 50."""
+    base = dict(
+        is_listing=True,
+        is_furnished=False,
+        unit_restaurant_score=None,
+        has_image=False,
+        has_drive_thru=False,
+        llm_suitability_score=None,
+        llm_listing_quality_score=None,
+    )
+    base.update(overrides)
+    return base
+
+
+def _fake_db_returning(rows):
+    """Build a MagicMock db whose .execute(...).mappings().all() returns
+    the supplied list of dicts. Matches the interface used inside
+    _district_momentum_score."""
+    db = MagicMock()
+    result = MagicMock()
+    result.mappings.return_value.all.return_value = rows
+    db.execute.return_value = result
+    return db
+
+
+def _fake_db_raising(exc: Exception):
+    db = MagicMock()
+    db.execute.side_effect = exc
+    return db
+
+
+def test_listing_quality_score_momentum_high_raises_composite():
+    """Momentum sub-weight is 0.15. A 100 vs 0 momentum swing must raise
+    the composite by exactly (100 - 0) * 0.15 = 15.0 points, with all
+    other sub-signals held at their neutral values and the drive-thru
+    bonus disabled."""
+    common = _lq_neutral_kwargs(effective_age_days=30)
+    high = _listing_quality_score(district_momentum_score=100.0, **common)
+    low = _listing_quality_score(district_momentum_score=0.0, **common)
+    assert abs((high - low) - 15.0) < 1e-9
+
+
+def test_listing_quality_score_momentum_none_neutral():
+    """district_momentum_score=None resolves to neutral 50.0. With
+    fully-neutral other inputs (freshness=50, suitability=50,
+    image_signal=30, furnished=50) and Phase 3b sub-weights, composite
+    = 50*0.2550 + 50*0.3400 + 30*0.1700 + 50*0.0850 + 50*0.15 = 46.60."""
+    common = _lq_neutral_kwargs(effective_age_days=None)
+    observed = _listing_quality_score(district_momentum_score=None, **common)
+    expected = (
+        50.0 * 0.2550
+        + 50.0 * 0.3400
+        + 30.0 * 0.1700
+        + 50.0 * 0.0850
+        + 50.0 * 0.15
+    )
+    assert abs(observed - expected) < 1e-9
+    assert abs(observed - 46.60) < 1e-9
+
+
+def test_listing_quality_score_momentum_below_floor_neutral():
+    """A candidate in a below-floor district receives district_momentum_score
+    = None (helper returns absent key) and must produce the exact same
+    composite as the neutral case above. Guards against accidentally
+    penalising sparsely-sampled districts."""
+    common = _lq_neutral_kwargs(effective_age_days=None)
+    absent = _listing_quality_score(district_momentum_score=None, **common)
+    # Simulate the helper-returns-empty-dict path: look up a district
+    # not present and feed the result (which is None) into the scorer.
+    momentum_dict: dict = {}
+    val = momentum_dict.get("الياسمين")
+    absent_via_helper = _listing_quality_score(district_momentum_score=val, **common)
+    assert absent == absent_via_helper
+
+
+def test_listing_quality_score_sub_weights_sum_to_one():
+    """Regression guard against silent sub-weight drift. Post-3b weights
+    must sum to 1.0 exactly under math.isclose."""
+    import math
+    assert math.isclose(0.2550 + 0.3400 + 0.1700 + 0.0850 + 0.15, 1.0)
+
+
+def test_district_momentum_score_composite_math():
+    """With percentile_raw=0.8 and percentile_absolute=0.6, the
+    composite = 0.5*0.8 + 0.5*0.6 = 0.7, and momentum_score =
+    round(0.7 * 100.0, 2) = 70.00."""
+    rows = [
+        {
+            "district_label": "العارض",
+            "activity_30d": 7,
+            "active_in_district": 45,
+            "percentile_raw": 0.8,
+            "percentile_absolute": 0.6,
+        },
+    ]
+    db = _fake_db_returning(rows)
+    out = _district_momentum_score(db)
+    assert len(out) == 1
+    entry = next(iter(out.values()))
+    assert abs(entry["percentile_composite"] - 0.7) < 1e-9
+    assert abs(entry["momentum_score"] - 70.0) < 1e-9
+    assert entry["sample_floor_applied"] is False
+    assert entry["activity_30d"] == 7
+    assert entry["active_in_district"] == 45
+
+
+def test_district_momentum_score_sample_floor_excludes_below_20():
+    """The HAVING clause at floor=20 excludes under-sampled districts.
+    The SQL is fake-mocked here; this test documents that rows the SQL
+    returns are trusted unchanged (no Python-side floor check) and that
+    rows the SQL does NOT return resolve to absent (→ neutral)."""
+    # The SQL enforces the floor; _fake_db_returning simulates post-filter
+    # output. A district that would have been filtered (active=19) is
+    # simply absent from the input rows.
+    rows = [
+        {
+            "district_label": "Hittin",
+            "activity_30d": 3,
+            "active_in_district": 23,
+            "percentile_raw": 0.2,
+            "percentile_absolute": 0.3,
+        },
+    ]
+    db = _fake_db_returning(rows)
+    out = _district_momentum_score(db)
+    # District with active=23 (above threshold) present.
+    assert any(v["district_label"] == "Hittin" for v in out.values())
+    # Absent key → None via .get.
+    assert out.get("not_a_real_district_key") is None
+
+
+def test_district_momentum_score_zero_activity_low_score_not_error():
+    """A qualifying district with activity_30d=0 must produce a finite
+    momentum_score (percentile_absolute COALESCEs to 0.5 on NULLIF-zero
+    and percentile_raw works on 0-values), never ZeroDivisionError."""
+    rows = [
+        {
+            "district_label": "Al Marwah",
+            "activity_30d": 0,
+            "active_in_district": 50,
+            "percentile_raw": 0.0,
+            "percentile_absolute": 0.5,  # NULLIF on zero numerator then COALESCE 0.5
+        },
+    ]
+    db = _fake_db_returning(rows)
+    out = _district_momentum_score(db)
+    entry = next(iter(out.values()))
+    assert 0.0 <= entry["momentum_score"] <= 100.0
+    # Composite = 0.5*0.0 + 0.5*0.5 = 0.25 → 25.0.
+    assert abs(entry["momentum_score"] - 25.0) < 1e-9
+
+
+def test_district_momentum_score_blank_district_label_filtered():
+    """A row whose district_label normalizes to empty (pure whitespace,
+    or a label that _normalize_district_key rejects) is dropped from
+    the returned dict. The SQL filter already drops NULL and numeric
+    labels; this guards the Python-side filter for edge cases."""
+    rows = [
+        {
+            "district_label": "  ",  # whitespace-only; normalize_district_key → ""
+            "activity_30d": 5,
+            "active_in_district": 30,
+            "percentile_raw": 0.5,
+            "percentile_absolute": 0.5,
+        },
+        {
+            "district_label": "As Sulay",
+            "activity_30d": 12,
+            "active_in_district": 85,
+            "percentile_raw": 0.6,
+            "percentile_absolute": 0.4,
+        },
+    ]
+    db = _fake_db_returning(rows)
+    out = _district_momentum_score(db)
+    # The blank-label row must be filtered; only "As Sulay" remains.
+    assert len(out) == 1
+    assert next(iter(out.values()))["district_label"] == "As Sulay"
+
+
+def test_district_momentum_score_empty_dict_on_db_failure():
+    """DB exception → {} so scoring falls back to neutral everywhere
+    without propagating the error."""
+    db = _fake_db_raising(RuntimeError("simulated DB failure"))
+    assert _district_momentum_score(db) == {}
+
+
+def test_district_momentum_blends_created_and_updated():
+    """Activity_30d must count a listing once if EITHER aqar_created_at
+    OR aqar_updated_at falls in the window, not both (de-duped).
+    Documents the SQL COUNT(*) FILTER (WHERE ... OR ...) semantics.
+    Here: 5 created-only, 8 updated-only, 3 overlap → 10 unique rows
+    (5 + 8 − 3 = 10)."""
+    rows = [
+        {
+            "district_label": "Banban",
+            "activity_30d": 10,  # SQL OR naturally dedupes per-row
+            "active_in_district": 32,
+            "percentile_raw": 0.55,
+            "percentile_absolute": 0.45,
+        },
+    ]
+    db = _fake_db_returning(rows)
+    out = _district_momentum_score(db)
+    entry = next(iter(out.values()))
+    assert entry["activity_30d"] == 10  # not 5 + 8 + 3 = 16, not 5 + 8 = 13
+
+
+def test_listing_quality_scoring_callsite_two_district_delta():
+    """Integration guard at the _listing_quality_score call-site contract.
+    Two synthetic candidates share all inputs except their district's
+    momentum score (80 vs absent → neutral 50). The composite must
+    differ by exactly (80 - 50) * 0.15 = 4.50 points."""
+    momentum_dict = {
+        "high_district": {"momentum_score": 80.0},
+        # "low_district" intentionally absent → .get returns None → neutral.
+    }
+    common = _lq_neutral_kwargs(effective_age_days=30)
+
+    # High-momentum candidate
+    high_entry = momentum_dict.get("high_district")
+    high_val = high_entry["momentum_score"] if high_entry else None
+    high_score = _listing_quality_score(
+        district_momentum_score=high_val, **common
+    )
+
+    # Below-floor candidate: entry absent, treated as neutral
+    low_entry = momentum_dict.get("low_district")
+    low_val = low_entry["momentum_score"] if low_entry else None
+    low_score = _listing_quality_score(
+        district_momentum_score=low_val, **common
+    )
+
+    assert abs((high_score - low_score) - 4.5) < 1e-9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -69,10 +69,11 @@ class FakeDB:
         # candidate_location count → return 0 so code falls to commercial_unit path
         if "COUNT(*)" in sql and "candidate_location" in sql:
             return _Result([{"count": 0}])
-        # Phase 3b _district_momentum_score — CTE "WITH district_counts AS".
-        # Match before the generic "FROM commercial_unit" branch so every
-        # candidate resolves to neutral 50.0 momentum in these fixtures.
-        if "WITH district_counts AS" in sql:
+        # Phase 3b _district_momentum_score — spatial CTE "WITH
+        # listing_district AS". Match before the generic
+        # "FROM commercial_unit" branch so every candidate resolves to
+        # neutral 50.0 momentum in these fixtures.
+        if "WITH listing_district AS" in sql:
             return _Result([])
         # commercial_unit queries → return candidate rows
         if "FROM commercial_unit" in sql:

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -69,6 +69,11 @@ class FakeDB:
         # candidate_location count → return 0 so code falls to commercial_unit path
         if "COUNT(*)" in sql and "candidate_location" in sql:
             return _Result([{"count": 0}])
+        # Phase 3b _district_momentum_score — CTE "WITH district_counts AS".
+        # Match before the generic "FROM commercial_unit" branch so every
+        # candidate resolves to neutral 50.0 momentum in these fixtures.
+        if "WITH district_counts AS" in sql:
+            return _Result([])
         # commercial_unit queries → return candidate rows
         if "FROM commercial_unit" in sql:
             return _Result(self.candidate_rows)


### PR DESCRIPTION
## Phase 3b: district momentum sub-signal in _listing_quality_score

### CEO directive addressed
> "Focus on areas that are actively attracting investors and businesses, rather than showing random or less relevant locations."

### What changed
- New helper `_district_momentum_score(db)` at `app/services/expansion_advisor.py:324`. Aggregates 30-day activity per district via a spatial join of `commercial_unit` points against `external_feature` polygons, with a two-layer priority chain (`osm_districts` first, `aqar_district_hulls` fallback) implemented as `DISTINCT ON (cu.aqar_id) ORDER BY CASE ef.layer_name`. Returns a 0-100 momentum score per qualifying district. `district_label` is Arabic from `ef.properties->>'district_raw'` — same key-space `normalize_district_key` uses on the scoring side, so lookups match by construction.
- `_listing_quality_score` gains a 5th sub-signal. Multiplicative rebalance preserves existing ratios exactly: freshness 0.2550 / suitability 0.3400 / image 0.1700 / furnished 0.0850 / momentum 0.1500.
- `_MOMENTUM_ENABLED` module toggle routes to pre-3b weights (0.30/0.40/0.20/0.10) when False — single-line revert without touching call sites.
- `feature_snapshot_json.district_momentum` added with full provenance (`momentum_score`, `activity_30d`, `active_in_district`, `percentile_raw`, `percentile_absolute`, `percentile_composite`, `district_label`, `sample_floor_applied`).
- Call sites wired at both scoring passes (preliminary `expansion_advisor.py:6026`, final `expansion_advisor.py:6731`). Final pass computes `district_norm_final` explicitly to avoid the pre-existing outer-loop binding leak.
- One-shot aggregation invoked adjacent to the existing `_precompute_district_delivery_stats` call; timing logged.

### What did NOT change
- Nine-component weight table (listing_quality stays at 11% of final_score).
- 3a freshness band cutoffs (14/30/60/120/240/365).
- `_FEATURE_SNAPSHOT_WHITELIST` in `app/services/llm_decision_memo.py`.
- Frontend, decision memo, rerank.
- Scraper, backfill, LLM classifier.

### DB verification (pre-implementation, Codespace psql, user-provided)

Spatial aggregation via `external_feature`:
- 39 qualifying districts at floor=20
- 1,680 active listings covered = 71.40% of active pool
- 1,420 activity_30d rows in qualifying districts
- Execution time: ~36ms (budget 250ms)
- `external_feature` layers used: `osm_districts` (priority 1), `aqar_district_hulls` (priority 2)

Earlier coverage datapoints that informed the final design:
- `aqar_created_at` coverage: 87.21%
- `aqar_updated_at` coverage: 87.21%
- Floor=20 via `candidate_location` join: 3 districts / 25.6% coverage — rejected
- Floor=20 via direct `commercial_unit` aggregation on `TRIM(neighborhood)`: 37 districts / 69.08% — rejected after `normalize_district_key` was shown to produce disjoint English vs Arabic key-spaces

### Key-space correctness

Scoring keys on `normalize_district_key(district)` where `district` is Arabic (primary pool `cl.district_ar` at `expansion_advisor.py:5568-5573`; fallback pool is spatially backfilled to Arabic at `expansion_advisor.py:5258-5291`). The helper now keys on the same Arabic string pulled from `external_feature.properties->>'district_raw'`. Match is structural. No translit step required.

### Expected impact (prediction)

- Max momentum swing on `final_score`: ±1.65 points (sub-weight 0.15 × listing_quality component weight 0.11 × 100-point max delta).
- Districts likely to rise: mid-density districts with high recent creates+updates (percentile_composite > 0.75).
- Districts likely to fall: stale-inventory districts (`activity_30d ≈ 0` with large active_in_district).
- ~29% of candidates go to neutral (sample floor, blank district label, scraper garbage, spatial miss).

### Test results

- Full in-sandbox suite: **217 passed** across `tests/test_expansion_advisor_regression.py`, `tests/test_expansion_advisor_service.py`, `tests/test_expansion_advisor_production_patch.py`, `tests/test_expansion_per_district_cap.py`.
- New tests added: **12**
  - `test_listing_quality_score_momentum_high_raises_composite`
  - `test_listing_quality_score_momentum_none_neutral` (composite = 46.60)
  - `test_listing_quality_score_momentum_below_floor_neutral`
  - `test_listing_quality_score_sub_weights_sum_to_one` (math.isclose)
  - `test_district_momentum_score_composite_math`
  - `test_district_momentum_score_sample_floor_excludes_below_20`
  - `test_district_momentum_score_zero_activity_low_score_not_error`
  - `test_district_momentum_score_blank_district_label_filtered`
  - `test_district_momentum_score_empty_dict_on_db_failure`
  - `test_district_momentum_blends_created_and_updated` (Correction 13)
  - `test_listing_quality_scoring_callsite_two_district_delta` (Correction 4, delta = 4.5)
  - `test_district_momentum_uses_external_feature_priority_chain` (DISTINCT ON + CASE priority)
- Updated tests: **5** (recomputed against multiplicative sub-weights 0.2550/0.3400/0.1700/0.0850/0.15 and passing `district_momentum_score=None` explicitly).
- Pre-existing environment failures out of scope: `test_expansion_advisor_phase3_chunk1.py`, `test_expansion_advisor_api.py`, `test_expansion_districts_api.py`, `test_expansion_branch_suggestions_api.py` all collect-fail on missing `psycopg` / `httpx` on this sandbox — confirmed identical outcome on the pre-3b tree.

### Rollback

Three-tiered:
1. `git revert` the three commits on this branch.
2. Toggle `_MOMENTUM_ENABLED = False` in `app/services/expansion_advisor.py` (keeps code in place, restores pre-3b weights, ignores `district_momentum_score`).
3. Manual: remove the momentum term from `_listing_quality_score` and revert to the pre-3b `0.30/0.40/0.20/0.10` tuple.

### Deviations & suggestions

- **Correction 5 arithmetic typo**: the spec's cited expected values (42.35, 55.10) do not match the formula it specifies with weights (0.2550, 0.3400, 0.1700, 0.0850, 0.15). The formula yields 46.60 and 59.35 respectively. Per Correction 5's explicit "verify every test's expected-value arithmetic against the multiplicative weights before committing" instruction, the formula-derived values are used in the updated tests.
- **Correction 9 first-pass bug caught before merge**: the original Correction 9 `TRIM(neighborhood)` aggregation produced English-namespace keys while scoring consumed Arabic-namespace keys. Flagged via the Correction 10 cross-namespace check; user-provided revision switched to `external_feature` spatial aggregation which is what this PR ships. Three commits on this branch trace the remediation: `661a32e48` (original helper), `b750f9ff6` (tests), `1b97b3e87` (SQL switch to spatial join + priority-chain test).
- **Proportional-rebalance wording**: decision text says "reduce each sub-weight by (new_momentum_sub_weight / 4) so their relative ratios are preserved." Additive subtraction preserves differences, not ratios; multiplicative scaling by 0.85 preserves ratios. This PR uses the multiplicative form per Correction 1.

No auto-merge.

https://claude.ai/code/session_016ktFxqKVTeUH9A48bxrQ5w