### PR TITLE
PR #1: Plumb advisory-report data into feature_snapshot_json

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -7208,6 +7208,91 @@ def run_expansion_search(
             area_m2=area_m2,
         )
 
+        # ── Advisory-grade snapshot plumbing (PR #1) ──
+        # Copy candidate-level scalars and a few derivations into
+        # feature_snapshot_json so the memo LLM can make grounded
+        # financial / market / risk arguments. Skip None values to
+        # keep the snapshot lean; the memo path tolerates absent keys.
+        if area_m2 is not None:
+            feature_snapshot_json["area_m2"] = area_m2
+        _unit_area_sqm_val = (
+            _safe_float(row.get("unit_area_sqm"))
+            if row.get("unit_area_sqm") is not None
+            else None
+        )
+        if _unit_area_sqm_val is not None:
+            feature_snapshot_json["unit_area_sqm"] = _unit_area_sqm_val
+        if _unit_street_width is not None:
+            feature_snapshot_json["unit_street_width_m"] = _unit_street_width
+        if estimated_annual_rent_sar is not None:
+            feature_snapshot_json["estimated_annual_rent_sar"] = round(
+                estimated_annual_rent_sar, 2
+            )
+        # Replicate display_annual_rent_sar rounding from
+        # _normalize_candidate_payload — that helper runs after persistence
+        # so the persisted snapshot would otherwise miss this key.
+        if (
+            estimated_rent_sar_m2_year is not None
+            and estimated_rent_sar_m2_year > 0
+            and area_m2 is not None
+            and area_m2 > 0
+        ):
+            feature_snapshot_json["display_annual_rent_sar"] = round(
+                round(estimated_rent_sar_m2_year) * area_m2, 2
+            )
+        elif estimated_annual_rent_sar is not None:
+            feature_snapshot_json["display_annual_rent_sar"] = round(
+                estimated_annual_rent_sar, 2
+            )
+        if population_reach is not None:
+            feature_snapshot_json["population_reach"] = population_reach
+        if delivery_listing_count is not None:
+            feature_snapshot_json["delivery_listing_count"] = delivery_listing_count
+        if access_visibility_score is not None:
+            feature_snapshot_json["access_visibility_score"] = round(
+                access_visibility_score, 2
+            )
+        if parking_score is not None:
+            feature_snapshot_json["parking_score"] = round(parking_score, 2)
+        if frontage_score is not None:
+            feature_snapshot_json["frontage_score"] = round(frontage_score, 2)
+        _district_display_val = district_canon.get("district_display")
+        if _district_display_val is not None:
+            feature_snapshot_json["district_display"] = _district_display_val
+
+        # landlord_signal — pull from score_breakdown_json["inputs"] so
+        # the memo LLM sees the same scalar the rerank LLM consumes.
+        _landlord_signal_val = (
+            (score_breakdown_json or {}).get("inputs", {}).get("landlord_signal")
+        )
+        if _landlord_signal_val is not None:
+            feature_snapshot_json["landlord_signal"] = _landlord_signal_val
+
+        # Comparable rent context — derive only when rent_burden ran in
+        # percentile mode. Named comparable_* (not district_*) because
+        # the percentile fallback chain reaches a city-band scope on
+        # ~42% of rows in production; comparable_source_label carries
+        # the actual scope so downstream callers can stay honest.
+        _rent_burden_meta = (
+            (score_breakdown_json or {})
+            .get("economics_detail", {})
+            .get("rent_burden", {})
+        )
+        if isinstance(_rent_burden_meta, dict) and _rent_burden_meta.get("mode") == "percentile":
+            _median_per_m2_month = _rent_burden_meta.get("median_monthly_rent_per_m2")
+            if _median_per_m2_month is not None and area_m2 is not None:
+                feature_snapshot_json["comparable_median_annual_rent_sar"] = round(
+                    float(_median_per_m2_month) * 12.0 * float(area_m2), 2
+                )
+            _n_comparable = _rent_burden_meta.get("n_comparable")
+            if _n_comparable is not None:
+                feature_snapshot_json["comparable_n"] = int(_n_comparable)
+            _comparable_source_label = _rent_burden_meta.get("source_label")
+            if _comparable_source_label is not None:
+                feature_snapshot_json["comparable_source_label"] = str(
+                    _comparable_source_label
+                )
+
         candidates.append(
             {
                 "id": str(uuid.uuid4()),

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -29,7 +29,7 @@ TEMPERATURE = 0.3
 # Bumped whenever STRUCTURED_MEMO_SYSTEM_PROMPT changes meaningfully.
 # Cached memos with a different version are treated as cache-miss and
 # regenerated lazily on next view.
-MEMO_PROMPT_VERSION = "v2-humanized-2026-04"
+MEMO_PROMPT_VERSION = "v3-snapshot-2026-04"
 
 # Soft daily ceiling in USD.  Raises RuntimeError before calling OpenAI
 # if the running total for today exceeds this value.
@@ -411,6 +411,13 @@ _RERANK_WHITELIST: tuple[str, ...] = (
 _MEMO_WHITELIST: tuple[str, ...] = _RERANK_WHITELIST + (
     "listing_age",
     "district_momentum",
+    # PR #1 — advisory-grade snapshot plumbing. Comparable-rent
+    # context (median, sample size, scope label) is plumbed into
+    # feature_snapshot_json so the memo LLM can ground rent
+    # arguments in observed peer listings rather than hand-wave.
+    "comparable_median_annual_rent_sar",
+    "comparable_n",
+    "comparable_source_label",
 )
 
 # Back-compat alias for existing memo call sites (:730, :901, :932).

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -1322,16 +1322,30 @@ def test_rerank_whitelist_excludes_memo_only_keys():
 
 def test_memo_whitelist_is_superset_of_rerank_whitelist():
     """The memo whitelist is the rerank whitelist plus the two Phase 4
-    keys. Any addition to the rerank set must also appear in the memo
-    set by construction, otherwise a signal the rerank LLM uses would
-    not be visible to the memo LLM."""
+    keys and the PR #1 advisory-grade comparable-rent keys. Any
+    addition to the rerank set must also appear in the memo set by
+    construction, otherwise a signal the rerank LLM uses would not be
+    visible to the memo LLM."""
     from app.services.llm_decision_memo import _MEMO_WHITELIST, _RERANK_WHITELIST
 
     assert set(_RERANK_WHITELIST).issubset(set(_MEMO_WHITELIST))
     assert set(_MEMO_WHITELIST) - set(_RERANK_WHITELIST) == {
         "listing_age",
         "district_momentum",
+        "comparable_median_annual_rent_sar",
+        "comparable_n",
+        "comparable_source_label",
     }
+
+
+def test_memo_whitelist_includes_comparable_rent_keys():
+    """PR #1 plumbed comparable-rent context into feature_snapshot_json.
+    Pin the whitelist so the memo LLM can read these new keys."""
+    from app.services.llm_decision_memo import _MEMO_WHITELIST
+
+    assert "comparable_median_annual_rent_sar" in _MEMO_WHITELIST
+    assert "comparable_n" in _MEMO_WHITELIST
+    assert "comparable_source_label" in _MEMO_WHITELIST
 
 
 def test_feature_snapshot_whitelist_alias_points_at_memo_whitelist():


### PR DESCRIPTION
## Summary

Per the CEO directive on advisory-report-grade decision memos, the memo LLM currently cannot make grounded financial / market / risk arguments because the candidate-loop persists a `feature_snapshot_json` keyset that's disjoint from `_MEMO_WHITELIST`. The model never sees absolute rent, comparable medians, area in m², population reach, parking / frontage scores, or landlord signal.

This PR is the data-plumbing prerequisite for PR #2 (prompt rewrite) and PR #3 (schema / frontend). Narrow scope: data plumbing only — no prompt, schema, or frontend changes.

## New keys written to `feature_snapshot_json`

Copied from candidate scope inside `run_expansion_search` (skips `None` values to keep the snapshot lean):

- `area_m2`
- `unit_area_sqm`
- `unit_street_width_m`
- `estimated_annual_rent_sar`
- `display_annual_rent_sar` (rounding logic from `_normalize_candidate_payload` replicated locally; normalizer runs after persistence)
- `population_reach`
- `delivery_listing_count`
- `access_visibility_score`
- `parking_score`
- `frontage_score`
- `district_display`
- `landlord_signal` (read from `score_breakdown_json["inputs"]` so memo and rerank see the same scalar)
- `comparable_median_annual_rent_sar` (derived from `rent_burden.median_monthly_rent_per_m2 * 12 * area_m2` when `rent_burden.mode == "percentile"`)
- `comparable_n`
- `comparable_source_label`

Naming note: `comparable_*` rather than `district_*` because the percentile fallback chain reaches a city-band scope on ~42% of rows in production. `comparable_source_label` carries the actual scope so downstream callers stay honest. The deprecated `district_median_rent` whitelist key is left in place with no producer; PR #2 cleans up.

## Whitelist & cache invalidation

- Added `comparable_median_annual_rent_sar`, `comparable_n`, `comparable_source_label` to `_MEMO_WHITELIST`. The other plumbed keys are already in `_RERANK_WHITELIST`, which `_MEMO_WHITELIST` is a superset of.
- Bumped `MEMO_PROMPT_VERSION` from `v2-humanized-2026-04` to `v3-snapshot-2026-04`. **This invalidates all cached memos** — newly persisted candidates regenerate against the enriched snapshot. Without this bump, the new keys reach the snapshot but cached memos never re-run.

## Dependencies

PR #2 (prompt rewrite) and PR #3 (schema / frontend) depend on this PR landing first.

## Caveat

**No behavior change for end users until PR #2 ships.** The new data is plumbed but the prompt doesn't reference it yet, so memo content quality won't visibly change after this PR alone.

## Test plan

- [x] `tests/test_llm_decision_memo.py` whitelist assertions updated for the three new comparable-rent keys; whitelist subset/superset invariant still pinned
- [x] `tests/test_expansion_advisor_service.py` passes (72/72) — fixtures use subset-style assertions on `feature_snapshot_json`, so additive keys don't break shape
- [x] `tests/test_sample_regression_memos.py` passes (6/6)
- [ ] Maintainer to validate against production via Codespace SQL after merge:
  1. Run a fresh search at the production link
  2. Inspect `feature_snapshot_json` of the new candidates to confirm all new keys are present
  3. Confirm the regenerated memo (cache invalidated by version bump) exists in `decision_memo_json` with `decision_memo_prompt_version = 'v3-snapshot-2026-04'`

Do not merge — waiting for explicit merge instruction.

https://claude.ai/code/session_01Mw5Cz8ZTBE376PfRprp7LP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mw5Cz8ZTBE376PfRprp7LP)_