### PR TITLE
Support English district names in rent lookups via AR↔EN crosswalk

### DIFF
--- a/app/ingest/candidate_rent_interpolation.py
+++ b/app/ingest/candidate_rent_interpolation.py
@@ -30,6 +30,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.db.session import SessionLocal
+from app.services.aqar_district_match import normalize_district_key_sql
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -379,9 +380,13 @@ def _step3_rent_from_district_median(db: Session) -> int:
     """Fill remaining candidates using district median from expansion_rent_comp.
 
     Matches on district_ar (Arabic name) against expansion_rent_comp.district.
-    Uses the median rent_sar_m2_year from commercial/retail comps.
+    Both sides apply ``normalize_district_key`` semantics in SQL so حي-prefix
+    and alef/ya variants don't break the AR↔AR join. Uses the median
+    rent_sar_m2_year from commercial/retail comps.
     """
-    sql = text("""
+    cl_norm = normalize_district_key_sql("cl.district_ar")
+    sub_norm = normalize_district_key_sql("sub.district")
+    sql = text(f"""
         UPDATE candidate_location cl
         SET rent_sar_m2_month = sub.median_rent_month,
             rent_sar_annual = CASE
@@ -403,7 +408,7 @@ def _step3_rent_from_district_median(db: Session) -> int:
             HAVING COUNT(*) >= 1
         ) sub
         WHERE cl.district_ar IS NOT NULL
-          AND lower(cl.district_ar) = lower(sub.district)
+          AND LOWER({cl_norm}) = LOWER({sub_norm})
           AND (cl.rent_confidence IS NULL OR cl.rent_confidence NOT IN ('actual', 'comp_interpolated'))
           AND cl.is_cluster_primary = TRUE
     """)

--- a/app/services/aqar_district_match.py
+++ b/app/services/aqar_district_match.py
@@ -110,6 +110,29 @@ def normalize_district_key(s: str | None) -> str:
     return base
 
 
+def normalize_district_key_sql(col_expr: str) -> str:
+    """SQL fragment (PostgreSQL) that mirrors :func:`normalize_district_key`.
+
+    Folds alef variants (أ/إ/آ → ا), alef maksura (ى → ي), strips TATWEEL
+    (ـ), strips a leading ``حي`` prefix, and trims whitespace, so an
+    English-bound caller's ``district`` bind value (resolved to its
+    Arabic norm-key via the crosswalk) compares cleanly against either
+    canonical or raw forms stored on the column side.
+
+    Caller is responsible for adding ``LOWER(...)`` if case-insensitive
+    matching is desired (no-op for Arabic, useful for English fallbacks).
+    """
+    return (
+        "TRIM(REGEXP_REPLACE("
+        f"TRANSLATE({col_expr}, "
+        "E'\\u0623\\u0625\\u0622\\u0649\\u0640', "
+        "E'\\u0627\\u0627\\u0627\\u064A'"
+        "), "
+        "E'^\\u062D\\u064A\\\\s+', '', 'g'"
+        "))"
+    )
+
+
 def _fetch_city_mv_rows(db: Session, city_ar: str, property_type: str | None) -> Iterable[dict]:
     params = {"aqar_city": city_ar}
     query = [

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -14,7 +14,11 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
-from app.services.aqar_district_match import is_mojibake, normalize_district_key
+from app.services.aqar_district_match import (
+    is_mojibake,
+    normalize_district_key,
+    normalize_district_key_sql,
+)
 from app.services.expansion_rerank import generate_rerank
 from app.services.rent import aqar_rent_median
 
@@ -3437,6 +3441,12 @@ def _estimate_rent_from_expansion_table(db: Session, district: str | None) -> tu
 
     Uses commercial/retail rents for F&B location scoring.
     Fallback chain: retail district → commercial district → retail city → commercial city.
+
+    English-bound callers (e.g. commercial_unit candidates whose neighborhood
+    field is the Aqar English label) are translated to the Arabic norm-key
+    via the AR↔EN crosswalk before the join. The SQL WHERE clause additionally
+    applies ``normalize_district_key`` semantics on both sides so حي-prefix
+    and alef/ya variants on the column side don't break the match.
     """
     try:
         with db.begin_nested():
@@ -3446,11 +3456,44 @@ def _estimate_rent_from_expansion_table(db: Session, district: str | None) -> tu
             if not has_rows:
                 return None
 
