### PR TITLE
Type gate_status_json with CandidateGateStatusJson interface

### DIFF
--- a/frontend/src/features/expansion-advisor/tiers.ts
+++ b/frontend/src/features/expansion-advisor/tiers.ts
@@ -43,16 +43,15 @@ export function classifyCandidateTier(candidate: ExpansionCandidate): CandidateT
     return "exploratory";
   }
 
-  // 2. Premier — grade A + score >= threshold, and the gate verdict is
-  //    not an explicit failure. Null overall_pass does not block Premier:
-  //    Aqar Tier 1 candidates structurally have overall_pass = null because
-  //    parking_pass is always null for them (no parking ground truth in
-  //    Aqar listings). Explicit failure (overall_pass === false) is already
-  //    routed to Exploratory by the precedence rule above, so the only
-  //    values that reach this branch are true and null.
+  // 2. Premier — grade A + score >= threshold. Null overall_pass does not
+  //    block Premier: Aqar Tier 1 candidates structurally have
+  //    overall_pass = null because parking_pass is always null for them
+  //    (no parking ground truth in Aqar listings). Explicit failure
+  //    (overall_pass === false) is already routed to Exploratory by the
+  //    precedence rule above, so the only values that reach this branch
+  //    are true and null — no need to recheck the gate here.
   if (
     grade === PREMIER_CONFIDENCE_GRADE &&
-    overallPass !== false &&
     typeof score === "number" &&
     score >= PREMIER_MIN_SCORE
   ) {

--- a/frontend/src/lib/api/expansionAdvisor.ts
+++ b/frontend/src/lib/api/expansionAdvisor.ts
@@ -50,6 +50,24 @@ export type CandidateGateReasons = {
   explanations: Record<string, unknown>;
 };
 
+// Per-gate verdicts are tri-state at runtime: true (pass), false (fail),
+// or null (unknown — the gate couldn't be evaluated, e.g. parking_pass
+// for Aqar listings with no parking ground truth). The backend's
+// `_candidate_gate_status` emits all three values, so each field is
+// `boolean | null` rather than the narrower `true | null`.
+export type CandidateGateStatusJson = {
+  overall_pass?: boolean | null;
+  zoning_fit_pass?: boolean | null;
+  area_fit_pass?: boolean | null;
+  frontage_access_pass?: boolean | null;
+  parking_pass?: boolean | null;
+  district_pass?: boolean | null;
+  cannibalization_pass?: boolean | null;
+  delivery_market_pass?: boolean | null;
+  economics_pass?: boolean | null;
+  [key: string]: boolean | null | undefined;
+};
+
 export type CandidateFeatureSnapshot = {
   context_sources: Record<string, unknown>;
   missing_context: string[];
@@ -157,7 +175,7 @@ export type ExpansionCandidate = {
   estimated_fitout_cost_sar?: number;
   estimated_revenue_index?: number;
   decision_summary?: string;
-  gate_status_json?: Record<string, boolean | null | undefined>;
+  gate_status_json?: CandidateGateStatusJson;
   gate_reasons_json?: CandidateGateReasons;
   feature_snapshot_json?: CandidateFeatureSnapshot;
   score_breakdown_json?: CandidateScoreBreakdown;
@@ -244,7 +262,7 @@ export type CompareCandidateItem = {
   final_score?: number;
   confidence_grade?: string;
   gate_verdict?: string;
-  gate_status_json?: Record<string, boolean | null | undefined>;
+  gate_status_json?: CandidateGateStatusJson;
   gate_reasons_json?: CandidateGateReasons;
   feature_snapshot_json?: CandidateFeatureSnapshot;
   score_breakdown_json?: CandidateScoreBreakdown;


### PR DESCRIPTION
## Summary
Introduced a new `CandidateGateStatusJson` type to replace the generic `Record<string, boolean | null | undefined>` type used for gate status fields. This improves type safety and documentation while also simplifying gate verdict logic.

## Key Changes
- **New Type Definition**: Created `CandidateGateStatusJson` interface that explicitly defines all gate verdict fields (overall_pass, zoning_fit_pass, area_fit_pass, etc.) with `boolean | null` values, plus an index signature for extensibility
- **Type Refinement**: Updated `gate_status_json` field in both `ExpansionCandidate` and `CompareCandidateItem` types to use the new interface instead of generic Record type
- **Logic Simplification**: Removed redundant `overallPass !== false` check in `classifyCandidateTier()` function since explicit failures are already filtered by precedence rules, and null values are intentionally allowed for Premier tier candidates
- **Documentation**: Added comprehensive comment explaining the tri-state nature of gate verdicts (true/false/null) and why null values are valid for certain candidate types like Aqar listings

## Implementation Details
The tri-state gate verdict system allows gates to be:
- `true`: gate passed
- `false`: gate failed (explicit rejection)
- `null`: gate couldn't be evaluated (e.g., parking_pass for Aqar listings without parking ground truth)

This is particularly important for Aqar Tier 1 candidates which structurally have `overall_pass = null` due to missing parking data, but should still qualify for Premier tier if they meet other criteria.

https://claude.ai/code/session_013YFmEvJpZ93tG2uMDppmhE