### PR TITLE
Coerce stringified Decimals to numbers at API boundary

### DIFF
--- a/frontend/src/features/expansion-advisor/ExpansionCandidateCard.test.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionCandidateCard.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import "../../i18n";
 import i18n from "../../i18n";
 import ExpansionCandidateCard from "./ExpansionCandidateCard";
+import { normalizeCandidate } from "../../lib/api/expansionAdvisor";
 import type { ExpansionCandidate, RerankStatus } from "../../lib/api/expansionAdvisor";
 
 beforeEach(async () => {
@@ -549,5 +550,30 @@ describe("ExpansionCandidateCard — Phase 4 pills (New / Updated / Top-tier mar
     );
     expect(html).toContain(">New<");
     expect(html).not.toContain(">Updated<");
+  });
+});
+
+describe("ExpansionCandidateCard — stringified-Decimal coercion at boundary", () => {
+  it("renders area, annual rent and fitout cost as real values when API returns strings", () => {
+    // Mirrors the real backend response shape: SQLAlchemy Numeric columns
+    // come over the wire as strings (e.g. "150.00"). Pre-coercion this
+    // produced "—" placeholders for area / annual-rent / fitout chips.
+    const apiShape = {
+      ...baseCandidate({ final_rank: 1 }),
+      area_m2: "150.00" as unknown as number,
+      display_annual_rent_sar: "210000.00" as unknown as number,
+      estimated_annual_rent_sar: "210000.00" as unknown as number,
+      estimated_fitout_cost_sar: "85000.00" as unknown as number,
+      distance_to_nearest_branch_m: "2300.00" as unknown as number,
+    };
+    const candidate = normalizeCandidate(apiShape);
+    const html = renderCard(candidate);
+    // Area chip
+    expect(html).toContain("150 m²");
+    // Annual rent chip — formatted as compact "SAR 210K"
+    expect(html).toContain("SAR 210K");
+    // Should not show the fallback in the metrics row.
+    const metricsBlock = html.split("ea-candidate__metrics")[1] || "";
+    expect(metricsBlock).not.toMatch(/—\/yr/);
   });
 });

