### PR TITLE
Extract district resolution logic into reusable helper function

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -21,6 +21,7 @@ from app.db.deps import get_db
 logger = logging.getLogger(__name__)
 from app.services.expansion_advisor import (
     _cached_district_lookup,
+    _resolve_district_to_ar_key,
     clear_expansion_caches,
     compare_candidates,
     create_saved_search,
@@ -837,22 +838,12 @@ def create_expansion_search(
     # user (or frontend) sends English names like "Al Yasmin", we need to
     # map them to the Arabic keys ("الياسمين") so the SQL filter matches.
     district_lookup = _cached_district_lookup(db)
-    # Build reverse map: lowercased English label → Arabic norm_key
-    _en_to_ar: dict[str, str] = {}
-    for _nk, _entry in district_lookup.items():
-        _en = (_entry.get("label_en") or "").strip()
-        if _en:
-            _en_to_ar[_en.lower()] = _nk
     resolved_target_districts: list[str] = []
     for td in canonical_target_districts:
-        if td in district_lookup:
-            # Already an Arabic norm_key
-            resolved_target_districts.append(td)
-        elif td.lower() in _en_to_ar:
-            resolved_target_districts.append(_en_to_ar[td.lower()])
-        else:
-            # Keep as-is (fallback)
-            resolved_target_districts.append(td)
+        resolved = _resolve_district_to_ar_key(td, district_lookup)
+        # Pass-through on miss preserves user input so downstream SQL
+        # filtering sees the raw string and misses naturally.
+        resolved_target_districts.append(resolved if resolved else td)
     req_target_districts = resolved_target_districts
 
     request_json = req.model_dump()

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -682,6 +682,37 @@ def _cached_district_lookup(db: Session) -> dict[str, dict[str, str]]:
     return _district_lookup_cache[key]
 
 
+def _resolve_district_to_ar_key(
+    input_value: str,
+    lookup: dict[str, dict[str, str]],
+) -> str | None:
+    """Resolve a district string (Arabic or English) to its canonical Arabic norm-key.
+
+    - Arabic input (already a key in ``lookup``): returned as-is after
+      ``normalize_district_key``. Because the first step is normalization,
+      raw forms with the ``حي`` prefix or ``أ/إ/آ/ى`` variants resolve to
+      the same canonical key — a beneficial side effect over a direct
+      dict membership check.
+    - English input matching a ``label_en`` in ``lookup`` (case- and
+      whitespace-insensitive): the corresponding norm-key is returned.
+    - No match: returns ``None``. Callers decide whether to fall back,
+      skip, or pass-through the original string.
+    """
+    if not input_value:
+        return None
+    normalized = normalize_district_key(input_value)
+    if normalized and normalized in lookup:
+        return normalized
+    input_lower = input_value.strip().lower()
+    if not input_lower:
+        return None
+    for nk, entry in lookup.items():
+        label_en = (entry.get("label_en") or "").strip()
+        if label_en and label_en.lower() == input_lower:
+            return nk
+    return None
+
+
 def _cached_table_available(db: Session, table_name: str) -> bool:
     """Cache table availability checks per table name within a process."""
     if table_name not in _table_avail_cache:

--- a/tests/test_district_canonicalization.py
+++ b/tests/test_district_canonicalization.py
@@ -12,6 +12,7 @@ import pytest
 from app.services.expansion_advisor import (
     _canonicalize_district_label,
     _normalize_candidate_payload,
+    _resolve_district_to_ar_key,
 )
 from app.services.aqar_district_match import normalize_district_key
 
@@ -228,3 +229,71 @@ class TestTargetDistrictNormalization:
     def test_empty_input_skipped(self):
         norm = normalize_district_key("")
         assert norm == ""
+
+
+# ---------------------------------------------------------------------------
+# _resolve_district_to_ar_key
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDistrictToArKey:
+    """Unit tests for the _resolve_district_to_ar_key helper."""
+
+    @pytest.fixture
+    def lookup(self) -> dict[str, dict[str, str]]:
+        # Synthetic lookup mirroring _build_district_lookup output shape.
+        return {
+            "الياسمين": {"label_ar": "الياسمين", "label_en": "Al Yasmin"},
+            "النخيل": {"label_ar": "النخيل", "label_en": "Al Nakheel"},
+            "الملقا": {"label_ar": "الملقا", "label_en": "Al Malqa"},
+            "العليا": {"label_ar": "العليا", "label_en": "Al Olaya"},
+        }
+
+    def test_empty_input_returns_none(self, lookup):
+        assert _resolve_district_to_ar_key("", lookup) is None
+
+    def test_ar_norm_key_direct_match(self, lookup):
+        assert _resolve_district_to_ar_key("الياسمين", lookup) == "الياسمين"
+
+    def test_ar_with_hayy_prefix_normalizes(self, lookup):
+        # 'حي الياسمين' should normalize through normalize_district_key
+        # to 'الياسمين' and resolve to that AR norm-key.
+        assert _resolve_district_to_ar_key("حي الياسمين", lookup) == "الياسمين"
+
+    def test_en_exact_match(self, lookup):
+        assert _resolve_district_to_ar_key("Al Yasmin", lookup) == "الياسمين"
+
+    def test_en_case_insensitive(self, lookup):
+        assert _resolve_district_to_ar_key("al yasmin", lookup) == "الياسمين"
+        assert _resolve_district_to_ar_key("AL YASMIN", lookup) == "الياسمين"
+
+    def test_en_with_extra_whitespace(self, lookup):
+        assert _resolve_district_to_ar_key("  Al Yasmin  ", lookup) == "الياسمين"
+
+    def test_no_match_returns_none(self, lookup):
+        assert _resolve_district_to_ar_key("Nonexistent District", lookup) is None
+
+    def test_ar_with_alef_variant_normalizes(self, lookup):
+        # Mixed-script / variant Arabic input should normalize via the
+        # Arabic path. 'العلىا' (using ى instead of ي) should still
+        # resolve to 'العليا'.
+        variant = "العلىا"
+        normalized = normalize_district_key(variant)
+        assert normalized in lookup  # sanity
+        assert _resolve_district_to_ar_key(variant, lookup) == normalized
+
+    def test_en_does_not_match_ar_key(self, lookup):
+        # An English string that does not match any label_en should not
+        # accidentally collide with an Arabic key.
+        assert _resolve_district_to_ar_key("Yasmin", lookup) is None
+
+    def test_empty_lookup(self):
+        # With no entries, both AR and EN paths should miss.
+        assert _resolve_district_to_ar_key("Al Yasmin", {}) is None
+        assert _resolve_district_to_ar_key("الياسمين", {}) is None
+
+    def test_lookup_entry_without_label_en(self, lookup):
+        # An entry missing label_en must not blow up the EN scan.
+        lookup_with_missing = dict(lookup)
+        lookup_with_missing["حي بلا"] = {"label_ar": "حي بلا", "label_en": None}
+        assert _resolve_district_to_ar_key("Al Yasmin", lookup_with_missing) == "الياسمين"


### PR DESCRIPTION
## Summary
Refactored district name resolution logic into a dedicated helper function `_resolve_district_to_ar_key()` to improve code reusability and testability. This function handles mapping both Arabic and English district names to their canonical Arabic keys.

## Key Changes
- **New helper function** `_resolve_district_to_ar_key()` in `app/services/expansion_advisor.py`:
  - Resolves district input (Arabic or English) to canonical Arabic norm-key
  - Handles Arabic normalization via `normalize_district_key()` (supports variants like `حي` prefix and alef variants)
  - Performs case- and whitespace-insensitive English label matching
  - Returns `None` on no match, allowing callers to decide fallback behavior

- **Simplified `create_expansion_search()`** in `app/api/expansion_advisor.py`:
  - Replaced inline reverse-mapping logic with call to `_resolve_district_to_ar_key()`
  - Maintains pass-through behavior on unmatched districts for natural SQL filtering

- **Comprehensive test coverage** in `tests/test_district_canonicalization.py`:
  - 11 new test cases covering empty input, direct matches, normalization, case-insensitivity, whitespace handling, and edge cases
  - Tests verify both Arabic and English resolution paths work correctly

## Implementation Details
- The helper function first attempts Arabic normalization (handles prefixes and character variants), then falls back to English label matching
- Pass-through on cache miss preserves original user input for downstream SQL filtering
- Lookup entries with missing `label_en` are safely handled without errors

https://claude.ai/code/session_01JHNdY1mtMKaxjjkxfmqW7A