### PR TITLE
Add concurrent pre-warming of expansion decision memos

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Literal
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -681,100 +683,137 @@ def _prewarm_decision_memos(
     targets = candidate_specs[:top_n]
     budget = float(settings.EXPANSION_MEMO_PREWARM_BUDGET_S)
     budget_enforced = budget > 0
+    concurrency = max(1, int(settings.EXPANSION_MEMO_PREWARM_CONCURRENCY))
     started_at = _prewarm_time.monotonic()
-    generated = 0
-    skipped = 0
-    failed = 0
 
-    db: Session = db_session.SessionLocal()
+    counters = {"generated": 0, "skipped": 0, "failed": 0}
+    counters_lock = threading.Lock()
+
+    logger.info(
+        "expansion_memo_prewarm start: search_id=%s top_n=%d budget_s=%s",
+        search_id, len(targets),
+        f"{budget:.0f}" if budget_enforced else "unbounded",
+    )
+
+    def _process_one(spec: dict[str, Any]) -> None:
+        # Each worker opens its own DB session — DO NOT share a session
+        # across threads. SQLAlchemy Session objects are not thread-safe.
+        # Per-candidate exceptions are swallowed and logged so one bad
+        # memo cannot crash the batch. The daily-cost ceiling check in
+        # ``llm_decision_memo._check_daily_ceiling`` is intentionally
+        # unlocked: under concurrency, up to N-1 calls may slip past the
+        # ceiling on the same tick (acceptable at the $5/day cap).
+        parcel_id = spec.get("parcel_id")
+        if not parcel_id:
+            with counters_lock:
+                counters["skipped"] += 1
+            return
+        db: Session = db_session.SessionLocal()
+        try:
+            cached = _decision_memo_cache_lookup(
+                db, search_id, str(parcel_id)
+            )
+            if cached is not None and cached[1] is not None:
+                with counters_lock:
+                    counters["skipped"] += 1
+                logger.info(
+                    "expansion_memo_prewarm skip cached: "
+                    "search_id=%s parcel_id=%s",
+                    search_id, parcel_id,
+                )
+                return
+            ctx = build_memo_context(
+                candidate=spec,
+                brief={"brand_profile": brand_profile or {}},
+                lang="en",
+            )
+            memo_json = generate_structured_memo(ctx)
+            if memo_json is None:
+                with counters_lock:
+                    counters["skipped"] += 1
+                logger.info(
+                    "expansion_memo_prewarm skip (no memo): "
+                    "search_id=%s parcel_id=%s",
+                    search_id, parcel_id,
+                )
+                return
+            memo_text = render_structured_memo_as_text(memo_json, "en")
+            _decision_memo_cache_write(
+                db, search_id, str(parcel_id), memo_text, memo_json,
+            )
+            with counters_lock:
+                counters["generated"] += 1
+            logger.info(
+                "expansion_memo_prewarm ok: "
+                "search_id=%s parcel_id=%s",
+                search_id, parcel_id,
+            )
+        except Exception:
+            with counters_lock:
+                counters["failed"] += 1
+            logger.warning(
+                "expansion_memo_prewarm fail: "
+                "search_id=%s parcel_id=%s",
+                search_id, parcel_id,
+                exc_info=True,
+            )
+        finally:
+            try:
+                db.close()
+            except Exception:
+                logger.debug(
+                    "expansion_memo_prewarm: db close failed",
+                    exc_info=True,
+                )
+
+    budget_breached = False
+    executor = ThreadPoolExecutor(max_workers=concurrency)
     try:
-        logger.info(
-            "expansion_memo_prewarm start: search_id=%s top_n=%d "
-            "budget_s=%s",
-            search_id, len(targets),
-            f"{budget:.0f}" if budget_enforced else "unbounded",
-        )
-        for index, spec in enumerate(targets):
-            parcel_id = spec.get("parcel_id")
-            if not parcel_id:
-                skipped += 1
-            else:
-                try:
-                    cached = _decision_memo_cache_lookup(
-                        db, search_id, str(parcel_id)
-                    )
-                    if cached is not None and cached[1] is not None:
-                        skipped += 1
-                        logger.info(
-                            "expansion_memo_prewarm skip cached: "
-                            "search_id=%s parcel_id=%s",
-                            search_id, parcel_id,
-                        )
-                    else:
-                        ctx = build_memo_context(
-                            candidate=spec,
-                            brief={"brand_profile": brand_profile or {}},
-                            lang="en",
-                        )
-                        memo_json = generate_structured_memo(ctx)
-                        if memo_json is None:
-                            skipped += 1
-                            logger.info(
-                                "expansion_memo_prewarm skip (no memo): "
-                                "search_id=%s parcel_id=%s",
-                                search_id, parcel_id,
-                            )
-                        else:
-                            memo_text = render_structured_memo_as_text(
-                                memo_json, "en"
-                            )
-                            _decision_memo_cache_write(
-                                db, search_id, str(parcel_id),
-                                memo_text, memo_json,
-                            )
-                            generated += 1
-                            logger.info(
-                                "expansion_memo_prewarm ok: "
-                                "search_id=%s parcel_id=%s",
-                                search_id, parcel_id,
-                            )
-                except Exception:
-                    failed += 1
-                    logger.warning(
-                        "expansion_memo_prewarm fail: "
-                        "search_id=%s parcel_id=%s",
-                        search_id, parcel_id,
-                        exc_info=True,
-                    )
-
-            # Budget check runs AFTER the iteration so the first candidate
-            # is always attempted even when the budget is tiny. Skip the
-            # check after the final iteration (nothing left to abort).
-            is_last = index == len(targets) - 1
-            if budget_enforced and not is_last:
+        futures = [executor.submit(_process_one, spec) for spec in targets]
+        for future in as_completed(futures):
+            # _process_one catches its own exceptions; this .result() is
+            # defensive and surfaces any unexpected error from the worker.
+            try:
+                future.result()
+            except Exception:
+                logger.debug(
+                    "expansion_memo_prewarm: unexpected worker exception",
+                    exc_info=True,
+                )
+            if budget_enforced:
                 elapsed = _prewarm_time.monotonic() - started_at
                 if elapsed >= budget:
-                    remaining = len(targets) - (index + 1)
+                    budget_breached = True
+                    remaining = 0
+                    for f in futures:
+                        if not f.done() and f.cancel():
+                            remaining += 1
+                    with counters_lock:
+                        snapshot = dict(counters)
                     logger.info(
                         "expansion_memo_prewarm budget exhausted: "
                         "search_id=%s elapsed=%.2fs budget=%.2fs "
                         "generated=%d skipped=%d failed=%d remaining=%d",
                         search_id, elapsed, budget,
-                        generated, skipped, failed, remaining,
+                        snapshot["generated"], snapshot["skipped"],
+                        snapshot["failed"], remaining,
                     )
                     break
-        logger.info(
-            "expansion_memo_prewarm done: search_id=%s wall_s=%.2f "
-            "generated=%d skipped=%d failed=%d",
-            search_id,
-            _prewarm_time.monotonic() - started_at,
-            generated, skipped, failed,
-        )
     finally:
-        try:
-            db.close()
-        except Exception:
-            logger.debug("expansion_memo_prewarm: db close failed", exc_info=True)
+        if budget_breached:
+            executor.shutdown(wait=False, cancel_futures=True)
+        else:
+            executor.shutdown(wait=True)
+
+    with counters_lock:
+        snapshot = dict(counters)
+    logger.info(
+        "expansion_memo_prewarm done: search_id=%s wall_s=%.2f "
+        "generated=%d skipped=%d failed=%d",
+        search_id,
+        _prewarm_time.monotonic() - started_at,
+        snapshot["generated"], snapshot["skipped"], snapshot["failed"],
+    )
 
 
 def _build_prewarm_specs(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -158,7 +158,7 @@ class Settings:
         in {"1", "true", "yes", "on"}
     )
     EXPANSION_MEMO_PREWARM_TOP_N: int = int(
-        os.getenv("EXPANSION_MEMO_PREWARM_TOP_N", "10")
+        os.getenv("EXPANSION_MEMO_PREWARM_TOP_N", "15")
     )
     # Wall-clock cap across the whole pre-warm batch. The check runs AFTER
     # each iteration, so the first candidate is ALWAYS attempted regardless
@@ -173,6 +173,14 @@ class Settings:
     #     ``EXPANSION_MEMO_PREWARM_TOP_N=0`` to disable pre-warm.
     EXPANSION_MEMO_PREWARM_BUDGET_S: float = float(
         os.getenv("EXPANSION_MEMO_PREWARM_BUDGET_S", "600")
+    )
+    # Max number of concurrent LLM calls during pre-warm. Each worker
+    # opens its own DB session — no cross-thread session sharing. Setting
+    # this to ``1`` reverts to strict sequential execution (the rollback
+    # path; see ``_prewarm_decision_memos``). Values above 10 risk hitting
+    # OpenAI tier-1 RPM limits on gpt-4o-mini.
+    EXPANSION_MEMO_PREWARM_CONCURRENCY: int = int(
+        os.getenv("EXPANSION_MEMO_PREWARM_CONCURRENCY", "5")
     )
 
 

--- a/tests/test_expansion_advisor_phase3_chunk1.py
+++ b/tests/test_expansion_advisor_phase3_chunk1.py
@@ -447,6 +447,8 @@ def test_prewarm_respects_top_n(monkeypatch):
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_ENABLED", True)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_TOP_N", 3)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_BUDGET_S", 1000.0)
+    # Pin to sequential execution so order assertions hold.
+    monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_CONCURRENCY", 1)
 
     # 5 candidates in a list; only the first 3 should be processed.
     items = [
@@ -484,7 +486,9 @@ def test_prewarm_respects_top_n(monkeypatch):
 
     assert gen_calls == ["p1", "p2", "p3"]
     assert [w[1] for w in writes] == ["p1", "p2", "p3"]
-    session_instance.close.assert_called_once()
+    # Each worker now opens its own session, so close() fires once per
+    # candidate (3 specs → 3 closes; SessionLocal returns the same mock).
+    assert session_instance.close.call_count == 3
 
 
 # ---------------------------------------------------------------------------
@@ -496,6 +500,8 @@ def test_prewarm_per_candidate_error_does_not_abort_batch(monkeypatch):
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_ENABLED", True)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_TOP_N", 3)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_BUDGET_S", 1000.0)
+    # Pin to sequential execution so write-order assertions hold.
+    monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_CONCURRENCY", 1)
 
     specs = [
         {"id": "c1", "parcel_id": "p1"},
@@ -536,6 +542,9 @@ def test_prewarm_generous_budget_warms_all(monkeypatch):
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_ENABLED", True)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_TOP_N", 3)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_BUDGET_S", 120.0)
+    # Pin to sequential execution so the mocked monotonic clock advances
+    # deterministically.
+    monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_CONCURRENCY", 1)
 
     specs = [{"id": f"c{i}", "parcel_id": f"p{i}"} for i in range(1, 4)]
 