--- a/frontend/src/features/expansion-advisor/formatHelpers.test.ts
+++ b/frontend/src/features/expansion-advisor/formatHelpers.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "../../i18n";
+import i18n from "../../i18n";
+import {
+  fmtM2,
+  fmtMeters,
+  fmtMonths,
+  fmtPct,
+  fmtSARCompact,
+  fmtSarPerM2,
+  fmtSarPerM2Year,
+  scoreColor,
+  toNumeric,
+} from "./formatHelpers";
+
+beforeEach(async () => {
+  if (i18n.language !== "en") await i18n.changeLanguage("en");
+});
+
+const FALLBACK = "—";
+
+describe("toNumeric", () => {
+  it("returns finite numbers unchanged", () => {
+    expect(toNumeric(42)).toBe(42);
+    expect(toNumeric(0)).toBe(0);
+    expect(toNumeric(-3.5)).toBe(-3.5);
+  });
+
+  it("parses numeric strings produced by SQLAlchemy Decimal serialization", () => {
+    expect(toNumeric("45.00")).toBe(45);
+    expect(toNumeric("  150.5  ")).toBe(150.5);
+    expect(toNumeric("0")).toBe(0);
+  });
+
+  it("returns null for null/undefined/empty/whitespace", () => {
+    expect(toNumeric(null)).toBeNull();
+    expect(toNumeric(undefined)).toBeNull();
+    expect(toNumeric("")).toBeNull();
+    expect(toNumeric("   ")).toBeNull();
+  });
+
+  it("returns null for unparseable strings and NaN/Infinity", () => {
+    expect(toNumeric("N/A")).toBeNull();
+    expect(toNumeric("—")).toBeNull();
+    expect(toNumeric(NaN)).toBeNull();
+    expect(toNumeric(Infinity)).toBeNull();
+  });
+});
+
+describe("fmtM2", () => {
+  it("formats numeric input", () => {
+    expect(fmtM2(150)).toBe("150 m²");
+  });
+  it("formats numeric-string input (Decimal serialization)", () => {
+    expect(fmtM2("150.00")).toBe("150 m²");
+  });
+  it("falls back for null/undefined/empty/unparseable", () => {
+    expect(fmtM2(null)).toBe(FALLBACK);
+    expect(fmtM2(undefined)).toBe(FALLBACK);
+    expect(fmtM2("")).toBe(FALLBACK);
+    expect(fmtM2("N/A")).toBe(FALLBACK);
+  });
+});
+
+describe("fmtMeters", () => {
+  it("formats sub-km values as meters", () => {
+    expect(fmtMeters(450)).toBe("450 m");
+    expect(fmtMeters("450.0")).toBe("450 m");
+  });
+  it("formats >= 1000 as km with one decimal", () => {
+    expect(fmtMeters(1500)).toBe("1.5 km");
+    expect(fmtMeters("1500.00")).toBe("1.5 km");
+  });
+  it("falls back for invalid input", () => {
+    expect(fmtMeters(null)).toBe(FALLBACK);
+    expect(fmtMeters("not-a-number")).toBe(FALLBACK);
+  });
+});
+
+describe("fmtSARCompact", () => {
+  it("formats <1k as exact integer", () => {
+    expect(fmtSARCompact(750)).toBe("SAR 750");
+    expect(fmtSARCompact("750.00")).toBe("SAR 750");
+  });
+  it("formats thousands with K suffix", () => {
+    expect(fmtSARCompact(168000)).toBe("SAR 168K");
+    expect(fmtSARCompact("168000.00")).toBe("SAR 168K");
+  });
+  it("formats millions with M suffix", () => {
+    expect(fmtSARCompact(1_200_000)).toBe("SAR 1.2M");
+    expect(fmtSARCompact("1200000.00")).toBe("SAR 1.2M");
+  });
+  it("falls back for invalid input", () => {
+    expect(fmtSARCompact(null)).toBe(FALLBACK);
+    expect(fmtSARCompact("")).toBe(FALLBACK);
+    expect(fmtSARCompact("garbage")).toBe(FALLBACK);
+  });
+});
+
+describe("fmtMonths", () => {
+  it("formats numeric and string input", () => {
+    expect(fmtMonths(12)).toBe("12 mo");
+    expect(fmtMonths("12.0")).toBe("12 mo");
+  });
+  it("falls back for invalid input", () => {
+    expect(fmtMonths(undefined)).toBe(FALLBACK);
+    expect(fmtMonths("N/A")).toBe(FALLBACK);
+  });
+});
+
+describe("fmtPct", () => {
+  it("formats numeric and string input", () => {
+    expect(fmtPct(85)).toBe("85%");
+    expect(fmtPct("85.00")).toBe("85%");
+  });
+  it("respects digits param", () => {
+    expect(fmtPct("12.345", 1)).toBe("12.3%");
+  });
+  it("falls back for invalid input", () => {
+    expect(fmtPct(null)).toBe(FALLBACK);
+    expect(fmtPct("")).toBe(FALLBACK);
+  });
+});
+
+describe("fmtSarPerM2 / fmtSarPerM2Year", () => {
+  it("formats numeric and string input", () => {
+    expect(fmtSarPerM2(1400)).toBe("1,400 SAR/m²");
+    expect(fmtSarPerM2("1400.00")).toBe("1,400 SAR/m²");
+    expect(fmtSarPerM2Year(1400)).toBe("1,400 SAR/m²/yr");
+    expect(fmtSarPerM2Year("1400.00")).toBe("1,400 SAR/m²/yr");
+  });
+  it("falls back for invalid input", () => {
+    expect(fmtSarPerM2(null)).toBe(FALLBACK);
+    expect(fmtSarPerM2Year(undefined)).toBe(FALLBACK);
+  });
+});
+
+describe("scoreColor", () => {
+  it("returns green for numeric >=70 (incl. boundary)", () => {
+    expect(scoreColor(85)).toBe("green");
+    expect(scoreColor(70)).toBe("green");
+  });
+  it("returns amber for [60, 70)", () => {
+    expect(scoreColor(65)).toBe("amber");
+    expect(scoreColor(60)).toBe("amber");
+  });
+  it("returns red for <60", () => {
+    expect(scoreColor(50)).toBe("red");
+    expect(scoreColor(0)).toBe("red");
+  });
+  it("uses the same thresholds for stringified scores", () => {
+    expect(scoreColor("85.00")).toBe("green");
+    expect(scoreColor("70.00")).toBe("green");
+    expect(scoreColor("60.00")).toBe("amber");
+    expect(scoreColor("59.99")).toBe("red");
+  });
+  it("returns neutral for null/undefined/empty/unparseable", () => {
+    expect(scoreColor(null)).toBe("neutral");
+    expect(scoreColor(undefined)).toBe("neutral");
+    expect(scoreColor("")).toBe("neutral");
+    expect(scoreColor("N/A")).toBe("neutral");
+  });
+});

