### PR TITLE
Fix score bar rendering for string-serialized numeric values

### DIFF
--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.test.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.test.tsx
@@ -629,4 +629,86 @@ describe("ExpansionMemoPanel — Breakdown tab content (initialTab='breakdown')"
     expect(html).toContain("width:50%");
     expect(html).toContain("width:100%");
   });
+
+  // Backend serializes SQLAlchemy Numeric columns as strings
+  // (e.g. "45.00") for precision. The Breakdown tab must coerce these
+  // strings into numbers before guarding the score bars.
+  it("renders score bars when numeric fields arrive as strings (Decimal-as-string serialization)", () => {
+    const memo = richBreakdownMemo() as any;
+    memo.candidate.parking_score = "45.00";
+    memo.candidate.frontage_score = "94.00";
+    memo.candidate.access_score = "90.00";
+    memo.candidate.access_visibility_score = "70.00";
+    memo.candidate.zoning_fit_score = "88.00";
+    memo.candidate.provider_density_score = "55.00";
+    memo.candidate.provider_whitespace_score = "60.00";
+    memo.candidate.multi_platform_presence_score = "45.00";
+    memo.candidate.delivery_competition_score = "40.00";
+    memo.candidate.cannibalization_score = "90.00";
+    const html = renderToStaticMarkup(
+      <ExpansionMemoPanel loading={false} memo={memo} initialTab="breakdown" />,
+    );
+    expect(html).toContain(en.expansionAdvisor.parkingScore);
+    expect(html).toContain(en.expansionAdvisor.frontageScore);
+    expect(html).toContain(en.expansionAdvisor.accessScore);
+    // The "Access & visibility" label is HTML-encoded by renderToStaticMarkup.
+    expect(html).toContain(en.expansionAdvisor.accessVisibility.replace("&", "&amp;"));
+    expect(html).toContain(en.expansionAdvisor.zoningFitScore);
+    expect(html).toContain(en.expansionAdvisor.providerDensity);
+    expect(html).toContain(en.expansionAdvisor.providerWhitespace);
+    expect(html).toContain(en.expansionAdvisor.multiPlatform);
+    expect(html).toContain(en.expansionAdvisor.deliveryCompetition);
+    expect(html).toContain(en.expansionAdvisor.cannibalization);
+    // Rounded values appear in the bar heads.
+    expect(html).toMatch(/>45</); // parking
+    expect(html).toMatch(/>94</); // frontage
+    expect(html).toMatch(/>90</); // access / cannibalization
+    // aria-valuenow on the progressbar reflects the parsed numeric.
+    expect(html).toMatch(/aria-valuenow="45"/);
+    expect(html).toMatch(/aria-valuenow="94"/);
+  });
+
+  it("hides score bars when numeric fields arrive as unparseable strings", () => {
+    const memo = richBreakdownMemo() as any;
+    memo.candidate.parking_score = "N/A";
+    memo.candidate.frontage_score = "";
+    memo.candidate.access_score = "—";
+    memo.candidate.access_visibility_score = null;
+    memo.candidate.zoning_fit_score = undefined;
+    memo.candidate.provider_density_score = "N/A";
+    memo.candidate.provider_whitespace_score = "";
+    memo.candidate.multi_platform_presence_score = null;
+    memo.candidate.delivery_competition_score = undefined;
+    memo.candidate.cannibalization_score = "—";
+    const html = renderToStaticMarkup(
+      <ExpansionMemoPanel loading={false} memo={memo} initialTab="breakdown" />,
+    );
+    // None of the per-axis score-bar labels should render.
+    expect(html).not.toContain(en.expansionAdvisor.parkingScore);
+    expect(html).not.toContain(en.expansionAdvisor.frontageScore);
+    expect(html).not.toContain(en.expansionAdvisor.accessScore);
+    expect(html).not.toContain(en.expansionAdvisor.accessVisibility.replace("&", "&amp;"));
+    expect(html).not.toContain(en.expansionAdvisor.zoningFitScore);
+    expect(html).not.toContain(en.expansionAdvisor.providerDensity);
+    expect(html).not.toContain(en.expansionAdvisor.providerWhitespace);
+    expect(html).not.toContain(en.expansionAdvisor.multiPlatform);
+    expect(html).not.toContain(en.expansionAdvisor.deliveryCompetition);
+    expect(html).not.toContain(en.expansionAdvisor.cannibalization);
+  });
+
+  it("ScoreBar head visually separates label and value (flex space-between)", () => {
+    const memo = richBreakdownMemo() as any;
+    const html = renderToStaticMarkup(
+      <ExpansionMemoPanel loading={false} memo={memo} initialTab="breakdown" />,
+    );
+    // The head wrapper carries flex+space-between so label and value
+    // never collide visually (no more "District momentum38").
+    const headIdx = html.indexOf("ea-score-bar__head");
+    expect(headIdx).toBeGreaterThan(-1);
+    // Look at the head element's style attribute — it should request
+    // flex layout with space-between.
+    const headSnippet = html.slice(headIdx, headIdx + 400);
+    expect(headSnippet).toMatch(/display:\s*flex/);
+    expect(headSnippet).toMatch(/justify-content:\s*space-between/);
+  });
 });

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
@@ -467,6 +467,27 @@ export default function ExpansionMemoPanel({
                             is null/undefined/empty (no "—" fallback), so the
                             tab adapts to data availability per candidate. */}
                         {activeTab === "breakdown" && (() => {
+                          // Backend serializes SQLAlchemy Numeric columns as strings
+                          // (e.g. "45.00") for precision. Coerce here so the
+                          // typeof-number guard below doesn't silently hide bars.
+                          const toNumber = (v: unknown): number | null => {
+                            if (typeof v === "number" && Number.isFinite(v)) return v;
+                            if (typeof v === "string") {
+                              const n = parseFloat(v);
+                              return Number.isFinite(n) ? n : null;
+                            }
+                            return null;
+                          };
+                          const parkingScore = toNumber(cand.parking_score);
+                          const frontageScore = toNumber(cand.frontage_score);
+                          const accessScore = toNumber(cand.access_score);
+                          const accessVisibilityScore = toNumber(cand.access_visibility_score);
+                          const zoningFitScore = toNumber(cand.zoning_fit_score);
+                          const providerDensityScore = toNumber(cand.provider_density_score);
+                          const providerWhitespaceScore = toNumber(cand.provider_whitespace_score);
+                          const multiPlatformPresenceScore = toNumber(cand.multi_platform_presence_score);
+                          const deliveryCompetitionScore = toNumber(cand.delivery_competition_score);
+                          const cannibalizationScore = toNumber(cand.cannibalization_score);
                           const ctxSources = (snapshot?.context_sources || {}) as Record<string, unknown>;
                           const roadBand = typeof ctxSources.road_evidence_band === "string" ? ctxSources.road_evidence_band : null;
                           const parkingBand = typeof ctxSources.parking_evidence_band === "string" ? ctxSources.parking_evidence_band : null;
@@ -534,11 +555,11 @@ export default function ExpansionMemoPanel({
                                 <h5 className="ea-detail__section-title">{t("expansionAdvisor.breakdownSiteGrade")}</h5>
                                 <p className="ea-memo-breakdown__explainer" style={{ fontSize: "var(--oak-fs-xs)", color: "var(--oak-text-light)", marginTop: 0, marginBottom: 8 }}>{t("expansionAdvisor.breakdownSiteGradeExplainer")}</p>
                                 <div className="ea-memo-breakdown__bars" style={{ display: "grid", gap: 8 }}>
-                                  {typeof cand.parking_score === "number" && <ScoreBar label={t("expansionAdvisor.parkingScore")} value={cand.parking_score as number} />}
-                                  {typeof cand.frontage_score === "number" && <ScoreBar label={t("expansionAdvisor.frontageScore")} value={cand.frontage_score as number} />}
-                                  {typeof cand.access_score === "number" && <ScoreBar label={t("expansionAdvisor.accessScore")} value={cand.access_score as number} />}
-                                  {typeof cand.access_visibility_score === "number" && <ScoreBar label={t("expansionAdvisor.accessVisibility")} value={cand.access_visibility_score as number} />}
-                                  {typeof cand.zoning_fit_score === "number" && <ScoreBar label={t("expansionAdvisor.zoningFitScore")} value={cand.zoning_fit_score as number} />}
+                                  {parkingScore !== null && <ScoreBar label={t("expansionAdvisor.parkingScore")} value={parkingScore} />}
+                                  {frontageScore !== null && <ScoreBar label={t("expansionAdvisor.frontageScore")} value={frontageScore} />}
+                                  {accessScore !== null && <ScoreBar label={t("expansionAdvisor.accessScore")} value={accessScore} />}
+                                  {accessVisibilityScore !== null && <ScoreBar label={t("expansionAdvisor.accessVisibility")} value={accessVisibilityScore} />}
+                                  {zoningFitScore !== null && <ScoreBar label={t("expansionAdvisor.zoningFitScore")} value={zoningFitScore} />}
                                 </div>
                                 {(roadBand || parkingBand) && (
                                   <div className="ea-detail__grid" style={{ marginTop: 10 }}>
@@ -563,11 +584,11 @@ export default function ExpansionMemoPanel({
                                 <h5 className="ea-detail__section-title">{t("expansionAdvisor.breakdownMarketSignals")}</h5>
                                 <p className="ea-memo-breakdown__explainer" style={{ fontSize: "var(--oak-fs-xs)", color: "var(--oak-text-light)", marginTop: 0, marginBottom: 8 }}>{t("expansionAdvisor.breakdownMarketSignalsExplainer")}</p>
                                 <div className="ea-memo-breakdown__bars" style={{ display: "grid", gap: 8 }}>
-                                  {typeof cand.provider_density_score === "number" && <ScoreBar label={t("expansionAdvisor.providerDensity")} value={cand.provider_density_score as number} />}
-                                  {typeof cand.provider_whitespace_score === "number" && <ScoreBar label={t("expansionAdvisor.providerWhitespace")} value={cand.provider_whitespace_score as number} />}
-                                  {typeof cand.multi_platform_presence_score === "number" && <ScoreBar label={t("expansionAdvisor.multiPlatform")} value={cand.multi_platform_presence_score as number} />}
-                                  {typeof cand.delivery_competition_score === "number" && <ScoreBar label={t("expansionAdvisor.deliveryCompetition")} value={cand.delivery_competition_score as number} />}
-                                  {typeof cand.cannibalization_score === "number" && <ScoreBar label={t("expansionAdvisor.cannibalization")} value={cand.cannibalization_score as number} />}
+                                  {providerDensityScore !== null && <ScoreBar label={t("expansionAdvisor.providerDensity")} value={providerDensityScore} />}
+                                  {providerWhitespaceScore !== null && <ScoreBar label={t("expansionAdvisor.providerWhitespace")} value={providerWhitespaceScore} />}
+                                  {multiPlatformPresenceScore !== null && <ScoreBar label={t("expansionAdvisor.multiPlatform")} value={multiPlatformPresenceScore} />}
+                                  {deliveryCompetitionScore !== null && <ScoreBar label={t("expansionAdvisor.deliveryCompetition")} value={deliveryCompetitionScore} />}
+                                  {cannibalizationScore !== null && <ScoreBar label={t("expansionAdvisor.cannibalization")} value={cannibalizationScore} />}
                                   {!dmSampleFloor && dmScore !== null && <ScoreBar label={t("expansionAdvisor.districtMomentumScore")} value={dmScore} />}
                                 </div>
                                 {dmSampleFloor ? (

--- a/frontend/src/features/expansion-advisor/ScoreBar.tsx
+++ b/frontend/src/features/expansion-advisor/ScoreBar.tsx
@@ -13,9 +13,36 @@ export default function ScoreBar({ label, value }: ScoreBarProps) {
   const clamped = numeric == null ? 0 : Math.max(0, Math.min(100, numeric));
   return (
     <div className="ea-score-bar">
-      <div className="ea-score-bar__head">
-        <span className="ea-score-bar__label">{label}</span>
-        <span className="ea-score-bar__value">{numeric == null ? "" : Math.round(numeric)}</span>
+      <div
+        className="ea-score-bar__head"
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          gap: 8,
+          marginBottom: 4,
+        }}
+      >
+        <span
+          className="ea-score-bar__label"
+          style={{
+            fontSize: "var(--oak-fs-xs, 12px)",
+            color: "var(--oak-text-light, #828282)",
+            fontWeight: "var(--oak-fw-medium, 500)",
+          }}
+        >
+          {label}
+        </span>
+        <span
+          className="ea-score-bar__value"
+          style={{
+            fontSize: "var(--oak-fs-sm, 14px)",
+            fontWeight: "var(--oak-fw-semibold, 600)",
+            color: "var(--oak-text-dark, #171717)",
+          }}
+        >
+          {numeric == null ? "" : Math.round(numeric)}
+        </span>
       </div>
       <div
         className="ea-score-bar__track"


### PR DESCRIPTION
## Summary
Fixed the Expansion Advisor's Breakdown tab to properly handle numeric score fields that arrive from the backend as strings (e.g., "45.00") due to SQLAlchemy Decimal serialization. Previously, these string values were silently hidden because the component only checked for `typeof === "number"`. The fix also improves the visual layout of score bars to prevent label-value collisions.

## Key Changes

- **Added numeric coercion logic** in `ExpansionMemoPanel.tsx`: Introduced a `toNumber()` helper that converts both numeric and string values to numbers, returning `null` for unparseable values. This ensures score bars render correctly regardless of whether the backend sends numbers or decimal strings.

- **Updated score bar guards**: Changed all score field conditionals from `typeof cand.field === "number"` to `fieldScore !== null`, allowing string-serialized decimals to pass through after coercion.

- **Enhanced ScoreBar styling**: Added flexbox layout with `justify-content: space-between` to the score bar head, preventing label and value from overlapping (e.g., "District momentum38" → properly spaced label and value).

- **Comprehensive test coverage**: Added three new test cases:
  - Validates score bars render when numeric fields arrive as decimal strings
  - Confirms score bars are hidden for unparseable values (N/A, empty strings, null, undefined)
  - Verifies the flex layout properly separates label and value visually

## Implementation Details

The `toNumber()` helper uses `Number.isFinite()` to safely validate both native numbers and parsed strings, ensuring only valid numeric values trigger score bar rendering. This approach gracefully handles all edge cases (null, undefined, empty strings, non-numeric strings) by returning `null`, which the component treats as "no data available."

https://claude.ai/code/session_011XQCL8s2HeTBbQLXaUrkq7