@@ -578,6 +587,9 @@ def test_prewarm_first_attempt_always_runs_then_budget_trips(monkeypatch, caplog
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_ENABLED", True)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_TOP_N", 3)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_BUDGET_S", 1.0)
+    # Pin to sequential execution so the mocked monotonic clock advances
+    # deterministically.
+    monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_CONCURRENCY", 1)
 
     specs = [{"id": f"c{i}", "parcel_id": f"p{i}"} for i in range(1, 4)]
 
@@ -628,6 +640,9 @@ def test_prewarm_budget_non_positive_is_unbounded(monkeypatch):
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_ENABLED", True)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_TOP_N", 3)
     monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_BUDGET_S", 0.0)
+    # Pin to sequential execution so the mocked monotonic clock advances
+    # deterministically.
+    monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_CONCURRENCY", 1)
 
     specs = [{"id": f"c{i}", "parcel_id": f"p{i}"} for i in range(1, 4)]
 

--- a/tests/test_prewarm_concurrency.py
+++ b/tests/test_prewarm_concurrency.py
@@ -1,0 +1,260 @@
+"""Concurrency behaviour for ``_prewarm_decision_memos``.
+
+The pre-warm loop was changed from a strict sequential ``for`` loop to a
+``ThreadPoolExecutor``-driven fan-out. These tests pin down the new
+contract:
+
+1. With concurrency > 1, all candidates complete inside a generous budget,
+   in roughly ``ceil(n / workers) × per-call`` wall time rather than
+   ``n × per-call``.
+2. When the budget breaches mid-batch, remaining futures are cancelled
+   (no crash, ``remaining`` count surfaced in the log line).
+3. Per-candidate exceptions are swallowed; ``failed`` and ``skipped``
+   counters are correct, batch completes.
+4. Concurrency=1 reproduces sequential behaviour exactly (rollback path).
+5. Each worker uses its own DB session — the outer scope never opens a
+   shared session that workers reuse.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app.core.config import settings as _ea_settings
+
+
+def _baseline_monkeypatch(monkeypatch, *, top_n: int, budget_s: float, concurrency: int) -> None:
+    monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_ENABLED", True)
+    monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_TOP_N", top_n)
+    monkeypatch.setattr(_ea_settings, "EXPANSION_MEMO_PREWARM_BUDGET_S", budget_s)
+    monkeypatch.setattr(
+        _ea_settings, "EXPANSION_MEMO_PREWARM_CONCURRENCY", concurrency
+    )
+
+
+def _stub_memo_helpers(monkeypatch, api_mod, gen_fn) -> list[str]:
+    """Stub out the memo helpers so tests don't need a real DB or LLM.
+
+    Returns the list that captures persisted parcel_ids in call order.
+    """
+    monkeypatch.setattr(api_mod, "generate_structured_memo", gen_fn)
+    monkeypatch.setattr(
+        api_mod, "render_structured_memo_as_text", lambda j, lang: "text"
+    )
+    monkeypatch.setattr(
+        api_mod, "_decision_memo_cache_lookup", lambda db, sid, pid: None
+    )
+    writes: list[str] = []
+    writes_lock = threading.Lock()
+
+    def _record_write(db, sid, pid, t, j):
+        with writes_lock:
+            writes.append(pid)
+
+    monkeypatch.setattr(api_mod, "_decision_memo_cache_write", _record_write)
+    return writes
+
+
+# ---------------------------------------------------------------------------
+# 1. Concurrent execution completes the full batch within budget.
+# ---------------------------------------------------------------------------
+def test_prewarm_concurrent_completes_all_within_budget(monkeypatch):
+    from app.api import expansion_advisor as api_mod
+
+    _baseline_monkeypatch(monkeypatch, top_n=15, budget_s=10.0, concurrency=5)
+
+    specs = [{"id": f"c{i}", "parcel_id": f"p{i}"} for i in range(1, 16)]
+
+    def _slow_gen(ctx):
+        time.sleep(0.1)
+        return {"headline_recommendation": "ok"}
+
+    writes = _stub_memo_helpers(monkeypatch, api_mod, _slow_gen)
+
+    with patch.object(
+        api_mod.db_session, "SessionLocal", return_value=MagicMock()
+    ):
+        wall_start = time.monotonic()
+        api_mod._prewarm_decision_memos("s1", specs, {})
+        wall_elapsed = time.monotonic() - wall_start
+
+    assert sorted(writes) == sorted(s["parcel_id"] for s in specs)
+    # 15 candidates / 5 workers = 3 batches × 0.1s ≈ 0.3s + scheduling.
+    # Sequential would be 15 × 0.1s = 1.5s. Anything under ~1s proves
+    # parallelism is real.
+    assert wall_elapsed < 1.0, (
+        f"prewarm wall time {wall_elapsed:.2f}s suggests sequential execution"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Budget breach cancels remaining futures cleanly.
+# ---------------------------------------------------------------------------
+def test_prewarm_budget_breach_cancels_remaining(monkeypatch, caplog):
+    from app.api import expansion_advisor as api_mod
+
+    _baseline_monkeypatch(monkeypatch, top_n=15, budget_s=1.0, concurrency=5)
+
+    specs = [{"id": f"c{i}", "parcel_id": f"p{i}"} for i in range(1, 16)]
+
+    def _very_slow_gen(ctx):
+        time.sleep(2.0)
+        return {"headline_recommendation": "ok"}
+
+    writes = _stub_memo_helpers(monkeypatch, api_mod, _very_slow_gen)
+
+    with caplog.at_level("INFO", logger=api_mod.logger.name):
+        with patch.object(
+            api_mod.db_session, "SessionLocal", return_value=MagicMock()
+        ):
+            api_mod._prewarm_decision_memos("s1", specs, {})
+
+    # At most ~1 batch of workers (5) finishes before the budget trips. We
+    # cap the assertion well above 5 to absorb scheduler noise but still
+    # well below 15 (sequential).
+    assert len(writes) <= 10
+    budget_lines = [
+        r.message for r in caplog.records if "budget exhausted" in r.message
+    ]
+    assert len(budget_lines) == 1
+    # Cancellation surfaced at least one un-started future. Workers that
+    # were already in-flight will not be cancellable, which is fine.
+    msg = budget_lines[0]
+    assert "remaining=" in msg
+    remaining_value = int(msg.split("remaining=")[1].split()[0])
+    assert remaining_value >= 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-candidate exception (and a None return) does not crash the batch.
+# ---------------------------------------------------------------------------
+def test_prewarm_per_candidate_exception_does_not_crash_batch(monkeypatch, caplog):
+    from app.api import expansion_advisor as api_mod
+
+    _baseline_monkeypatch(monkeypatch, top_n=15, budget_s=120.0, concurrency=5)
+
+    specs = [{"id": f"c{i}", "parcel_id": f"p{i}"} for i in range(1, 16)]
+
+    def _gen(ctx):
+        if ctx.parcel_id == "p3":
+            raise RuntimeError("synthetic failure")
+        if ctx.parcel_id == "p5":
+            return None
+        return {"headline_recommendation": "ok"}
+
+    writes = _stub_memo_helpers(monkeypatch, api_mod, _gen)
+
+    with caplog.at_level("WARNING", logger=api_mod.logger.name):
+        with patch.object(
+            api_mod.db_session, "SessionLocal", return_value=MagicMock()
+        ):
+            api_mod._prewarm_decision_memos("s1", specs, {})
+
+    # 13 generated (15 minus the raise and the None), no crash.
+    assert len(writes) == 13
+    assert "p3" not in writes  # raised
+    assert "p5" not in writes  # validator returned None
+
+    # The exception path went through logger.warning with exc_info.
+    fail_records = [
+        r for r in caplog.records
+        if r.levelname == "WARNING"
+        and "expansion_memo_prewarm fail" in r.message
+        and "parcel_id=p3" in r.message
+    ]
+    assert len(fail_records) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Concurrency=1 is sequential-equivalent (rollback path).
+# ---------------------------------------------------------------------------
+def test_prewarm_concurrency_one_is_sequential_equivalent(monkeypatch):
+    from app.api import expansion_advisor as api_mod
+
+    _baseline_monkeypatch(monkeypatch, top_n=3, budget_s=120.0, concurrency=1)
+
+    specs = [{"id": f"c{i}", "parcel_id": f"p{i}"} for i in range(1, 4)]
+
+    sleep_per_call = 0.05
+    call_order: list[str] = []
+
+    def _gen(ctx):
+        call_order.append(str(ctx.parcel_id))
+        time.sleep(sleep_per_call)
+        return {"headline_recommendation": "ok"}
+
+    writes = _stub_memo_helpers(monkeypatch, api_mod, _gen)
+
+    with patch.object(
+        api_mod.db_session, "SessionLocal", return_value=MagicMock()
+    ):
+        wall_start = time.monotonic()
+        api_mod._prewarm_decision_memos("s1", specs, {})
+        wall_elapsed = time.monotonic() - wall_start
+
+    # Strict sequential ordering and write order.
+    assert call_order == ["p1", "p2", "p3"]
+    assert writes == ["p1", "p2", "p3"]
+    # Wall time ≈ 3 × per-call sleep. A real concurrent run would be ~1×.
+    assert wall_elapsed >= 3 * sleep_per_call * 0.9, (
+        f"wall {wall_elapsed:.3f}s shorter than sequential lower bound — "
+        f"concurrency=1 is not actually sequential"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Each worker opens its own DB session.
+# ---------------------------------------------------------------------------
+def test_prewarm_each_worker_uses_own_db_session(monkeypatch):
+    from app.api import expansion_advisor as api_mod
+
+    _baseline_monkeypatch(monkeypatch, top_n=4, budget_s=120.0, concurrency=4)
+
+    specs = [{"id": f"c{i}", "parcel_id": f"p{i}"} for i in range(1, 5)]
+
+    sessions_seen: list[int] = []
+    sessions_lock = threading.Lock()
+
+    def _fake_session_local():
+        m = MagicMock(name=f"Session-{len(sessions_seen)}")
+        with sessions_lock:
+            sessions_seen.append(id(m))
+        return m
+
+    # The lookup helper records which session id was passed in, so we can
+    # verify the inner helper's session — not some smuggled outer session
+    # — is what gets to the DB layer.
+    seen_in_lookup: list[int] = []
+
+    def _fake_lookup(db, sid, pid):
+        with sessions_lock:
+            seen_in_lookup.append(id(db))
+        return None
+
+    monkeypatch.setattr(api_mod, "_decision_memo_cache_lookup", _fake_lookup)
+    monkeypatch.setattr(
+        api_mod, "generate_structured_memo",
+        lambda ctx: {"headline_recommendation": "ok"},
+    )
+    monkeypatch.setattr(
+        api_mod, "render_structured_memo_as_text", lambda j, lang: "text"
+    )
+    monkeypatch.setattr(
+        api_mod, "_decision_memo_cache_write",
+        lambda db, sid, pid, t, j: None,
+    )
+
+    with patch.object(
+        api_mod.db_session, "SessionLocal", side_effect=_fake_session_local
+    ):
+        api_mod._prewarm_decision_memos("s1", specs, {})
+
+    # One SessionLocal() call per candidate (no shared outer session).
+    assert len(sessions_seen) == 4
+    # All session ids are distinct — no thread is sharing.
+    assert len(set(sessions_seen)) == 4
+    # Every lookup saw one of the per-worker sessions.
+    assert set(seen_in_lookup).issubset(set(sessions_seen))
+    assert len(seen_in_lookup) == 4


### PR DESCRIPTION
## Summary
Converts the sequential pre-warming loop for expansion decision memos into a concurrent implementation using `ThreadPoolExecutor`, enabling faster batch processing while maintaining safety and correctness guarantees.

## Key Changes

- **Concurrent execution**: Replaced the sequential `for` loop in `_prewarm_decision_memos()` with a `ThreadPoolExecutor`-based fan-out pattern, controlled by a new `EXPANSION_MEMO_PREWARM_CONCURRENCY` setting (default: 5 workers).

- **Per-worker DB sessions**: Each worker now opens its own SQLAlchemy `Session` to avoid thread-safety issues. The outer scope no longer maintains a shared session.

- **Budget enforcement with cancellation**: When the wall-clock budget is breached, remaining un-started futures are cancelled cleanly. The log message surfaces the count of cancelled tasks.

- **Thread-safe counters**: Converted `generated`, `skipped`, and `failed` counters to a shared dictionary protected by a lock, ensuring accurate tallies under concurrent updates.

- **Exception isolation**: Per-candidate exceptions are caught and logged without crashing the batch. Failed and skipped candidates are properly tracked.

- **Rollback path**: Setting `EXPANSION_MEMO_PREWARM_CONCURRENCY=1` reverts to strict sequential execution, preserving the original behavior for debugging or safety.

- **Configuration updates**: 
  - Added `EXPANSION_MEMO_PREWARM_CONCURRENCY` setting (default: 5, configurable via env var)
  - Increased `EXPANSION_MEMO_PREWARM_TOP_N` default from 10 to 15

## Implementation Details

- Uses `concurrent.futures.as_completed()` to process futures as they finish, enabling budget checks between completions rather than waiting for all tasks.
- Each worker's `_process_one()` function is self-contained: it opens a session, processes the candidate, handles exceptions, and closes the session.
- Budget breach triggers `executor.shutdown(wait=False, cancel_futures=True)` to abort remaining work immediately.
- Thread locks protect counter updates and snapshot reads for consistent logging.
- Comprehensive test suite (`test_prewarm_concurrency.py`) validates all five contract points: concurrent speedup, budget cancellation, exception handling, sequential equivalence at concurrency=1, and per-worker session isolation.

## Testing
- Updated existing tests to pin `EXPANSION_MEMO_PREWARM_CONCURRENCY=1` where order assertions depend on sequential execution.
- Added 260 lines of new tests covering concurrency behavior, budget enforcement, exception handling, and session isolation.

https://claude.ai/code/session_01DybXsVjxoioXUrWUwTKLs4