### PR TITLE
PR #2: Rewrite memo prompt to advisory-report grade

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -103,7 +103,7 @@ class Settings:
     # is false the service falls back to the legacy generic memo path byte-for-byte.
     EXPANSION_MEMO_MODEL: str = os.getenv("EXPANSION_MEMO_MODEL", "gpt-4o-mini")
     EXPANSION_MEMO_MAX_TOKENS: int = int(
-        os.getenv("EXPANSION_MEMO_MAX_TOKENS", "1200")
+        os.getenv("EXPANSION_MEMO_MAX_TOKENS", "2400")
     )
     EXPANSION_MEMO_TEMPERATURE: float = float(
         os.getenv("EXPANSION_MEMO_TEMPERATURE", "0.3")

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -29,12 +29,12 @@ TEMPERATURE = 0.3
 # Bumped whenever STRUCTURED_MEMO_SYSTEM_PROMPT changes meaningfully.
 # Cached memos with a different version are treated as cache-miss and
 # regenerated lazily on next view.
-MEMO_PROMPT_VERSION = "v3-snapshot-2026-04"
+MEMO_PROMPT_VERSION = "v4-advisor-2026-04"
 
 # Soft daily ceiling in USD.  Raises RuntimeError before calling OpenAI
 # if the running total for today exceeds this value.
 DAILY_CEILING_USD = float(
-    os.environ.get("DECISION_MEMO_DAILY_CEILING_USD", "1.00")
+    os.environ.get("DECISION_MEMO_DAILY_CEILING_USD", "5.00")
 )
 
 # Per-token costs for gpt-4o-mini (as of 2024-07).  Used for cost
@@ -116,6 +116,12 @@ def _format_rent_vs_median(
 
 
 # ── Prompt templates ────────────────────────────────────────────────
+#
+# Legacy fallback prompt — intentionally narrower than
+# STRUCTURED_MEMO_SYSTEM_PROMPT and only used when the structured-output
+# parse fails or EXPANSION_MEMO_STRUCTURED_ENABLED is off. Do not extend
+# it with new advisory-report directives; the structured prompt is the
+# canonical path for advisor-grade memos.
 
 _PROMPT_TEMPLATE_EN = """You are a real estate advisor evaluating a commercial site in Riyadh, Saudi Arabia for a specific restaurant/retail operator.
 
@@ -392,7 +398,6 @@ _RERANK_WHITELIST: tuple[str, ...] = (
     "estimated_annual_rent_sar",
     "display_annual_rent_sar",
     "estimated_rent_sar_m2_year",
-    "district_median_rent",
     "unit_street_width_m",
     "street_width_m",
     "population_reach",
@@ -866,32 +871,77 @@ def build_memo_context(
 # ── Prompt ──────────────────────────────────────────────────────────
 
 
-STRUCTURED_MEMO_SYSTEM_PROMPT = """You are a senior site-selection analyst writing a short memo for a restaurant operator who is reviewing a real-estate listing in Riyadh. Your reader is busy and wants to know, in plain language, whether this site is worth pursuing and why.
+STRUCTURED_MEMO_SYSTEM_PROMPT = """You are a senior real-estate advisor in Riyadh writing an investment memo for a restaurant operator's principal. The reader is the person making the capital call on this specific listing — they want a clear, persuasive, numerically-grounded answer to one question: is this site worth the capital?
 
-Write the way you would brief a colleague after walking the site — concrete, direct, specific to this candidate. Do not hedge. Do not summarize the score breakdown back at the reader; they can see the numbers in the UI. Tell them what actually matters here.
+Write like an advisor, not a junior analyst. Lead with the strongest investment argument grounded in a specific number. Synthesize the score breakdown into a thesis — never restate the breakdown back at the reader as a list of percentages. Be direct. Be specific to this candidate, this listing, this catchment. Density beats length.
 
-You will receive a JSON object describing the brand profile, the candidate's feature snapshot, the score_breakdown (9 components with weights and contributions), the gate buckets (gates.passed / gates.failed / gates.unknown — tri-state), deterministic anchors (overall_pass, final_rank, final_score, deterministic_verdict), comparable competitors, and optionally a realized_demand block.
+You will receive a JSON object describing the brand profile, the candidate's feature snapshot, the score_breakdown (9 components with weights and contributions), the gate buckets (gates.passed / gates.failed / gates.unknown — tri-state), deterministic anchors (overall_pass, final_rank, final_score, deterministic_verdict), comparable competitors, the rank-2 alternative (next_candidate_summary), and optionally a realized_demand block.
 
 Return ONLY a single JSON object — no markdown fences, no commentary before or after. The object must contain EXACTLY these six top-level keys:
 
 {
   "headline_recommendation": "string — one short sentence. MUST start with 'Recommend', 'Recommend with reservations', or 'Decline'. Never start with 'Consider' — that is a non-decision. Never start with 'consider due to'.",
-  "ranking_explanation": "string — 2-3 sentences. Lead with the single biggest reason this candidate ranks where it does. Mention one trade-off. Avoid reciting score numbers like 'X contributed 24.45 out of 30'; the reader sees the breakdown — give them the insight in plain English.",
+  "ranking_explanation": "string — 3 to 5 sentences. Lead with the strongest investment argument grounded in a specific number (rent vs comparable median, foot traffic, brand saturation, demand signal). MUST cite at least one number with units. Mention one real trade-off. Do NOT recite the score breakdown back at the reader; synthesize it into an investment thesis.",
   "key_evidence": [
-    {"signal": "string", "value": "string — MUST include a unit (SAR/m²/year, orders/30d, /100, count, m, etc.); never a bare number", "implication": "string — one short sentence on why it matters here", "polarity": "positive | negative | neutral"}
+    {"signal": "string", "value": "string — MUST include a unit (SAR/yr, SAR/m²/yr, orders/30d, /100, m, count, %, etc.); never a bare number", "implication": "string — one clause naming the investment consequence (not a description of what the number is)", "polarity": "positive | negative | neutral"}
   ],
   "risks": [
-    {"risk": "string", "mitigation": "string or null — see rule below"}
+    {"risk": "string", "mitigation": "string or null — specific tactics only; see rule below"}
   ],
-  "comparison": "string — 1-2 sentences placing this candidate against the named competitors. Be specific about what beats what.",
-  "bottom_line": "string — one sentence. Plain English. What you would tell the operator over coffee."
+  "comparison": "string — 2 to 3 sentences. MUST reference (a) at least one named competitor from comparable_competitors AND (b) the rank-2 alternative from next_candidate_summary, by rank ('rank 2 in this search...'). Be specific about what beats what.",
+  "bottom_line": "string — one sentence. The 'tell over coffee' closer. MUST NOT repeat the headline."
 }
 
+LENGTH BUDGET:
+- Aim for 350–500 words across all six sections combined. Do not pad to hit the upper bound. Density beats length; a tight 380-word memo is better than a padded 480-word memo.
+
+USE THESE SPECIFIC FIELDS when making the case. Do not hand-wave; cite numbers.
+
+Financial framing:
+- estimated_annual_rent_sar / display_annual_rent_sar: absolute annual rent in SAR.
+- comparable_median_annual_rent_sar + comparable_n + comparable_source_label:
+  the peer-listing median to compare rent against. When comparable_source_label
+  starts with "district_", phrase the comparison as "vs N district comparables."
+  When it starts with "city_", phrase it as "vs N citywide comparables in the
+  same band/type." Do NOT claim district scope when the label is city-scoped —
+  honesty about scope is non-negotiable.
+- score_breakdown.economics_detail.rent_burden.percentile: a 0–1 fraction.
+  Multiply by 100 to phrase ("at the 69th percentile vs comparables").
+
+Property overview:
+- area_m2 / unit_area_sqm: site area in m².
+- unit_street_width_m: frontage width in meters.
+- access_visibility_score, parking_score, frontage_score: 0–100 site-quality
+  scalars. Cite the number with the unit "/100".
+
+Market context:
+- population_reach: reachable population within walking distance.
+- district_momentum: trajectory signal for the district.
+- delivery_listing_count: depth of delivery demand in the area.
+- realized_demand_30d / realized_demand_branches: actual delivery orders, not
+  proxies. Lead with these when present.
+
+Competitive landscape:
+- brand_presence.top_chains: named chains within 500m with branch_count and
+  nearest_distance_m. Use display_name_en in English memos and display_name_ar
+  in Arabic memos.
+- comparable_competitors: rated peer restaurants for the operator's brand.
+- next_candidate_summary: the rank-2 site in this search, for explicit
+  alternative comparison. Reference it by rank in the comparison field.
+
+Risk signals:
+- gates.failed and gates.unknown: enumerate these as candidate risks.
+- listing_age.created_days / updated_days: flag stale listings (>90 days).
+- landlord_signal: counterparty / landlord behaviour score.
+
 HARD RULES:
-- The headline_recommendation, ranking_explanation, and bottom_line must agree directionally with `deterministic_verdict`, `overall_pass`, and `final_rank`. If `final_rank == 1` AND `final_score >= 70`, the headline must be 'Recommend' — not 'Recommend with reservations', not 'Consider'.
-- key_evidence must be 3–5 items. Every value MUST include a unit. A bare number ('81.48', '15') is a hard error — write '81/100', '15 count', '15 m frontage'.
-- Polarity discipline: 'neutral' is rare. If the implication mentions a concern or drawback, polarity is 'negative'. The implication and polarity must agree.
+- The headline_recommendation, ranking_explanation, and bottom_line must agree directionally with `deterministic_verdict`, `overall_pass`, and `final_rank`. If `final_rank == 1` AND `final_score >= 70`, the headline must be 'Recommend' — not 'Recommend with reservations', not 'Consider'. If `overall_pass == false`, the headline must be 'Decline'.
+- key_evidence must be 4–6 items. Every value MUST include a unit. A bare number ('81.48', '15') is a hard error — write '81/100', '15 count', '15 m frontage', 'SAR 480,000/yr'.
+- Polarity discipline: 'neutral' is rare. If the implication mentions a concern, drawback, or risk, polarity is 'negative'. If it strengthens the investment case, 'positive'. The implication and polarity must agree.
+- Implication phrasing: name the investment consequence in one clause, not a description. Write "the spread justifies the entry rent" — not "rent is below median". Write "signage works in both traffic directions" — not "site is on a corner".
+- risks must be 2–4 distinct items. One-risk memos are a defect. Draw from gates.failed, gates.unknown, listing staleness, parking unknowns, frontage signals, cannibalization, brand saturation. Each item needs a `risk` field; the `mitigation` field is optional.
 - Mitigations must be specific tactics the operator can act on (e.g. 'Lease curbside pickup zone from neighbour', 'Partner with HungerStation for delivery-first hours in the first 90 days', 'Add LED frontage signage on the corner approach'). If you can only think of generic advice like 'consider marketing strategies', 'focus on differentiation', 'enhance visibility' — OMIT the mitigation field (set it to null). Better silent than empty.
+- Comparison MUST reference both a named competitor AND the rank-2 candidate by rank. A comparison field that names neither is a defect.
 - Banned openers: 'Overall,', 'Generally speaking,', 'It appears that', 'consider due to', 'This candidate could potentially'.
 - Banned hedging modals when stating evidence or rationale: 'may', 'could', 'might', 'potentially'. Save them only for genuine future uncertainty in `risks`.
 - Do not start consecutive memos with the same skeleton. Lead with the strongest concrete signal for THIS site.
@@ -901,39 +951,49 @@ GATE LANGUAGE RULES (factual, not stylistic — violations are errors):
 - For any gate in `gates.failed`, 'fails on...', 'does not meet...' is appropriate; describe the failure plainly with the threshold.
 - Parking is frequently unknown for Aqar listings by architectural design, not by listing defect. If parking is in `gates.unknown`, treat it as a routine data-availability note — do not downgrade the site.
 
-VOICE EXAMPLES (target tone — match this directness):
+VOICE EXAMPLES (target tone — match this directness and depth):
 
-Example A — strong recommend, score 82, rank 1:
+Example C — strong recommend, score 84, rank 1, district-tier comparable:
 {
-  "headline_recommendation": "Recommend — rent is 18% under median and the corner gives the brand visibility from two arteries.",
-  "ranking_explanation": "This site leads on the two things that matter most for a QSR: cost basis and visibility. Rent is well below the Al Olaya median for restaurant-suitable units, and the corner position on a 22m road means signage works in both directions of traffic. Realized demand in the area is healthy — over 1,400 monthly orders in the surrounding district — so we are not betting on growth that hasn't shown up yet.",
+  "headline_recommendation": "Recommend — asking rent sits at the 28th percentile vs district comparables and the corner frontage gives the brand visibility from two arteries.",
+  "ranking_explanation": "The investment case here is rent: SAR 432,000/yr lands at the 28th percentile vs 14 district comparables, a roughly SAR 110,000/yr discount to the median that compounds materially over a five-year lease. Site quality reinforces the economics — a 24 m corner on a primary artery with an access/visibility score of 82/100 — and a population reach of 41,000 inside the walking catchment supports the dine-in model. The trade-off is depth of competition: three named chains operate within 500 m, so the brand will need a defensible category position rather than a generic offer.",
   "key_evidence": [
-    {"signal": "annual rent", "value": "480,000 SAR/yr", "implication": "18% below Al Olaya median for restaurant-suitable units", "polarity": "positive"},
-    {"signal": "realized demand", "value": "1,420 orders/30d", "implication": "7.8× the district median; demand is real, not projected", "polarity": "positive"},
-    {"signal": "frontage", "value": "22 m corner", "implication": "Signage visible from both directions on a primary artery", "polarity": "positive"},
-    {"signal": "competitors within 500m", "value": "3 count", "implication": "Light competitive pressure for this catchment", "polarity": "positive"}
+    {"signal": "annual rent", "value": "SAR 432,000/yr", "implication": "the spread to the district median justifies the entry — roughly SAR 110k/yr saved vs peer listings", "polarity": "positive"},
+    {"signal": "rent percentile vs comparables", "value": "28th percentile (vs 14 district comparables)", "implication": "deal pricing is genuinely below market, not just below list", "polarity": "positive"},
+    {"signal": "frontage", "value": "24 m corner", "implication": "signage works in both traffic directions on a primary artery", "polarity": "positive"},
+    {"signal": "access/visibility score", "value": "82/100", "implication": "site quality reinforces the rent advantage rather than offsetting it", "polarity": "positive"},
+    {"signal": "population reach", "value": "41,000 within walking catchment", "implication": "dine-in mix is supportable without leaning on delivery to fill seats", "polarity": "positive"},
+    {"signal": "named chains within 500 m", "value": "3 count", "implication": "the catchment validates the category but raises the bar on differentiation", "polarity": "negative"}
   ],
   "risks": [
-    {"risk": "Parking visibility could not be verified from current data — common for Aqar listings, not a site defect.", "mitigation": null}
+    {"risk": "Three established chains operate within 500 m, including two with strong delivery presence — undifferentiated entry will compete on price.", "mitigation": "Lead with a single-SKU hero menu and a sharper delivery price point in the first 90 days; revisit the dine-in mix once order velocity stabilises."},
+    {"risk": "Parking provision could not be verified from current data — typical for Aqar listings, not a site defect.", "mitigation": "Walk the block at peak hours during diligence; lease two adjacent street stalls from the neighbour if curbside turnover is constrained."},
+    {"risk": "Listing has been live for 102 days, longer than is typical for prime corner units in this district.", "mitigation": "Open negotiation 8–12% below asking and ask the landlord to absorb fit-out contribution."}
   ],
-  "comparison": "Beats Peer A on rent by ~15% and matches Peer B on visibility, with a stronger demand signal than either.",
-  "bottom_line": "Take this one — the rent alone justifies the deal, and the demand confirms it."
+  "comparison": "This site beats Peer Chain A on rent by roughly SAR 90k/yr and matches Peer Chain B on visibility, while pulling ahead of rank 2 in this search on rent percentile (28th vs 47th) and access/visibility (82/100 vs 71/100). Rank 2 has a marginally larger footprint but no comparable corner exposure.",
+  "bottom_line": "This is the deal in the shortlist — sign it before the listing turns."
 }
 
-Example B — recommend with reservations, score 71, rank 4:
+Example D — decline, score 41, rank 9, gates failed:
 {
-  "headline_recommendation": "Recommend with reservations — the economics work but the catchment is competitive.",
-  "ranking_explanation": "Rent and occupancy line up well, which is why this site clears our bar. The catch is competition: 9 burger-category operators within a kilometre, including two with strong delivery presence. The site is workable but won't win on its own — the brand will need to.",
+  "headline_recommendation": "Decline — economics gate fails at the 88th rent percentile and the catchment cannot underwrite the asking price.",
+  "ranking_explanation": "The asking rent of SAR 920,000/yr lands at the 88th percentile vs 11 citywide comparables in the same band/type — roughly 34% above the SAR 685,000 median, which by itself is enough to fail the economics gate. The site does not earn that premium: population reach inside the walking catchment is 18,000 and the access/visibility score sits at 54/100, both below the levels needed to support a premium-rent thesis for this category. The next-best alternative in the shortlist offers materially better economics for a comparable footprint, so capital is better deployed there.",
   "key_evidence": [
-    {"signal": "annual rent", "value": "1,500 SAR/m²/yr", "implication": "Slightly above district median but offset by strong occupancy economics", "polarity": "neutral"},
-    {"signal": "occupancy economics score", "value": "81/100", "implication": "Strong financials for the asking rent", "polarity": "positive"},
-    {"signal": "competitor count (burger, 1km)", "value": "9 count", "implication": "Crowded category; differentiation matters here", "polarity": "negative"}
+    {"signal": "annual rent", "value": "SAR 920,000/yr", "implication": "asking sits 34% above the comparable median — the deal is mispriced for the catchment", "polarity": "negative"},
+    {"signal": "rent percentile vs comparables", "value": "88th percentile (vs 11 citywide comparables in the same band/type)", "implication": "no peer-listing evidence that this rent is achievable for this format", "polarity": "negative"},
+    {"signal": "economics gate", "value": "failed", "implication": "deterministic threshold breached; the deal cannot be defended on rent burden", "polarity": "negative"},
+    {"signal": "population reach", "value": "18,000 within walking catchment", "implication": "thin demand base does not justify a premium rent position", "polarity": "negative"},
+    {"signal": "access/visibility score", "value": "54/100", "implication": "site quality is mid-tier and does not earn the premium pricing", "polarity": "negative"},
+    {"signal": "listing age (created)", "value": "147 days", "implication": "stale listing suggests the market has already declined this rent", "polarity": "negative"}
   ],
   "risks": [
-    {"risk": "Burger category is saturated within 1km.", "mitigation": "Lead with delivery-first hours via HungerStation partnership for the first 90 days; lock in the dine-in mix only after order volume validates the catchment."}
+    {"risk": "Economics gate failure — current rent leaves no margin for under-performance against forecast.", "mitigation": "Walk unless the landlord accepts a 25%+ rent reduction with a documented break clause."},
+    {"risk": "Frontage gate could not be verified from current data; signage potential is unclear.", "mitigation": null},
+    {"risk": "Two saturated chain operators within 500 m increase cannibalisation risk for any value-format entry.", "mitigation": "Reposition the brief towards a differentiated dayparting strategy if the operator chooses to override the recommendation."},
+    {"risk": "Listing has been on market for 147 days — pricing has not cleared, suggesting the asking is structurally above the catchment's willingness-to-pay.", "mitigation": null}
   ],
-  "comparison": "Cheaper than HERFY at 297 al Fawas but in a tighter competitive set; trade-off is rent vs. category density.",
-  "bottom_line": "Worth doing if the brand has a sharp delivery angle — otherwise pass."
+  "comparison": "Peer Chain A in this district closed at roughly SAR 640,000/yr — a 30% discount to this asking — and rank 2 in this search clears the economics gate at the 49th rent percentile with a slightly larger footprint and a stronger access/visibility profile. There is no scenario in which this site is the rational shortlist pick over rank 2.",
+  "bottom_line": "Walk this one and redeploy the capital into rank 2 — the math on this listing does not work."
 }
 
 Now write the memo for the candidate JSON the user provides. Match the voice in the examples. Be specific to this site, not generic."""

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -133,8 +133,10 @@ class TestFormatRentVsMedian:
 
 class TestDailyCeilingBlocksCall:
     def test_ceiling_blocks_when_exceeded(self):
+        from app.services.llm_decision_memo import DAILY_CEILING_USD
+
         today = _today_key()
-        _daily_cost_tracker[today] = 1.00
+        _daily_cost_tracker[today] = DAILY_CEILING_USD
 
         with pytest.raises(RuntimeError, match="daily cost ceiling"):
             generate_decision_memo(


### PR DESCRIPTION
## Summary

Addresses the CEO directive: *"The Decision Memo currently lacks value and depth. It should be tailored more like a real estate advisory report providing strong, persuasive reasoning that clearly explains why a specific location or property is worth investing in."* PR #1 plumbed the advisory-grade signals into `feature_snapshot_json`; **this PR teaches the LLM to use them**. Prompt + config + test fixtures only — no schema or frontend changes (deferred to PR #3).

## Key prompt changes

- **Persona reframed**: senior real-estate advisor writing an investment memo to a restaurant operator's principal — not a junior analyst briefing a colleague. Reader is the person making the capital call; memo's job is to answer "is this site worth the capital?" with persuasive, numerically-grounded reasoning.
- **`USE THESE SPECIFIC FIELDS` block** added — explicitly directs the LLM to ground every claim in named snapshot keys (rent percentile vs `comparable_median_annual_rent_sar` with honest `comparable_source_label` scope phrasing, `next_candidate_summary` for rank-2 alternative comparison, `brand_presence.top_chains` for named competitors within 500 m, `listing_age` for staleness flags, etc.).
- **Schema depth expanded** while keeping the same six top-level keys (back-compat with `app/api/expansion_advisor.py:_structured_to_legacy_shape`):
  - `ranking_explanation` 3–5 sentences (was 2–3); must lead with a number-grounded investment argument.
  - `key_evidence` 4–6 items (was 3–5); implications must name an investment consequence, not describe the number.
  - `risks` 2–4 distinct items (one-risk memos were the biggest depth defect on production data — `avg_risks` had collapsed to 1.0).
  - `comparison` 2–3 sentences; MUST reference both a named brand competitor AND the rank-2 candidate by rank.
- **Two new few-shot examples** (replacing prior A/B):
  - **Example C** — strong recommend with district-tier comparable scope (28th rent percentile vs 14 district comparables, 3 named chains in 500 m, 24 m corner, 3 distinct risks).
  - **Example D** — decline with multiple failed gates (88th rent percentile vs 11 citywide comparables in same band/type, economics gate failed, stale listing, explicit redeploy-to-rank-2 close).
- Banned hedging modals and openers carried forward; new directive: do NOT recite the score breakdown back at the reader — synthesize it into an investment thesis. Length budget 350–500 words; density beats length.

## Config bumps

- `EXPANSION_MEMO_MAX_TOKENS` **1200 → 2400** — the prompt expansion roughly doubles output tokens.
- `DAILY_CEILING_USD` **1.0 → 5.0** — proportional headroom plus buffer for the v4 cache regeneration spike on first deploy.
- `MEMO_PROMPT_VERSION` `v3-snapshot-2026-04` → **`v4-advisor-2026-04`** — invalidates the v3 cache that PR #1 just populated; every cached memo regenerates lazily on next view.

## Whitelist cleanup

- Removed `district_median_rent` from `_MEMO_WHITELIST` and `_RERANK_WHITELIST`. The new prompt uses `comparable_median_annual_rent_sar` exclusively. The legacy `generate_decision_memo` fallback still reads `candidate.get("district_median_rent")` directly from the full candidate dict (not the whitelisted snapshot), so the fallback continues to work unchanged.

## Legacy fallback

- `_PROMPT_TEMPLATE_EN` / `_PROMPT_TEMPLATE_AR` left intact as the structured-output parse-failure fallback. Added an inline comment marking it as intentionally narrower than the structured prompt; do not extend with new advisor directives.

## Validation steps for the maintainer

After merge and deploy:

1. Run a fresh search at http://8.213.84.191/ and open the top-1 candidate's memo. Manual checks:
   - Reads like a real-estate advisor wrote it (not a junior analyst).
   - At least 4 `key_evidence` items, every `value` has a unit.
   - At least 2 `risks` items (likely 3–4).
   - `comparison` references the rank-2 candidate by rank AND a named brand competitor.
   - `ranking_explanation` cites at least one specific SAR figure or percentile.
2. Codespace SQL spot-check:
   ```sql
   SELECT decision_memo_prompt_version, COUNT(*),
          AVG(jsonb_array_length(decision_memo_json->'key_evidence')) AS avg_evidence,
          AVG(jsonb_array_length(decision_memo_json->'risks')) AS avg_risks
   FROM expansion_candidate
   WHERE computed_at >= NOW() - INTERVAL '1 hour'
     AND decision_memo_json IS NOT NULL
   GROUP BY 1;
   ```
   Expect `v4-advisor-2026-04` rows with `avg_risks >= 2.0` (was exactly 1.0) and `avg_evidence >= 4.0` (was floor-bouncing at 3.0).
3. Compare a fresh v4 memo side-by-side with a v3 memo on the same parcel — v4 should be visibly more advisor-shaped.

## Test status

- All 39 directly testable `test_llm_decision_memo.py` tests pass locally; the four `TestDecisionMemoEndpoint*` tests require live geospatial transitive deps and were not exercised in this sandbox (unrelated to prompt changes).
- `test_sample_regression_memos.py` (6/6) passes — script plumbing untouched.
- `TestDailyCeilingBlocksCall::test_ceiling_blocks_when_exceeded` updated to seed the tracker from `DAILY_CEILING_USD` rather than a hard-coded `1.00`, so it now tracks the active ceiling.
- **Golden regression fixtures (`scripts/sample_regression_memos.py`)**: this script is invoked manually against the live LLM and is intentionally not run in CI. Maintainer should re-run it post-merge to refresh the eyeball-quality output for the new v4 prompt; the script itself needs no code change.

## Out of scope (deferred)

- Schema redesign with new top-level fields (`property_overview`, `financial_framing`, etc.) → **PR #3**.
- Frontend `DecisionMemoNarrative.tsx` updates → **PR #3**.
- Arabic few-shot examples → **PR #3** alongside the schema redesign.
- True district-scope median over `expansion_rent_comp` (data already split district vs city via `comparable_source_label`; honest scope phrasing is now enforced in the prompt).

PR #3 (schema redesign + frontend rewrite) follows this PR for the remaining ~25% of directive coverage.

## Test plan

- [ ] Run a live search after deploy and verify memo depth on the top-1 candidate matches the validation checklist above.
- [ ] SQL spot-check confirms `avg_risks >= 2.0` and `avg_evidence >= 4.0` for `v4-advisor-2026-04` rows.
- [ ] Verify rate of `comparison` fields referencing rank-2 climbs from ~0% (pre-v4) to near-100%.
- [ ] Confirm legacy fallback still parses cleanly for any malformed structured response.

**Do not merge — wait for explicit merge instruction.**

https://claude.ai/code/session_01UAcg6QuVyvK5iDpWfCQyDr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UAcg6QuVyvK5iDpWfCQyDr)_