+            # Resolve EN→AR via the district crosswalk; pass-through on miss
+            # so callers that already supply Arabic keep working.
+            district_normalized: str | None = None
+            if district:
+                lookup = _cached_district_lookup(db)
+                resolved = _resolve_district_to_ar_key(district, lookup)
+                if resolved:
+                    district_normalized = resolved
+                    if normalize_district_key(district) == resolved:
+                        logger.debug("rent_lookup: AR direct match for %s", district)
+                    else:
+                        logger.debug("rent_lookup: EN→AR match %s → %s", district, resolved)
+                else:
+                    district_normalized = normalize_district_key(district) or district
+                    logger.debug(
+                        "rent_lookup: no district resolution for %s, using pass-through",
+                        district,
+                    )
+
+            district_where = (
+                f"AND LOWER({normalize_district_key_sql('district')}) = LOWER(:district_normalized)"
+            )
+
             # Filters to try in priority order: narrowest (retail + district) to broadest (commercial + city)
             filters = []
-            if district:
-                filters.append(("AND lower(district) = lower(:district) AND asset_type = 'commercial' AND unit_type = 'retail'", {"district": district}, 3, "expansion_rent_district_retail"))
-                filters.append(("AND lower(district) = lower(:district) AND asset_type = 'commercial'", {"district": district}, 3, "expansion_rent_district_commercial"))
+            if district and district_normalized:
+                filters.append((
+                    f"{district_where} AND asset_type = 'commercial' AND unit_type = 'retail'",
+                    {"district_normalized": district_normalized},
+                    3,
+                    "expansion_rent_district_retail",
+                ))
+                filters.append((
+                    f"{district_where} AND asset_type = 'commercial'",
+                    {"district_normalized": district_normalized},
+                    3,
+                    "expansion_rent_district_commercial",
+                ))
             filters.append(("AND asset_type = 'commercial' AND unit_type = 'retail'", {}, 0, "expansion_rent_city_retail"))
             filters.append(("AND asset_type = 'commercial'", {}, 0, "expansion_rent_city_commercial"))
 
