### PR TITLE
Allow Premier tier for Aqar candidates with null overall_pass

### DIFF
--- a/frontend/src/features/expansion-advisor/tiers.test.ts
+++ b/frontend/src/features/expansion-advisor/tiers.test.ts
@@ -78,15 +78,27 @@ describe("classifyCandidateTier", () => {
     expect(classifyCandidateTier(c)).toBe("standard");
   });
 
-  it("Standard when overall_pass is null (unknown) even with grade A + high score", () => {
-    // Premier requires pass === true. Unknown falls through to Standard,
-    // not demoted to Exploratory.
+  it("Premier when overall_pass is null (unknown) with grade A + high score — unknown does not block", () => {
+    // Aqar Tier 1 candidates structurally have overall_pass = null because
+    // parking_pass is null (no parking ground truth for Aqar listings).
+    // Premier treats null as "not a blocker" so Tier 1 candidates can
+    // qualify. Explicit failure (overall_pass = false) still demotes to
+    // Exploratory via the precedence rule.
     const c = makeCandidate({
       confidence_grade: "A",
       final_score: 80,
       gate_status_json: { overall_pass: null },
     });
-    expect(classifyCandidateTier(c)).toBe("standard");
+    expect(classifyCandidateTier(c)).toBe("premier");
+  });
+
+  it("Premier with explicit overall_pass=true, grade A, high score — canonical path still works", () => {
+    const c = makeCandidate({
+      confidence_grade: "A",
+      final_score: 80,
+      gate_status_json: { overall_pass: true },
+    });
+    expect(classifyCandidateTier(c)).toBe("premier");
   });
 
   it("Standard at the exploratory boundary (score === EXPLORATORY_MAX_SCORE)", () => {

--- a/frontend/src/features/expansion-advisor/tiers.ts
+++ b/frontend/src/features/expansion-advisor/tiers.ts
@@ -43,11 +43,16 @@ export function classifyCandidateTier(candidate: ExpansionCandidate): CandidateT
     return "exploratory";
   }
 
-  // 2. Premier — all three signals must be positive. Null overall_pass
-  //    is treated as "not true" here (Premier is opt-in, not inferred).
+  // 2. Premier — grade A + score >= threshold, and the gate verdict is
+  //    not an explicit failure. Null overall_pass does not block Premier:
+  //    Aqar Tier 1 candidates structurally have overall_pass = null because
+  //    parking_pass is always null for them (no parking ground truth in
+  //    Aqar listings). Explicit failure (overall_pass === false) is already
+  //    routed to Exploratory by the precedence rule above, so the only
+  //    values that reach this branch are true and null.
   if (
     grade === PREMIER_CONFIDENCE_GRADE &&
-    overallPass === true &&
+    overallPass !== false &&
     typeof score === "number" &&
     score >= PREMIER_MIN_SCORE
   ) {


### PR DESCRIPTION
## Summary
Updated the Premier tier classification logic to treat `null` `overall_pass` values as non-blocking, allowing Aqar Tier 1 candidates to qualify for Premier tier. This accommodates the structural reality that Aqar listings have no parking ground truth data, resulting in `null` parking_pass values.

## Key Changes
- Modified the Premier tier condition from `overallPass === true` to `overallPass !== false`, allowing both `true` and `null` values to pass the gate check
- Updated the logic comment to explain that `null` is not a blocker for Premier qualification, while explicit `false` values are still routed to Exploratory via the precedence rule
- Added clarification that Aqar Tier 1 candidates structurally have `overall_pass = null` due to missing parking ground truth data

## Implementation Details
- The change maintains the existing precedence rule where explicit `overall_pass === false` still demotes candidates to Exploratory
- Only candidates with `overall_pass === true` or `null` can reach the Premier classification branch
- Added test case to verify the new behavior: candidates with grade A, high score, and `null` overall_pass now correctly classify as Premier
- Retained existing test case for the canonical path (explicit `overall_pass === true`)

https://claude.ai/code/session_01KtkJPTkRyGXRgips314vEH