### PR TITLE
Add immediate-close sweep for unseen listings

### DIFF
--- a/scripts/scrape_aqar.py
+++ b/scripts/scrape_aqar.py
@@ -1616,6 +1616,69 @@ def mark_stale_listings(db, type_keys: list[str] | None = None) -> int:
     return result.rowcount
 
 
+# Coverage floor for the per-run immediate-close sweep: require that the
+# scrape saw at least this fraction of the currently-active pool for the
+# type before we trust a "not seen this run" signal to mean "closed". A
+# broken crawl (e.g. Aqar HTML layout change) that returns only a handful
+# of listings must not be allowed to nuke the whole pool — in that case
+# we fall back to the 28-day ``mark_stale_listings`` safety net.
+_IMMEDIATE_CLOSE_MIN_COVERAGE = 0.5
+
+
+def mark_unseen_listings_closed(
+    db,
+    type_key: str,
+    seen_aqar_ids: set[str],
+    min_coverage: float = _IMMEDIATE_CLOSE_MIN_COVERAGE,
+) -> int:
+    """Flip active listings of ``type_key`` whose ``aqar_id`` was not seen in
+    the current scrape to ``status = 'stale'``. Lets closed listings drop
+    from the downstream shortlist on the same day instead of waiting the
+    28-day stale-marker window.
+
+    Returns the number of rows flipped to ``'stale'``, or ``-1`` when the
+    coverage guard tripped and the sweep was skipped.
+    """
+    from sqlalchemy import text as sa_text
+
+    active_count = db.execute(
+        sa_text(
+            "SELECT COUNT(*) FROM commercial_unit "
+            "WHERE status = 'active' AND listing_type = :lt"
+        ),
+        {"lt": type_key},
+    ).scalar() or 0
+
+    if active_count == 0:
+        return 0
+
+    coverage = len(seen_aqar_ids) / active_count
+    if coverage < min_coverage:
+        logger.warning(
+            "Skipping immediate-close sweep for %s: only %d of %d currently-active "
+            "listings were seen (%.1f%% < %.0f%% coverage floor). Falling back to "
+            "the %d-day stale marker.",
+            type_key,
+            len(seen_aqar_ids),
+            active_count,
+            coverage * 100,
+            min_coverage * 100,
+            _STALE_DAYS,
+        )
+        return -1
+
+    result = db.execute(
+        sa_text(
+            "UPDATE commercial_unit SET status = 'stale' "
+            "WHERE status = 'active' "
+            "  AND listing_type = :lt "
+            "  AND aqar_id <> ALL(:seen_ids)"
+        ),
+        {"lt": type_key, "seen_ids": list(seen_aqar_ids)},
+    )
+    return result.rowcount
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -1931,6 +1994,21 @@ def main():
 
                 if db and not args.dry_run:
                     db.commit()
