### PR TITLE
Hide advanced geography section in expansion brief form

### DIFF
--- a/frontend/src/features/expansion-advisor/ExpansionBriefForm.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionBriefForm.tsx
@@ -6,6 +6,14 @@ import CategorySelect from "./CategorySelect";
 import DistrictMultiSelect from "./DistrictMultiSelect";
 import BranchLocationPicker from "./BranchLocationPicker";
 
+// Hide the Advanced "GEOGRAPHY" section (preferred/excluded districts).
+// Target districts in the main brief body is the operator's real lever;
+// preferred/excluded contribute only a ~±0.55 overall-score nudge via
+// _brand_fit_score and are redundant with the hard target_districts filter.
+// Backend schema, persistence, and scoring are untouched — defaults to []
+// keep the payload contract intact. Flip to `true` to re-expose.
+const SHOW_ADVANCED_GEOGRAPHY_SECTION = false;
+
 export const defaultBrief: ExpansionBrief = {
   brand_name: "",
   category: "",
@@ -320,33 +328,35 @@ export default function ExpansionBriefForm({ initialValue, onSubmit, loading }: 
           </div>
 
           {/* Preferred / excluded districts */}
-          <div className="ea-form__section">
-            <h4 className="ea-form__section-title">{t("expansionAdvisor.geography")}</h4>
-            <div className="ea-form__row">
-              <div className="ea-form__field">
-                <label className="ea-form__label">{t("expansionAdvisor.preferredDistricts")}</label>
-                <DistrictMultiSelect
-                  options={districtOptions}
-                  selected={brief.brand_profile?.preferred_districts || []}
-                  onChange={(vals) => setProfile("preferred_districts", vals)}
-                  disabled={loading}
-                  placeholder={t("expansionAdvisor.preferredDistricts")}
-                  conflictValues={brief.brand_profile?.excluded_districts || []}
-                />
-              </div>
-              <div className="ea-form__field">
-                <label className="ea-form__label">{t("expansionAdvisor.excludedDistricts")}</label>
-                <DistrictMultiSelect
-                  options={districtOptions}
-                  selected={brief.brand_profile?.excluded_districts || []}
-                  onChange={(vals) => setProfile("excluded_districts", vals)}
-                  disabled={loading}
-                  placeholder={t("expansionAdvisor.excludedDistricts")}
-                  conflictValues={brief.brand_profile?.preferred_districts || []}
-                />
+          {SHOW_ADVANCED_GEOGRAPHY_SECTION && (
+            <div className="ea-form__section">
+              <h4 className="ea-form__section-title">{t("expansionAdvisor.geography")}</h4>
+              <div className="ea-form__row">
+                <div className="ea-form__field">
+                  <label className="ea-form__label">{t("expansionAdvisor.preferredDistricts")}</label>
+                  <DistrictMultiSelect
+                    options={districtOptions}
+                    selected={brief.brand_profile?.preferred_districts || []}
+                    onChange={(vals) => setProfile("preferred_districts", vals)}
+                    disabled={loading}
+                    placeholder={t("expansionAdvisor.preferredDistricts")}
+                    conflictValues={brief.brand_profile?.excluded_districts || []}
+                  />
+                </div>
+                <div className="ea-form__field">
+                  <label className="ea-form__label">{t("expansionAdvisor.excludedDistricts")}</label>
+                  <DistrictMultiSelect
+                    options={districtOptions}
+                    selected={brief.brand_profile?.excluded_districts || []}
+                    onChange={(vals) => setProfile("excluded_districts", vals)}
+                    disabled={loading}
+                    placeholder={t("expansionAdvisor.excludedDistricts")}
+                    conflictValues={brief.brand_profile?.preferred_districts || []}
+                  />
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary
Hide the Advanced "GEOGRAPHY" section (preferred/excluded districts) in the Expansion Brief Form behind a feature flag. The section can be re-exposed by toggling `SHOW_ADVANCED_GEOGRAPHY_SECTION` to `true`.

## Key Changes
- Added `SHOW_ADVANCED_GEOGRAPHY_SECTION` constant (set to `false`) to control visibility of the geography section
- Wrapped the preferred/excluded districts form section with a conditional render based on the feature flag
- Added detailed inline comment explaining the rationale: target districts in the main brief body is the primary lever, while preferred/excluded districts only contribute a ~±0.55 overall-score nudge and are redundant with the hard `target_districts` filter

## Implementation Details
- Backend schema, persistence, and scoring remain untouched
- The form payload contract is preserved (defaults to empty arrays `[]`)
- No functional changes to the form logic or data handling
- This is a UI-only change that allows easy re-exposure of the feature without code modifications

https://claude.ai/code/session_01XoDUFTMYvjFs1Wft7KcRiM