@@ -4617,17 +4660,9 @@ def _query_commercial_unit_candidates(
             for i, td in enumerate(sorted(target_district_norm)):
                 params[f"td_{i}"] = td
 
-            # TRANSLATE mirrors normalize_district_key(): أ→ا إ→ا آ→ا ى→ي
-            _NORM_SQL = (
-                "TRIM(REGEXP_REPLACE("
-                "TRANSLATE("
-                "COALESCE(p.district_label, ''), "
-                "E'\\u0623\\u0625\\u0622\\u0649\\u0640', "
-                "E'\\u0627\\u0627\\u0627\\u064A'"
-                "), "
-                "E'^\\u062D\\u064A\\\\s+', '', 'g'"
-                "))"
-            )
+            # Mirrors normalize_district_key(): folds alef/ya variants,
+            # strips حي prefix, trims whitespace.
+            _NORM_SQL = normalize_district_key_sql("COALESCE(p.district_label, '')")
 
             centroid_sql = sa_text(f"""
                 SELECT

--- a/app/services/rent.py
+++ b/app/services/rent.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import date, timedelta
 from math import ceil
 from typing import Iterable, Optional
 
-from sqlalchemy import func
+from sqlalchemy import func, text
 from sqlalchemy.orm import Session
 
 from app.ml.name_normalization import norm_city, norm_district
 from app.models.tables import RentComp
+from app.services.aqar_district_match import (
+    normalize_district_key,
+    normalize_district_key_sql,
+)
+
+logger = logging.getLogger(__name__)
 
 
 # Kaggle/Aqar scrapes frequently encode *annual* rents (SAR/year) even when the
@@ -100,6 +107,41 @@ def aqar_rent_median(
 
     district_norm = district_norm or (norm_district(city_norm, district) if district else "")
 
+    # Resolve English district names to their canonical Arabic norm-key via
+    # the AR↔EN crosswalk so callers passing English (e.g. cu.neighborhood)
+    # can hit Arabic-keyed RentComp rows. Lazy import avoids a circular
+    # dependency with expansion_advisor.
+    district_for_match = district_norm
+    if district:
+        try:
+            from app.services.expansion_advisor import (
+                _cached_district_lookup,
+                _resolve_district_to_ar_key,
+            )
+
+            lookup = _cached_district_lookup(db)
+            resolved = _resolve_district_to_ar_key(district, lookup)
+            if resolved:
+                district_for_match = resolved
+                if normalize_district_key(district) == resolved:
+                    logger.debug("rent_lookup: AR direct match for %s", district)
+                else:
+                    logger.debug("rent_lookup: EN→AR match %s → %s", district, resolved)
+            else:
+                logger.debug(
+                    "rent_lookup: no district resolution for %s, using pass-through",
+                    district,
+                )
+        except Exception:
+            logger.debug("rent_lookup: crosswalk unavailable for %s", district, exc_info=True)
+
+    dialect_name = ""
+    try:
+        bind = db.get_bind()
+        dialect_name = getattr(getattr(bind, "dialect", None), "name", "") or ""
+    except Exception:
+        dialect_name = ""
+
     since_date = date.today() - timedelta(days=since_days) if since_days else None
 
     def _values(scope_district: bool, apply_unit: bool = True) -> list[float]:
@@ -114,9 +156,23 @@ def aqar_rent_median(
             q = q.filter(RentComp.date >= since_date)
         if scope_district:
             # If no district was supplied, avoid "faking" a district median by returning city stats.
-            if not district_norm:
+            if not district_for_match:
                 return []
-            q = q.filter(func.lower(RentComp.district) == district_norm.lower())
+            if dialect_name == "postgresql":
+                # Apply normalize_district_key semantics on the column side
+                # so حي-prefix and alef/ya variants in stored data don't
+                # break the join. The bind value is already a norm-key
+                # (resolved above or normalized below), so wrapping it in
+                # the same fragment is a no-op but keeps both sides
+                # symmetric and dialect-friendly.
+                q = q.filter(
+                    text(
+                        f"LOWER({normalize_district_key_sql('rent_comp.district')}) "
+                        f"= LOWER({normalize_district_key_sql(':district_normalized')})"
+                    ).bindparams(district_normalized=district_for_match)
+                )
+            else:
+                q = q.filter(func.lower(RentComp.district) == district_for_match.lower())
         return [
             _normalize_kaggle_rent_per_m2_month(float(rent_per_m2), source, asset_type)
             for rent_per_m2, source in q.all()

--- a/tests/test_expansion_advisor_data_pipeline.py
+++ b/tests/test_expansion_advisor_data_pipeline.py
@@ -887,6 +887,11 @@ class TestRentEstimationFallback:
         def mock_execute(stmt, params=None):
             sql_str = str(stmt)
             result = MagicMock()
+            if "external_feature" in sql_str:
+                # District AR↔EN lookup invoked by _cached_district_lookup
+                call_sequence.append("district_lookup")
+                result.fetchall.return_value = []
+                return result
             if "EXISTS" in sql_str:
                 call_sequence.append("exists")
                 result.scalar.return_value = True


### PR DESCRIPTION
## Summary
This PR enables rent lookup functions to accept English district names by resolving them to their canonical Arabic norm-keys via an existing AR↔EN crosswalk. This allows callers passing English district labels (e.g., `commercial_unit.neighborhood`) to successfully match against Arabic-keyed rent comparison data.

## Key Changes

- **Extract SQL normalization logic**: Created `normalize_district_key_sql()` in `aqar_district_match.py` to mirror the Python `normalize_district_key()` function in PostgreSQL, handling alef/ya variants, TATWEEL stripping, and حي-prefix removal.

- **Enhance `aqar_rent_median()` in `rent.py`**:
  - Added lazy import of district lookup functions to avoid circular dependencies
  - Resolve English district names to Arabic norm-keys via `_resolve_district_to_ar_key()`
  - Apply SQL normalization on both sides of district comparisons for PostgreSQL to handle variant forms in stored data
  - Fall back to pass-through normalization if crosswalk resolution fails
  - Added debug logging for resolution outcomes

- **Update `_estimate_rent_from_expansion_table()` in `expansion_advisor.py`**:
  - Import `normalize_district_key_sql` from district match module
  - Implement same EN→AR resolution logic as `aqar_rent_median()`
  - Use SQL normalization in WHERE clause filters for district matching
  - Enhanced docstring explaining the English-to-Arabic translation flow

- **Update `_query_commercial_unit_candidates()` in `expansion_advisor.py`**:
  - Replace inline SQL normalization with call to `normalize_district_key_sql()`
  - Improves maintainability by centralizing normalization logic

- **Update `_step3_rent_from_district_median()` in `candidate_rent_interpolation.py`**:
  - Apply SQL normalization to both sides of district AR↔AR join
  - Updated docstring to document the normalization behavior

- **Test updates**: Added mock handling for district lookup queries in expansion advisor tests

## Implementation Details

- The crosswalk resolution is attempted first; if it succeeds, the resolved Arabic norm-key is used for matching. If it fails, the input is normalized using the standard Python function and used as a pass-through.
- SQL normalization is only applied on PostgreSQL (dialect check) to avoid compatibility issues with other databases.
- Both bind values and column expressions are wrapped in the same normalization fragment to ensure symmetric, dialect-friendly comparisons.
- Debug logging tracks whether matches are direct Arabic matches or English-to-Arabic translations.

https://claude.ai/code/session_01CDi9BWv6131ZAotYvbGPMg