### PR TITLE
Remove category filter from brand presence query

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -6622,7 +6622,7 @@ def run_expansion_search(
     _bulk_brand_presence: dict[str, list[dict]] = {}
     if ea_competitor_populated and _shortlist_coords:
         _bp_union_parts: list[str] = []
-        _bp_params: dict = {"category": category}
+        _bp_params: dict = {}
         for _bpi, (_bp_pid, (_bp_lon, _bp_lat)) in enumerate(_shortlist_coords.items()):
             _bp_params[f"bp_pid_{_bpi}"] = str(_bp_pid)
             _bp_params[f"bp_lon_{_bpi}"] = _bp_lon
@@ -6640,7 +6640,6 @@ def run_expansion_search(
                  FROM {_EA_COMPETITOR_TABLE} ecq
                  WHERE ecq.geom IS NOT NULL
                    AND ecq.canonical_brand_id IS NOT NULL
-                   AND lower(COALESCE(ecq.category, '')) = lower(:category)
                    AND ST_DWithin(
                        ecq.geom::geography,
                        ST_SetSRID(ST_MakePoint(:bp_lon_{_bpi}, :bp_lat_{_bpi}), 4326)::geography,


### PR DESCRIPTION
## Summary
Removed the category-based filtering from the brand presence SQL query in the expansion advisor service. This change simplifies the query logic by eliminating an unnecessary constraint.

## Key Changes
- Removed `"category": category` initialization from `_bp_params` dictionary
- Removed the `AND lower(COALESCE(ecq.category, '')) = lower(:category)` WHERE clause condition from the competitor query

## Implementation Details
The category parameter was being passed to the SQL query but is no longer needed for filtering competitor brand presence data. This reduces the query complexity and removes a potential filtering constraint that may have been overly restrictive for the expansion advisor's candidate selection logic.

https://claude.ai/code/session_01KRn9DM72tfk5aykUWnB1qc