### PR TITLE
Trust derived parking_score for listings in expansion advisor

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -2428,7 +2428,7 @@ def _candidate_gate_status(
     landuse_available: bool,
     frontage_score: float,
     access_score: float,
-    parking_score: float,
+    parking_score: float | None,
     district: str | None,
     distance_to_nearest_branch_m: float | None,
     provider_density_score: float,
@@ -2488,16 +2488,21 @@ def _candidate_gate_status(
         frontage_access_pass: bool | None = None
     else:
         frontage_access_pass = (frontage_score >= thresholds["frontage_access_min"]) and (access_score >= thresholds["frontage_access_min"])
-    # Parking gate: tri-state for listings.
-    # Aqar publishes no parking ground truth on units. Bulk OSM parking
-    # enrichment is about the surrounding neighborhood, not the listing
-    # itself, so it cannot substitute. For listings, always mark parking
-    # as unknown — failing a listing on a low parking score is penalizing
-    # operators for data we structurally cannot get.
-    if is_listing:
-        parking_pass: bool | None = None
+    # parking_pass — trust the derived parking_score when it's populated.
+    # For Aqar listings, Aqar doesn't expose a structured parking field
+    # (their template only has Water/Electricity/Drainage), so the verdict
+    # has historically been None. But the scorer already derives a parking
+    # context from nearby OSM parking amenities and street-width signals,
+    # and that score is populated on virtually all candidates. Treating that
+    # score as ground truth for the gate lets overall_pass resolve to a
+    # real true/false verdict instead of being stuck at null.
+    parking_pass: bool | None
+    if parking_score is None:
+        parking_pass = None
+    elif parking_score >= thresholds["parking_min"]:
+        parking_pass = True
     else:
-        parking_pass = parking_score >= thresholds["parking_min"]
+        parking_pass = False
 
     district_norm = normalize_district_key(district) if district else None
     excluded = {
@@ -2605,11 +2610,7 @@ def _candidate_gate_status(
             if frontage_access_pass is None and is_listing
             else "Frontage/access gate depends on road context and road-adjacent signals."
         ),
-        "parking_pass": (
-            "Parking context is not available for Aqar listings — cannot evaluate."
-            if parking_pass is None and is_listing
-            else "Parking gate depends on nearby parking amenity context and parcel suitability."
-        ),
+        "parking_pass": "Parking context is derived from nearby parking amenities and street geometry; passes when derived score meets the minimum threshold.",
         "district_pass": "District gate fails only for explicitly excluded districts.",
         "cannibalization_pass": "Cannibalization gate checks minimum spacing from existing branches.",
         "delivery_market_pass": delivery_explanation,

--- a/tests/test_expansion_advisor.py
+++ b/tests/test_expansion_advisor.py
@@ -831,6 +831,64 @@ def test_candidate_gate_status_blocking_failure_on_low_fit():
     assert len(reasons["blocking_failures"]) > 0
 
 
+# ---------------------------------------------------------------------------
+# parking_pass trusts derived parking_score (Aqar listings)
+# ---------------------------------------------------------------------------
+
+_PARKING_GATE_KWARGS = dict(
+    fit_score=78.0,
+    area_fit_score=82.0,
+    area_m2=200.0,
+    min_area_m2=100.0,
+    max_area_m2=500.0,
+    zoning_fit_score=88.0,
+    landuse_available=True,
+    frontage_score=70.0,
+    access_score=70.0,
+    district="Al Olaya",
+    distance_to_nearest_branch_m=3200.0,
+    provider_density_score=60.0,
+    multi_platform_presence_score=40.0,
+    economics_score=70.0,
+    brand_profile={"primary_channel": "balanced"},
+    road_context_available=True,
+    parking_context_available=True,
+    is_listing=True,
+    unit_street_width_m=12.0,
+)
+
+
+def test_parking_pass_true_when_score_above_threshold_for_listing():
+    """Aqar listings with parking_score >= 45 now pass the parking gate
+    instead of being stuck at None."""
+    gate_status, reasons = _candidate_gate_status(
+        **_PARKING_GATE_KWARGS, parking_score=60.0,
+    )
+    assert gate_status["parking_pass"] is True
+    assert "parking_pass" in reasons["passed"]
+
+
+def test_parking_pass_false_when_score_below_threshold_for_listing():
+    """Aqar listings with parking_score < 45 fail the parking gate as an
+    advisory failure (not a blocking failure)."""
+    gate_status, reasons = _candidate_gate_status(
+        **_PARKING_GATE_KWARGS, parking_score=30.0,
+    )
+    assert gate_status["parking_pass"] is False
+    assert "parking_pass" in reasons["failed"]
+    assert "parking_pass" in reasons["advisory_failures"]
+    assert "parking_pass" not in reasons["blocking_failures"]
+
+
+def test_parking_pass_none_when_score_missing_for_listing():
+    """When parking_score is None (no context), parking_pass stays None."""
+    gate_status, reasons = _candidate_gate_status(
+        **_PARKING_GATE_KWARGS, parking_score=None,
+    )
+    assert gate_status["parking_pass"] is None
+    assert "parking_pass" in reasons["unknown"]
+
+
 def test_smoke():
     assert True
 


### PR DESCRIPTION
## Summary
Changed the parking gate logic to trust the derived `parking_score` for Aqar listings instead of always marking it as unknown. This allows the overall expansion advisor verdict to resolve to a definitive true/false instead of remaining null.

## Key Changes
- **Updated parking_pass logic**: Changed from always returning `None` for listings to evaluating the derived `parking_score` against the minimum threshold (45)
  - `parking_score >= 45` → `parking_pass = True` (passes)
  - `parking_score < 45` → `parking_pass = False` (advisory failure, not blocking)
  - `parking_score = None` → `parking_pass = None` (unknown)

- **Made parking_score parameter nullable**: Updated type signature from `float` to `float | None` to properly handle cases where parking context is unavailable

- **Updated gate explanation**: Simplified the parking_pass explanation to reflect that the derived score from nearby parking amenities and street geometry is now trusted as ground truth for listings

- **Added comprehensive test coverage**: Three new tests validate the three states of parking_pass for listings:
  - `test_parking_pass_true_when_score_above_threshold_for_listing`: Verifies passing case
  - `test_parking_pass_false_when_score_below_threshold_for_listing`: Verifies advisory failure case
  - `test_parking_pass_none_when_score_missing_for_listing`: Verifies unknown case

## Implementation Details
The scorer already derives parking context from nearby OSM parking amenities and street-width signals, and this score is populated on virtually all candidates. By treating this derived score as ground truth for the gate, listings can now achieve a definitive expansion advisor verdict rather than being stuck at null due to lack of structured parking data in Aqar's template.

https://claude.ai/code/session_01SYbWqHxmFqatwrWdo1Buy2