+
+            # Immediate-close sweep: flip listings of this type that Aqar did
+            # not return in this run to 'stale' right away, so closed listings
+            # drop from the downstream candidate_location rebuild on the same
+            # day rather than lingering for the 28-day stale-marker window.
+            # Coverage-guarded inside mark_unseen_listings_closed() to avoid
+            # a broken crawl wiping the whole pool.
+            if db and not args.dry_run and not args.list_only:
+                closed = mark_unseen_listings_closed(db, type_key, seen_aqar_ids)
+                db.commit()
+                if closed > 0:
+                    print(
+                        f"  Marked {closed} {type_key} listings as closed "
+                        f"(not seen in this run)"
+                    )
 
             logger.info(
                 "Type %s done: scraped=%d, skipped_existing=%d, insert=%d, update=%d",

--- a/tests/test_scrape_aqar.py
+++ b/tests/test_scrape_aqar.py
@@ -282,3 +282,79 @@ class TestParseAreaTelemetryCounters:
         _parse_area_token("14,285 m²", listing_type="store")
         assert _area_parse_stats["attempted"] == 1
         assert _area_parse_stats["rejected_decimal_fallback_too_small"] == 1
+
+
+class _FakeResult:
+    def __init__(self, scalar_value=None, rowcount=0):
+        self._scalar = scalar_value
+        self.rowcount = rowcount
+
+    def scalar(self):
+        return self._scalar
+
+
+class _FakeDB:
+    """Records execute() calls and returns canned results in order."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls: list[tuple[str, dict]] = []
+
+    def execute(self, stmt, params=None):
+        self.calls.append((str(stmt), dict(params or {})))
+        return self._results.pop(0)
+
+
+class TestMarkUnseenListingsClosed:
+    """Immediate-close sweep: closed aqar listings drop same-day, not in 28."""
+
+    def test_flips_unseen_listings_to_stale_when_coverage_ok(self):
+        from scripts.scrape_aqar import mark_unseen_listings_closed
+
+        db = _FakeDB([_FakeResult(scalar_value=100), _FakeResult(rowcount=7)])
+        seen = {f"id_{i}" for i in range(80)}  # 80/100 = 80% coverage
+
+        closed = mark_unseen_listings_closed(db, "store", seen)
+
+        assert closed == 7
+        assert len(db.calls) == 2
+        count_sql, count_params = db.calls[0]
+        assert "SELECT COUNT(*)" in count_sql
+        assert count_params == {"lt": "store"}
+        update_sql, update_params = db.calls[1]
+        assert "UPDATE commercial_unit SET status = 'stale'" in update_sql
+        assert update_params["lt"] == "store"
+        assert set(update_params["seen_ids"]) == seen
+
+    def test_coverage_guard_skips_sweep_when_crawl_looks_broken(self):
+        from scripts.scrape_aqar import mark_unseen_listings_closed
+
+        db = _FakeDB([_FakeResult(scalar_value=1000)])
+        seen = {f"id_{i}" for i in range(10)}  # 10/1000 = 1% coverage
+
+        closed = mark_unseen_listings_closed(db, "store", seen)
+
+        assert closed == -1
+        assert len(db.calls) == 1  # only the COUNT, no UPDATE issued
+
+    def test_zero_active_pool_is_noop(self):
+        from scripts.scrape_aqar import mark_unseen_listings_closed
+
+        db = _FakeDB([_FakeResult(scalar_value=0)])
+
+        closed = mark_unseen_listings_closed(db, "store", set())
+
+        assert closed == 0
+        assert len(db.calls) == 1
+
+    def test_full_coverage_with_all_unseen_closes_everything(self):
+        from scripts.scrape_aqar import mark_unseen_listings_closed
+
+        # Edge: scrape saw exactly as many listings as are currently active,
+        # but none of them overlap. All 50 active rows should close.
+        db = _FakeDB([_FakeResult(scalar_value=50), _FakeResult(rowcount=50)])
+        seen = {f"new_id_{i}" for i in range(50)}
+
+        closed = mark_unseen_listings_closed(db, "store", seen)
+
+        assert closed == 50


### PR DESCRIPTION
## Summary
Implement an immediate-close mechanism for real estate listings that are no longer returned by the Aqar scraper, allowing closed listings to drop from the downstream candidate pool on the same day rather than waiting the standard 28-day stale-marker window.

## Key Changes
- **New function `mark_unseen_listings_closed()`**: Flips active listings whose `aqar_id` was not seen in the current scrape to `status = 'stale'`. Includes a coverage guard (`_IMMEDIATE_CLOSE_MIN_COVERAGE = 0.5`) that prevents the sweep from running if the scrape coverage falls below 50%, protecting against broken crawls (e.g., HTML layout changes) that would otherwise nuke the entire pool.

- **Integration into main scrape loop**: Added immediate-close sweep call in the `main()` function after each listing type is processed. The sweep only runs when not in dry-run or list-only modes, and logs the number of listings marked as closed.

- **Comprehensive test coverage**: Added `TestMarkUnseenListingsClosed` test class with four test cases covering:
  - Normal operation when coverage is sufficient
  - Coverage guard activation when crawl appears broken
  - Edge case of zero active listings
  - Edge case of full coverage with complete turnover

## Implementation Details
- Uses SQLAlchemy's `text()` for raw SQL queries to handle the `<> ALL()` array comparison operator
- Returns `-1` when coverage guard trips (instead of 0) to distinguish between "nothing to close" and "sweep skipped"
- Includes detailed warning logs when coverage guard prevents the sweep, referencing the fallback 28-day stale marker
- Test infrastructure includes `_FakeDB` and `_FakeResult` helper classes to mock database interactions without requiring actual database setup

https://claude.ai/code/session_01CJUPbWXodoUEZUwjDLvFyp