### PR TITLE
Add manual workflow for aqar district hulls generation

### DIFF
--- a/.github/workflows/aqar-district-hulls-manual.yml
+++ b/.github/workflows/aqar-district-hulls-manual.yml
@@ -1,0 +1,44 @@
+name: aqar-district-hulls (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      city:
+        description: City name
+        required: true
+        default: Riyadh
+      min_points:
+        description: Minimum points per hull
+        required: true
+        default: '50'
+
+jobs:
+  run-loader:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run aqar_district_hulls loader
+        env:
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_SSLMODE: ${{ secrets.POSTGRES_SSLMODE }}
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          python -m app.ingest.aqar_district_hulls \
+            --city "${{ inputs.city }}" \
+            --min-points "${{ inputs.min_points }}"


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that enables manual triggering of the aqar district hulls data loader with customizable parameters.

## Key Changes
- Added `.github/workflows/aqar-district-hulls-manual.yml` workflow file that:
  - Allows manual workflow dispatch via GitHub UI
  - Accepts two configurable inputs:
    - `city`: City name (default: Riyadh)
    - `min_points`: Minimum points per hull (default: 50)
  - Sets up Python 3.12 environment with dependencies
  - Executes the `app.ingest.aqar_district_hulls` module with provided parameters
  - Uses PostgreSQL secrets for database connectivity

## Implementation Details
- Workflow uses `workflow_dispatch` trigger for manual execution
- Passes user inputs as command-line arguments to the Python loader module
- Includes all necessary PostgreSQL connection environment variables from repository secrets
- Sets `PYTHONPATH` to workspace root for proper module resolution

https://claude.ai/code/session_01JdgXDBy6KUhZpkZCf9EvQz