### PR TITLE
Add English district labels to aqar_district_hulls layer

### DIFF
--- a/app/ingest/aqar_district_hulls.py
+++ b/app/ingest/aqar_district_hulls.py
@@ -1,16 +1,48 @@
+"""Build per-district convex hull polygons from ``aqar.listings``.
+
+The loader populates ``external_feature`` rows for the
+``aqar_district_hulls`` layer by grouping ``aqar.listings`` points by
+district and emitting the convex hull as a polygon feature. Idempotency
+is achieved via DELETE-then-INSERT on every run.
+
+In addition to the Arabic ``district`` norm key and the raw upstream
+``district_raw`` form, each row's JSONB ``properties`` carries
+``district_en`` — the conventional English transliteration looked up
+from ``app.data.riyadh_district_crosswalk.RIYADH_DISTRICT_AR_TO_EN``.
+
+Crosswalk keys are stored in ``normalize_district_key`` form, so the
+loader normalizes the AR district through ``normalize_district_key``
+before performing the crosswalk lookup. This bridges the 5 districts
+where the upstream Aqar form retains pre-normalize Arabic variants
+(``أ``, ``ى``) — e.g. ``أحد``, ``الخزامى``, ``الندى``,
+``العريجاء الوسطى``, ``جامعة الأميرة نورة`` — that would otherwise miss
+the crosswalk and silently get ``district_en = None``.
+
+Districts not present in the crosswalk get ``district_en = None`` and
+are reported via an info-level coverage log line — not an error. Tail
+districts are expected to grow into the crosswalk over time, and
+storing ``None`` lets the downstream EN -> AR helper distinguish
+"no canonical EN form" from "key never written."
+"""
+
 from __future__ import annotations
 
 import argparse
 import json
+import logging
 import statistics
 from typing import Iterable, List, Sequence, Tuple
 
 from sqlalchemy import bindparam, text
 from sqlalchemy.orm import Session
 
+from app.data.riyadh_district_crosswalk import RIYADH_DISTRICT_AR_TO_EN
 from app.db.session import SessionLocal
 from app.ml.name_normalization import norm_city, norm_district
 from app.models.tables import ExternalFeature
+from app.services.aqar_district_match import normalize_district_key
+
+logger = logging.getLogger(__name__)
 
 LAYER_NAME = "aqar_district_hulls"
 SOURCE = "aqar:listings_convex_hull"
@@ -70,12 +102,22 @@ def ingest_aqar_district_hulls(
     inserted = 0
     districts = set()
     point_counts: List[int] = []
+    rows_with_en = 0
 
     for row in rows:
         district_raw = str(row["district_raw"])
         n_points = int(row["n_points"])
         geometry = json.loads(row["geometry"])
         district_norm = norm_district(target_city_norm, district_raw)
+
+        # Look up English label from the crosswalk. Apply normalize_district_key
+        # to bridge raw forms (أحد, الخزامى) to the crosswalk's post-normalized
+        # keys (احد, الخزامي). Falls back to None when no English label is
+        # available — properties.district_en stays NULL, which is the correct
+        # signal for "no canonical EN form" rather than a crosswalk miss.
+        district_en = RIYADH_DISTRICT_AR_TO_EN.get(
+            normalize_district_key(district_norm)
+        )
 
         db.add(
             ExternalFeature(
@@ -86,6 +128,7 @@ def ingest_aqar_district_hulls(
                     "district": district_norm,
                     "district_raw": district_raw,
                     "n_points": n_points,
+                    "district_en": district_en,
                 },
                 source=SOURCE,
             )
@@ -95,8 +138,17 @@ def ingest_aqar_district_hulls(
         point_counts.append(n_points)
         if district_norm:
             districts.add(district_norm)
+        if district_en is not None:
+            rows_with_en += 1
 
     db.commit()
+
+    logger.info(
+        "aqar_district_hulls: %d/%d rows have district_en (%.1f%% coverage)",
+        rows_with_en,
+        inserted,
+        100.0 * rows_with_en / max(1, inserted),
+    )
 
     return inserted, len(districts), point_counts
 


### PR DESCRIPTION
## Summary
This change enhances the `aqar_district_hulls` layer by adding English district name labels (`district_en`) to each feature's properties. The implementation includes a crosswalk lookup mechanism that bridges normalized Arabic district names to their English equivalents, with proper handling of edge cases and coverage reporting.

## Key Changes
- **Added comprehensive module docstring** explaining the layer's purpose, data flow, and the normalization strategy for handling pre-normalized Arabic variants (e.g., `أحد`, `الخزامى`) that need to be normalized before crosswalk lookup
- **Integrated district name crosswalk** using `RIYADH_DISTRICT_AR_TO_EN` to populate `district_en` property for each district hull
- **Implemented normalization bridge** via `normalize_district_key()` to handle 5 districts with upstream Arabic variants that would otherwise miss the crosswalk
- **Added coverage logging** with info-level reporting showing the percentage of rows with available English labels, helping track crosswalk completeness over time
- **Graceful fallback to None** for districts not in the crosswalk, allowing downstream helpers to distinguish "no canonical EN form" from "key never written"

## Implementation Details
- The `district_en` lookup applies `normalize_district_key()` to the already-normalized `district_norm` value before querying the crosswalk, ensuring consistent key matching
- Missing English labels are stored as `None` rather than raising errors, supporting the expected growth of tail districts into the crosswalk over time
- Coverage metrics are logged on every ingest run to monitor crosswalk completeness without blocking the operation

https://claude.ai/code/session_01SnsWHmCmNGARHDcbaB5Sj7