--- a/frontend/src/features/expansion-advisor/formatHelpers.ts
+++ b/frontend/src/features/expansion-advisor/formatHelpers.ts
@@ -1,6 +1,11 @@
 import { formatCurrencySAR, formatNumber, formatInteger } from "../../i18n/format";
+import { toNumeric } from "../../lib/api/coerceNumeric";
+
+export { toNumeric };
 
 const FALLBACK = "—";
+
+type NumericLike = number | string | null | undefined;
 
 /** Prefix a formatted value with "Est. ~" when it is estimated, not actual. */
 export function fmtEstimated(value: string, isEstimated: boolean): string {
@@ -13,62 +18,70 @@ export function fmtSAR(value: number | null | undefined): string {
 }
 
 /** Compact SAR formatting: SAR 168K, SAR 1.2M — no "Est. ~" prefix */
-export function fmtSARCompact(value: number | null | undefined): string {
-  if (value == null || !Number.isFinite(value)) return FALLBACK;
-  const abs = Math.abs(value);
+export function fmtSARCompact(value: NumericLike): string {
+  const n = toNumeric(value);
+  if (n == null) return FALLBACK;
+  const abs = Math.abs(n);
   if (abs >= 1_000_000) {
-    const m = value / 1_000_000;
+    const m = n / 1_000_000;
     return `SAR ${m % 1 === 0 ? m.toFixed(0) : m.toFixed(1)}M`;
   }
   if (abs >= 1_000) {
-    const k = value / 1_000;
+    const k = n / 1_000;
     return `SAR ${k % 1 === 0 ? k.toFixed(0) : k.toFixed(0)}K`;
   }
-  return `SAR ${Math.round(value)}`;
+  return `SAR ${Math.round(n)}`;
 }
 
 export function fmtScore(value: number | null | undefined, digits = 0): string {
   return formatNumber(value, { maximumFractionDigits: digits, minimumFractionDigits: digits }, FALLBACK);
 }
 
-export function fmtM2(value: number | null | undefined): string {
-  if (value == null || !Number.isFinite(value)) return FALLBACK;
-  return `${formatInteger(Math.round(value), FALLBACK)} m²`;
+export function fmtM2(value: NumericLike): string {
+  const n = toNumeric(value);
+  if (n == null) return FALLBACK;
+  return `${formatInteger(Math.round(n), FALLBACK)} m²`;
 }
 
-export function fmtMeters(value: number | null | undefined): string {
-  if (value == null || !Number.isFinite(value)) return FALLBACK;
-  if (value >= 1000) {
-    return `${formatNumber(value / 1000, { maximumFractionDigits: 1, minimumFractionDigits: 1 }, FALLBACK)} km`;
+export function fmtMeters(value: NumericLike): string {
+  const n = toNumeric(value);
+  if (n == null) return FALLBACK;
+  if (n >= 1000) {
+    return `${formatNumber(n / 1000, { maximumFractionDigits: 1, minimumFractionDigits: 1 }, FALLBACK)} km`;
   }
-  return `${formatInteger(Math.round(value), FALLBACK)} m`;
+  return `${formatInteger(Math.round(n), FALLBACK)} m`;
 }
 
-export function fmtMonths(value: number | null | undefined): string {
-  if (value == null || !Number.isFinite(value)) return FALLBACK;
-  return `${Math.round(value)} mo`;
+export function fmtMonths(value: NumericLike): string {
+  const n = toNumeric(value);
+  if (n == null) return FALLBACK;
+  return `${Math.round(n)} mo`;
 }
 
-export function fmtPct(value: number | null | undefined, digits = 0): string {
-  if (value == null || !Number.isFinite(value)) return FALLBACK;
-  return `${formatNumber(value, { maximumFractionDigits: digits, minimumFractionDigits: digits }, FALLBACK)}%`;
+export function fmtPct(value: NumericLike, digits = 0): string {
+  const n = toNumeric(value);
+  if (n == null) return FALLBACK;
+  return `${formatNumber(n, { maximumFractionDigits: digits, minimumFractionDigits: digits }, FALLBACK)}%`;
 }
 
-export function fmtSarPerM2(value: number | null | undefined): string {
-  if (value == null || !Number.isFinite(value)) return FALLBACK;
-  return `${formatInteger(Math.round(value), FALLBACK)} SAR/m²`;
+export function fmtSarPerM2(value: NumericLike): string {
+  const n = toNumeric(value);
+  if (n == null) return FALLBACK;
+  return `${formatInteger(Math.round(n), FALLBACK)} SAR/m²`;
 }
 
-export function fmtSarPerM2Year(value: number | null | undefined): string {
-  if (value == null || !Number.isFinite(value)) return FALLBACK;
-  return `${formatInteger(Math.round(value), FALLBACK)} SAR/m²/yr`;
+export function fmtSarPerM2Year(value: NumericLike): string {
+  const n = toNumeric(value);
+  if (n == null) return FALLBACK;
+  return `${formatInteger(Math.round(n), FALLBACK)} SAR/m²/yr`;
 }
 
 /** Color semantic: >=80 dark green, >=70 green, >=60 amber, <60 red */
-export function scoreColor(value: number | null | undefined): "green" | "amber" | "red" | "neutral" {
-  if (value == null || !Number.isFinite(value)) return "neutral";
-  if (value >= 70) return "green";
-  if (value >= 60) return "amber";
+export function scoreColor(value: NumericLike): "green" | "amber" | "red" | "neutral" {
+  const n = toNumeric(value);
+  if (n == null) return "neutral";
+  if (n >= 70) return "green";
+  if (n >= 60) return "amber";
   return "red";
 }
 

--- a/frontend/src/lib/api/coerceNumeric.ts
+++ b/frontend/src/lib/api/coerceNumeric.ts
@@ -1,0 +1,79 @@
+/**
+ * Coerce values that arrive from the backend as either numbers or stringified
+ * Decimals (e.g. "45.00" from SQLAlchemy Numeric columns) into a JS number.
+ *
+ * Returns `null` for null/undefined, empty/whitespace strings, and anything
+ * that fails to parse — never NaN.
+ */
+export const toNumeric = (value: unknown): number | null => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const n = parseFloat(trimmed);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+};
+
+/**
+ * Coerce a candidate-shaped object's numeric fields in place. Fields that
+ * are absent on the input are left absent on the output (so existing
+ * `field != null` and optional-chaining checks keep working).
+ *
+ * Used at the API boundary by `normalize*Response` to neutralize the
+ * Numeric-as-string serialization the backend uses for precision.
+ */
+export function coerceCandidateNumerics<T extends Record<string, unknown>>(
+  candidate: T,
+  fields: readonly string[],
+): T {
+  const out: Record<string, unknown> = { ...candidate };
+  for (const key of fields) {
+    if (key in out) {
+      const v = out[key];
+      // Preserve explicit null/undefined as-is so callers can still
+      // distinguish "missing" from "zero" downstream.
+      if (v == null) continue;
+      out[key] = toNumeric(v);
+    }
+  }
+  return out as T;
+}
+
+/**
+ * Numeric fields on `ExpansionCandidate` that the backend serializes from
+ * SQLAlchemy Numeric columns and therefore arrive as strings (e.g. "45.00").
+ *
+ * Keep this list in sync with the candidate shape — adding a Numeric column
+ * on the backend means adding the field name here.
+ */
+export const CANDIDATE_NUMERIC_FIELDS = [
+  "area_m2",
+  "final_score",
+  "economics_score",
+  "brand_fit_score",
+  "provider_density_score",
+  "provider_whitespace_score",
+  "multi_platform_presence_score",
+  "delivery_competition_score",
+  "demand_score",
+  "whitespace_score",
+  "fit_score",
+  "zoning_fit_score",
+  "frontage_score",
+  "access_score",
+  "parking_score",
+  "access_visibility_score",
+  "confidence_score",
+  "cannibalization_score",
+  "distance_to_nearest_branch_m",
+  "estimated_rent_sar_m2_year",
+  "estimated_annual_rent_sar",
+  "estimated_fitout_cost_sar",
+  "estimated_revenue_index",
+  "display_annual_rent_sar",
+  "unit_price_sar_annual",
+  "unit_area_sqm",
+  "unit_street_width_m",
+] as const;

--- a/frontend/src/lib/api/expansionAdvisor.numericCoercion.test.ts
+++ b/frontend/src/lib/api/expansionAdvisor.numericCoercion.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeCandidate,
+  normalizeCompareResponse,
+  normalizeMemoResponse,
+  normalizeReportResponse,
+} from "./expansionAdvisor";
+import type {
+  CandidateMemoResponse,
+  CompareCandidatesResponse,
+  ExpansionCandidate,
+  RecommendationReportResponse,
+} from "./expansionAdvisor";
+
+const baseCandidate: ExpansionCandidate = {
+  id: "cand-1",
+  search_id: "search-1",
+  parcel_id: "parcel-1",
+  lat: 24.7,
+  lon: 46.7,
+};
+
+describe("normalizeCandidate — Numeric coercion at the API boundary", () => {
+  it("coerces stringified Decimals into numbers", () => {
+    // SQLAlchemy serializes Numeric columns as strings (e.g. "45.00").
+    const raw = {
+      ...baseCandidate,
+      area_m2: "150.00" as unknown as number,
+      final_score: "78.50" as unknown as number,
+      cannibalization_score: "12.00" as unknown as number,
+      distance_to_nearest_branch_m: "2300.50" as unknown as number,
+      estimated_annual_rent_sar: "168000.00" as unknown as number,
+      estimated_fitout_cost_sar: "50000.00" as unknown as number,
+      estimated_rent_sar_m2_year: "1400.00" as unknown as number,
+      unit_price_sar_annual: "750000.00" as unknown as number,
+      unit_area_sqm: "120.00" as unknown as number,
+      unit_street_width_m: "8.50" as unknown as number,
+    };
+    const out = normalizeCandidate(raw);
+    expect(out.area_m2).toBe(150);
+    expect(out.final_score).toBe(78.5);
+    expect(out.cannibalization_score).toBe(12);
+    expect(out.distance_to_nearest_branch_m).toBe(2300.5);
+    expect(out.estimated_annual_rent_sar).toBe(168000);
+    expect(out.estimated_fitout_cost_sar).toBe(50000);
+    expect(out.estimated_rent_sar_m2_year).toBe(1400);
+    expect(out.unit_price_sar_annual).toBe(750000);
+    expect(out.unit_area_sqm).toBe(120);
+    expect(out.unit_street_width_m).toBe(8.5);
+  });
+
+  it("passes already-numeric input through unchanged", () => {
+    const raw = {
+      ...baseCandidate,
+      area_m2: 150,
+      final_score: 78.5,
+      estimated_annual_rent_sar: 168000,
+    };
+    const out = normalizeCandidate(raw);
+    expect(out.area_m2).toBe(150);
+    expect(out.final_score).toBe(78.5);
+    expect(out.estimated_annual_rent_sar).toBe(168000);
+  });
+
+  it("preserves null/undefined for missing fields", () => {
+    const out = normalizeCandidate({ ...baseCandidate });
+    expect(out.area_m2).toBeUndefined();
+    expect(out.final_score).toBeUndefined();
+    expect(out.estimated_annual_rent_sar).toBeUndefined();
+  });
+
+  it("coerces unparseable numeric strings to null", () => {
+    const raw = {
+      ...baseCandidate,
+      area_m2: "" as unknown as number,
+      final_score: "N/A" as unknown as number,
+    };
+    const out = normalizeCandidate(raw);
+    expect(out.area_m2).toBeNull();
+    expect(out.final_score).toBeNull();
+  });
+
+  it("matches a real-world API response shape (mirrors المونسية candidate)", () => {
+    // Mirrors the field shape the backend actually emits: a mix of stringified
+    // Decimals, ints, and nulls.
+    const raw = {
+      ...baseCandidate,
+      district: "المونسية",
+      area_m2: "150.00" as unknown as number,
+      final_score: "73.25" as unknown as number,
+      economics_score: "68.00" as unknown as number,
+      brand_fit_score: "82.50" as unknown as number,
+      cannibalization_score: "5.00" as unknown as number,
+      distance_to_nearest_branch_m: "3200.00" as unknown as number,
+      estimated_annual_rent_sar: "210000.00" as unknown as number,
+      estimated_fitout_cost_sar: "85000.00" as unknown as number,
+      estimated_rent_sar_m2_year: "1400.00" as unknown as number,
+      display_annual_rent_sar: "210000.00" as unknown as number,
+    };
+    const out = normalizeCandidate(raw);
+    expect(typeof out.area_m2).toBe("number");
+    expect(typeof out.final_score).toBe("number");
+    expect(typeof out.estimated_annual_rent_sar).toBe("number");
+    expect(typeof out.distance_to_nearest_branch_m).toBe("number");
+    // The card renders `area_m2`, `display_annual_rent_sar`, and the chip
+    // shows `estimated_fitout_cost_sar`. All three must be numbers post-norm.
+    expect(out.area_m2).toBe(150);
+    expect(out.display_annual_rent_sar).toBe(210000);
+    expect(out.estimated_fitout_cost_sar).toBe(85000);
+  });
+});
+
+describe("normalizeMemoResponse — Numeric coercion on candidate sub-object", () => {
+  it("coerces stringified Decimals on memo.candidate", () => {
+    const raw: CandidateMemoResponse = {
+      brand_profile: {},
+      recommendation: {},
+      candidate: {
+        // CandidateMemoResponse.candidate is loosely typed (`[k: string]: unknown`),
+        // so we can pass strings through and assert the post-coerce shape.
+        final_score: "78.50" as unknown as number,
+        economics_score: "65.00" as unknown as number,
+        brand_fit_score: "82.00" as unknown as number,
+      },
+      market_research: {},
+    };
+    const out = normalizeMemoResponse(raw);
+    expect(out.candidate.final_score).toBe(78.5);
+    expect(out.candidate.economics_score).toBe(65);
+    expect(out.candidate.brand_fit_score).toBe(82);
+  });
+
+  it("leaves rerank metadata defaults intact alongside coerced numerics", () => {
+    const raw: CandidateMemoResponse = {
+      brand_profile: {},
+      recommendation: {},
+      candidate: {
+        final_score: "70.00" as unknown as number,
+      },
+      market_research: {},
+    };
+    const out = normalizeMemoResponse(raw);
+    expect(out.candidate.final_score).toBe(70);
+    expect(out.candidate.rerank_applied).toBe(false);
+    expect(out.candidate.decision_memo_json).toBeNull();
+  });
+});
+
+describe("normalizeCompareResponse — Numeric coercion on items", () => {
+  it("coerces stringified Decimals on each item", () => {
+    const raw = {
+      items: [
+        {
+          candidate_id: "c1",
+          area_m2: "150.00",
+          final_score: "78.00",
+          estimated_annual_rent_sar: "168000.00",
+          estimated_fitout_cost_sar: "50000.00",
+          distance_to_nearest_branch_m: "2300.00",
+        },
+      ],
+      summary: {},
+    } as unknown as CompareCandidatesResponse;
+    const out = normalizeCompareResponse(raw);
+    const item = out.items[0];
+    expect(item.area_m2).toBe(150);
+    expect(item.final_score).toBe(78);
+    expect(item.estimated_annual_rent_sar).toBe(168000);
+    expect(item.estimated_fitout_cost_sar).toBe(50000);
+    expect(item.distance_to_nearest_branch_m).toBe(2300);
+  });
+
+  it("preserves existing default-fill behaviour", () => {
+    const raw = {
+      items: [{ candidate_id: "c1", final_score: "85.00" }],
+      summary: { best_overall_candidate_id: "c1" },
+    } as unknown as CompareCandidatesResponse;
+    const out = normalizeCompareResponse(raw);
+    expect(out.items[0].gate_status_json).toEqual({});
+    expect(out.items[0].confidence_grade).toBe("D");
+    expect(out.items[0].final_score).toBe(85);
+  });
+});
+
+describe("normalizeReportResponse — Numeric coercion on top_candidates", () => {
+  it("coerces stringified Decimals on each top_candidate", () => {
+    const raw = {
+      top_candidates: [
+        { id: "c1", final_score: "85.00" },
+        { id: "c2", final_score: "72.50" },
+      ],
+      recommendation: {},
+      assumptions: {},
+      brand_profile: {},
+      meta: {},
+    } as unknown as RecommendationReportResponse;
+    const out = normalizeReportResponse(raw);
+    expect(out.top_candidates[0].final_score).toBe(85);
+    expect(out.top_candidates[1].final_score).toBe(72.5);
+  });
+
+  it("preserves default-fill behaviour for missing top_candidates", () => {
+    const raw = {} as RecommendationReportResponse;
+    const out = normalizeReportResponse(raw);
+    expect(out.top_candidates).toEqual([]);
+    // recommendation.* defaults are filled (pass_count: 0, summary: "", etc.)
+    expect(out.recommendation.pass_count).toBe(0);
+    expect(out.recommendation.summary).toBe("");
+  });
+});

--- a/frontend/src/lib/api/expansionAdvisor.ts
+++ b/frontend/src/lib/api/expansionAdvisor.ts
@@ -1,4 +1,5 @@
 import { buildApiUrl, fetchWithAuth } from "../../api";
+import { CANDIDATE_NUMERIC_FIELDS, coerceCandidateNumerics } from "./coerceNumeric";
 
 export type ExpansionAdvisorMeta = {
   version?: string;
@@ -436,9 +437,16 @@ const DEFAULT_FEATURE_SNAPSHOT: CandidateFeatureSnapshot = { context_sources: {}
 const DEFAULT_SCORE_BREAKDOWN: CandidateScoreBreakdown = { weights: {}, inputs: {}, weighted_components: {}, final_score: 0 };
 
 export function normalizeCandidate(candidate: ExpansionCandidate): ExpansionCandidate {
+  // Backend serializes Numeric columns as strings (e.g. "45.00") for
+  // precision; coerce them to numbers at the boundary so downstream
+  // formatters and arithmetic don't have to defend against mixed types.
+  const coerced = coerceCandidateNumerics(
+    candidate as unknown as Record<string, unknown>,
+    CANDIDATE_NUMERIC_FIELDS,
+  ) as ExpansionCandidate;
   return {
-    ...candidate,
-    rank_position: candidate.rank_position ?? undefined,
+    ...coerced,
+    rank_position: coerced.rank_position ?? undefined,
     confidence_grade: candidate.confidence_grade || "D",
     compare_rank: candidate.compare_rank ?? undefined,
     decision_summary: candidate.decision_summary || "",
@@ -499,13 +507,20 @@ export function normalizeReportResponse(data: RecommendationReportResponse): Rec
   const rec = data.recommendation || {};
   return {
     ...data,
-    top_candidates: (data.top_candidates || []).map((tc) => ({
-      ...tc,
-      top_positives_json: tc.top_positives_json || [],
-      top_risks_json: tc.top_risks_json || [],
-      score_breakdown_json: tc.score_breakdown_json || DEFAULT_SCORE_BREAKDOWN,
-      feature_snapshot_json: tc.feature_snapshot_json || {},
-    })),
+    top_candidates: (data.top_candidates || []).map((rawTc) => {
+      // Coerce stringified-Decimal numeric fields (see normalizeCandidate).
+      const tc = coerceCandidateNumerics(
+        rawTc as unknown as Record<string, unknown>,
+        CANDIDATE_NUMERIC_FIELDS,
+      ) as RecommendationTopCandidate;
+      return {
+        ...tc,
+        top_positives_json: tc.top_positives_json || [],
+        top_risks_json: tc.top_risks_json || [],
+        score_breakdown_json: tc.score_breakdown_json || DEFAULT_SCORE_BREAKDOWN,
+        feature_snapshot_json: tc.feature_snapshot_json || {},
+      };
+    }),
     assumptions: data.assumptions ?? {},
     recommendation: {
       ...rec,
@@ -527,7 +542,12 @@ export function normalizeReportResponse(data: RecommendationReportResponse): Rec
 }
 
 export function normalizeMemoResponse(data: CandidateMemoResponse): CandidateMemoResponse {
-  const cand = data.candidate || ({} as CandidateMemoResponse["candidate"]);
+  const rawCand = data.candidate || ({} as CandidateMemoResponse["candidate"]);
+  // Coerce stringified-Decimal numeric fields (see normalizeCandidate).
+  const cand = coerceCandidateNumerics(
+    rawCand as unknown as Record<string, unknown>,
+    CANDIDATE_NUMERIC_FIELDS,
+  ) as CandidateMemoResponse["candidate"];
   return {
     ...data,
     brand_profile: data.brand_profile || {},
@@ -557,7 +577,13 @@ export function normalizeMemoResponse(data: CandidateMemoResponse): CandidateMem
 export function normalizeCompareResponse(data: CompareCandidatesResponse): CompareCandidatesResponse {
   return {
     ...data,
-    items: (data.items || []).map((item) => ({
+    items: (data.items || []).map((rawItem) => {
+      // Coerce stringified-Decimal numeric fields (see normalizeCandidate).
+      const item = coerceCandidateNumerics(
+        rawItem as unknown as Record<string, unknown>,
+        CANDIDATE_NUMERIC_FIELDS,
+      ) as CompareCandidateItem;
+      return {
       ...item,
       confidence_grade: item.confidence_grade || "D",
       gate_status_json: (typeof item.gate_status_json === "object" && item.gate_status_json !== null) ? item.gate_status_json : {},
@@ -570,7 +596,8 @@ export function normalizeCompareResponse(data: CompareCandidatesResponse): Compa
       decision_summary: item.decision_summary || "",
       demand_thesis: item.demand_thesis || "",
       cost_thesis: item.cost_thesis || "",
-    })),
+      };
+    }),
     summary: data.summary || {},
   };
 }


### PR DESCRIPTION
## Summary
The backend serializes SQLAlchemy `Numeric` columns as strings (e.g., `"45.00"`) for precision. This change adds automatic coercion of these stringified decimals to JavaScript numbers at the API boundary, ensuring downstream formatters and components work with consistent numeric types.

## Key Changes

- **New `coerceNumeric.ts` module**: Provides `toNumeric()` utility to safely parse numeric strings and numbers, returning `null` for unparseable/invalid values (never `NaN`). Includes `coerceCandidateNumerics()` helper to coerce specific fields on candidate objects and `CANDIDATE_NUMERIC_FIELDS` constant listing all numeric fields that need coercion.

- **Updated `expansionAdvisor.ts` normalization functions**: Modified `normalizeCandidate()`, `normalizeCompareResponse()`, `normalizeMemoResponse()`, and `normalizeReportResponse()` to coerce stringified Decimals on candidates and candidate collections at the API boundary.

- **Updated `formatHelpers.ts`**: All formatting functions (`fmtM2`, `fmtMeters`, `fmtSARCompact`, `fmtMonths`, `fmtPct`, `fmtSarPerM2`, `fmtSarPerM2Year`, `scoreColor`) now accept `NumericLike` (number | string | null | undefined) and use `toNumeric()` internally, eliminating the need for callers to pre-coerce values. Exported `toNumeric` for direct use.

- **Comprehensive test coverage**: Added 210 lines of tests in `expansionAdvisor.numericCoercion.test.ts` covering coercion behavior across all normalize functions, and 163 lines in `formatHelpers.test.ts` validating formatter behavior with both numeric and stringified inputs. Updated `ExpansionCandidateCard.test.tsx` with integration test verifying real-world API response shape renders correctly.

## Implementation Details

- Coercion preserves `null`/`undefined` to maintain downstream `field != null` checks and optional-chaining semantics
- Empty and whitespace-only strings coerce to `null` (not `0`)
- Unparseable strings and non-finite numbers (`NaN`, `Infinity`) coerce to `null`
- The `CANDIDATE_NUMERIC_FIELDS` constant must be kept in sync with backend schema changes
- Coercion happens once at the API boundary, eliminating repeated defensive checks throughout the codebase

https://claude.ai/code/session_019S8J9rX7dkv17Zw9SckJms