### PR TITLE
chore(prewarm): bump EXPANSION_MEMO_PREWARM_BUDGET_S default 120s → 600s for v5 memo pacing

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -172,7 +172,7 @@ class Settings:
     #     ``EXPANSION_MEMO_PREWARM_ENABLED=false`` or
     #     ``EXPANSION_MEMO_PREWARM_TOP_N=0`` to disable pre-warm.
     EXPANSION_MEMO_PREWARM_BUDGET_S: float = float(
-        os.getenv("EXPANSION_MEMO_PREWARM_BUDGET_S", "120")
+        os.getenv("EXPANSION_MEMO_PREWARM_BUDGET_S", "600")
     )
 
 


### PR DESCRIPTION
## Context

Production logs after the v5 deploy show:

```
expansion_memo_prewarm budget exhausted: elapsed=172.14s budget=120.00s
  generated=3 skipped=0 failed=0 remaining=7
expansion_memo_prewarm done: wall_s=172.14 generated=3 skipped=0 failed=0
```

v5 memos take ~57s each (vs ~15s for v4.2 — driven by 10 keys + thesis paragraphs at 1300–1500 output tokens, fully expected for `gpt-4o-mini`'s output rate). The 120s budget covers 3 of 10 candidates; the other 7 stay NULL and trigger the on-demand legacy fallback when clicked.

This is **Shape 1** of a two-shape fix: bump the default to immediately close the visible gap. **Shape 2** (parallelization) follows in a separate PR.

## Change

Single-line default bump in `app/core/config.py`:

```python
EXPANSION_MEMO_PREWARM_BUDGET_S: float = float(
    os.getenv("EXPANSION_MEMO_PREWARM_BUDGET_S", "600")  # was "120"
)
```

## Sanity checks

1. **No env override masks the new default.** `grep -rn EXPANSION_MEMO_PREWARM_BUDGET_S` across `k8s/` and `.github/` returns no hits — the new default takes effect on deploy.
2. **Prewarm runs as a background task.** `app/api/expansion_advisor.py:986-991` invokes it via `background_tasks.add_task(_prewarm_decision_memos, ...)` before the response dict is returned at line 993. A 600s budget therefore adds **zero** latency to the user-facing search request.

## Rationale

- v5 generation works correctly when given the chance (3/3 success rate, zero validator/parse failures observed in production logs).
- The 120s budget was sized for v4.2's faster memos. v5's longer thesis prose makes each call ~57s, so the budget needs to cover ~10 × 57s = 570s.
- 600s gives a 30s cushion for tail latency.
- **Cost impact:** each search now spends ~10 LLM calls instead of ~3. At observed $0.0024/call, that's ~$0.024/search. The `_check_daily_ceiling()` cost cap at $5/day in `app/services/llm_decision_memo.py` still bounds runaway. Cost is non-binding.
- **Latency impact for users:** zero — prewarm runs in a background task after the search response is sent.
- **Rollback:** revert this single line; redeploy.

## Tests

No test changes required — this is a default value bump, not a logic change. Existing tests pass through (they `monkeypatch` the setting explicitly).

## What this fixes

- Closes the symptom of "12 of 15 candidates have NULL `decision_memo_json`" after a fresh search.
- Faisal will see PR #3's typed advisory cards on candidates ranked 1–10 in any fresh search after this deploys.
- Pre-existing NULL candidates from searches before this deploy remain NULL until clicked (they regenerate v5 lazily on click — also expected behavior).

## What this does NOT fix

- Sequential bottleneck. If `EXPANSION_MEMO_PREWARM_TOP_N` is ever raised above 10 (e.g., to 15), 600s won't be enough. Shape 2 (parallelization) addresses this in a follow-up PR.

## Risk

**Low.** Default-value change only. Behavior is unchanged for any environment that already sets `EXPANSION_MEMO_PREWARM_BUDGET_S` explicitly. No code paths altered.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127iUbKz1FjbdEZAj4tko9U)_