### PR TITLE
fix(memo): render advisory cards from fetched memo, not candidate-list shape

### DIFF
--- a/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import type {
   GeneratedDecisionMemo,
@@ -8,6 +8,23 @@ import type {
   StructuredMemoRisk,
 } from "../../lib/api/expansionAdvisor";
 import { generateDecisionMemo } from "../../lib/api/expansionAdvisor";
+import AdvisorySectionCards from "./AdvisorySectionCards";
+
+// Module-level cache shared across all DecisionMemoNarrative instances. Lets
+// callers (and tests) read the fetched memo synchronously after it has
+// resolved once for a given candidate id.
+const memoModuleCache = new Map<string, GeneratedDecisionMemo>();
+
+export function _seedDecisionMemoCacheForTest(
+  candidateId: string,
+  value: GeneratedDecisionMemo,
+): void {
+  memoModuleCache.set(candidateId, value);
+}
+
+export function _clearDecisionMemoCacheForTest(): void {
+  memoModuleCache.clear();
+}
 
 type Props = {
   candidate: Record<string, unknown>;
@@ -169,6 +186,13 @@ export function StructuredNarrative({ memo, lang }: { memo: StructuredMemo; lang
           <p className="ea-memo-structured__bottom-line-text">{bottomLine}</p>
         </section>
       )}
+
+      {/* PR #3: v5 advisory section cards. Sourced from the same fetched
+          structured memo as the narrative above — the candidate-list shape
+          intentionally excludes decision_memo_json, and the GET memo endpoint
+          may return it null until the prewarm cache is written. Renders
+          nothing when none of the four v5 sections are populated. */}
+      <AdvisorySectionCards memo={memo} lang={lang === "ar" ? "ar" : "en"} />
     </div>
   );
 }
@@ -229,20 +253,19 @@ export function LegacyNarrative({ memo, lang }: { memo: LLMDecisionMemo; lang: s
 
 export default function DecisionMemoNarrative({ candidate, brief, lang }: Props) {
   const { t } = useTranslation();
-  const [result, setResult] = useState<GeneratedDecisionMemo | null>(null);
+  const candidateId = String((candidate as Record<string, unknown>).id ?? "");
+  // Seed initial state from the module cache so tests (and same-session
+  // re-mounts) can render synchronously without re-fetching.
+  const [result, setResult] = useState<GeneratedDecisionMemo | null>(
+    () => (candidateId ? memoModuleCache.get(candidateId) ?? null : null),
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Cache by candidate id so re-renders don't re-fetch. The cache stores the
-  // full GeneratedDecisionMemo wrapper so both structured and legacy shapes
-  // survive candidate switching.
-  const cacheRef = useRef<Map<string, GeneratedDecisionMemo>>(new Map());
-  const candidateId = String((candidate as Record<string, unknown>).id ?? "");
 
   useEffect(() => {
     if (!candidateId) return;
 
-    const cached = cacheRef.current.get(candidateId);
+    const cached = memoModuleCache.get(candidateId);
     if (cached) {
       setResult(cached);
       setError(null);
@@ -257,7 +280,7 @@ export default function DecisionMemoNarrative({ candidate, brief, lang }: Props)
     generateDecisionMemo(candidate, brief, lang)
       .then((fetched) => {
         if (cancelled) return;
-        cacheRef.current.set(candidateId, fetched);
+        memoModuleCache.set(candidateId, fetched);
         setResult(fetched);
       })
       .catch(() => {

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.test.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.test.tsx
@@ -5,9 +5,15 @@ import "../../i18n";
 import i18n from "../../i18n";
 import en from "../../i18n/en.json";
 import ExpansionMemoPanel, { type MemoDrawerSection } from "./ExpansionMemoPanel";
+import {
+  _seedDecisionMemoCacheForTest,
+  _clearDecisionMemoCacheForTest,
+} from "./DecisionMemoNarrative";
+import type { StructuredMemo } from "../../lib/api/expansionAdvisor";
 
 beforeEach(async () => {
   if (i18n.language !== "en") await i18n.changeLanguage("en");
+  _clearDecisionMemoCacheForTest();
 });
 
 function renderPanel() {
@@ -111,7 +117,54 @@ describe("ExpansionMemoPanel chunk 3b reorganisation", () => {
 /* ─── PR #3: AdvisorySectionCards mount + graceful degradation ───────────── */
 
 describe("ExpansionMemoPanel — PR #3 advisory cards", () => {
-  function memoWithAdvisorySections() {
+  function structuredMemoWithV5Sections(): StructuredMemo {
+    return {
+      headline_recommendation: "Recommend",
+      ranking_explanation: "rx",
+      key_evidence: [],
+      risks: [],
+      comparison: "c",
+      bottom_line: "bl",
+      property_overview: {
+        summary: "180 m² unit on a primary artery.",
+        area_m2: 180,
+        frontage_width_m: 24,
+        street_type: "primary",
+        parking_evidence: "shared",
+        visibility_score: 82,
+        listing_age_days: 64,
+        vacancy_status: "vacant",
+      },
+      financial_framing: {
+        summary: "SAR 432,000/yr below median.",
+        thesis: "Rent is the spine.",
+        annual_rent_sar: 432000,
+        comparable_median_annual_rent_sar: 542000,
+        rent_percentile_vs_comparables: 0.28,
+        comparable_n: 14,
+        comparable_scope: "district",
+        spread_to_median_sar: -110000,
+      },
+      market_context: {
+        summary: "41,000 catchment with rising momentum.",
+        demand_thesis: "Demand is observable.",
+        population_reach: 41000,
+        district_momentum: "rising",
+        realized_demand_30d: 380,
+        realized_demand_branches: 6,
+        delivery_listing_count: 22,
+      },
+      competitive_landscape: {
+        summary: "Three chains within 500 m.",
+        saturation_thesis: "Saturated.",
+        top_chains: [{ display_name_en: "Peer A", display_name_ar: null, branch_count: 2, nearest_distance_m: 180 }],
+        comparable_competitors: [],
+        next_candidate_summary: null,
+      },
+    } as StructuredMemo;
+  }
+
+  function memoFixtureBare() {
     return {
       recommendation: { verdict: "go", headline: "GO" },
       candidate: {
@@ -121,61 +174,33 @@ describe("ExpansionMemoPanel — PR #3 advisory cards", () => {
           final_score: 78, weights: {}, inputs: {}, weighted_components: {},
         },
         gate_status: { overall_pass: true },
-        decision_memo_json: {
-          headline_recommendation: "Recommend",
-          ranking_explanation: "rx",
-          key_evidence: [],
-          risks: [],
-          comparison: "c",
-          bottom_line: "bl",
-          property_overview: {
-            summary: "180 m² unit on a primary artery.",
-            area_m2: 180,
-            frontage_width_m: 24,
-            street_type: "primary",
-            parking_evidence: "shared",
-            visibility_score: 82,
-            listing_age_days: 64,
-            vacancy_status: "vacant",
-          },
-          financial_framing: {
-            summary: "SAR 432,000/yr below median.",
-            thesis: "Rent is the spine.",
-            annual_rent_sar: 432000,
-            comparable_median_annual_rent_sar: 542000,
-            rent_percentile_vs_comparables: 0.28,
-            comparable_n: 14,
-            comparable_scope: "district",
-            spread_to_median_sar: -110000,
-          },
-          market_context: {
-            summary: "41,000 catchment with rising momentum.",
-            demand_thesis: "Demand is observable.",
-            population_reach: 41000,
-            district_momentum: "rising",
-            realized_demand_30d: 380,
-            realized_demand_branches: 6,
-            delivery_listing_count: 22,
-          },
-          competitive_landscape: {
-            summary: "Three chains within 500 m.",
-            saturation_thesis: "Saturated.",
-            top_chains: [{ display_name_en: "Peer A", display_name_ar: null, branch_count: 2, nearest_distance_m: 180 }],
-            comparable_competitors: [],
-            next_candidate_summary: null,
-          },
-        },
       },
       market_research: {},
       brand_profile: {},
     };
   }
 
+  function seedFetchedMemo(candidateId: string, structured: StructuredMemo) {
+    _seedDecisionMemoCacheForTest(candidateId, {
+      memo: {
+        headline: "GO",
+        fit_summary: "",
+        top_reasons_to_pursue: [],
+        top_risks: [],
+        recommended_next_action: "",
+        rent_context: "",
+      },
+      memo_text: null,
+      memo_json: structured,
+    });
+  }
+
   it("mounts AdvisorySectionCards between the narrative and the verdict row", () => {
+    seedFetchedMemo("cand_1", structuredMemoWithV5Sections());
     const html = renderToStaticMarkup(
       <ExpansionMemoPanel
         loading={false}
-        memo={memoWithAdvisorySections() as any}
+        memo={memoFixtureBare() as any}
         candidateRaw={{ id: "cand_1" }}
         briefRaw={{ brand_name: "Test" }}
       />,
@@ -186,16 +211,19 @@ describe("ExpansionMemoPanel — PR #3 advisory cards", () => {
     expect(cardsIdx).toBeGreaterThan(-1);
     expect(verdictIdx).toBeGreaterThan(-1);
     expect(narrativeIdx).toBeGreaterThan(-1);
-    // Order: narrative wrapper, cards, verdict row.
+    // Order: narrative wrapper opens, cards render inside it, verdict row follows.
     expect(narrativeIdx).toBeLessThan(cardsIdx);
     expect(cardsIdx).toBeLessThan(verdictIdx);
   });
 
   it("renders each advisory card as a <details> closed by default", () => {
+    seedFetchedMemo("cand_1", structuredMemoWithV5Sections());
     const html = renderToStaticMarkup(
       <ExpansionMemoPanel
         loading={false}
-        memo={memoWithAdvisorySections() as any}
+        memo={memoFixtureBare() as any}
+        candidateRaw={{ id: "cand_1" }}
+        briefRaw={{ brand_name: "Test" }}
       />,
     );
     const tags = html.match(/<details[^>]*ea-memo-section[^>]*>/g) ?? [];
@@ -203,21 +231,63 @@ describe("ExpansionMemoPanel — PR #3 advisory cards", () => {
     for (const t of tags) expect(t.includes(" open")).toBe(false);
   });
 
-  it("does NOT render advisory cards when decision_memo_json is absent (graceful degradation)", () => {
+  it("does NOT render advisory cards when the fetched memo lacks v5 sections (graceful degradation)", () => {
+    // Seed the cache with a structured memo that has narrative fields but no
+    // v5 advisory sections. AdvisorySectionCards should return null.
+    _seedDecisionMemoCacheForTest("cand_1", {
+      memo: {
+        headline: "GO",
+        fit_summary: "",
+        top_reasons_to_pursue: [],
+        top_risks: [],
+        recommended_next_action: "",
+        rent_context: "",
+      },
+      memo_text: null,
+      memo_json: {
+        headline_recommendation: "Recommend",
+        ranking_explanation: "",
+        key_evidence: [],
+        risks: [],
+        comparison: "",
+        bottom_line: "",
+      } as StructuredMemo,
+    });
     const html = renderToStaticMarkup(
       <ExpansionMemoPanel
         loading={false}
-        memo={{
-          recommendation: { verdict: "go", headline: "GO" },
-          candidate: {
-            final_score: 78,
-            confidence_grade: "B",
-            score_breakdown_json: { final_score: 78, weights: {}, inputs: {}, weighted_components: {} },
-            gate_status: { overall_pass: true },
-          },
-          market_research: {},
-          brand_profile: {},
-        }}
+        memo={memoFixtureBare() as any}
+        candidateRaw={{ id: "cand_1" }}
+        briefRaw={{ brand_name: "Test" }}
+      />,
+    );
+    expect(html).not.toContain("ea-memo-advisory-cards");
+  });
+
+  it("does NOT render advisory cards when the fetched memo hasn't resolved (no cache hit)", () => {
+    // No seed → DecisionMemoNarrative renders null under SSR (useEffect skipped).
+    const html = renderToStaticMarkup(
+      <ExpansionMemoPanel
+        loading={false}
+        memo={memoFixtureBare() as any}
+        candidateRaw={{ id: "cand_unfetched" }}
+        briefRaw={{ brand_name: "Test" }}
+      />,
+    );
+    expect(html).not.toContain("ea-memo-advisory-cards");
+  });
+
+  it("ignores cand.decision_memo_json (cards source from the POST /decision-memo response)", () => {
+    // Regression: the previous mount read cand.decision_memo_json. Confirm it's
+    // no longer the source — even when populated, no cache seed → no cards.
+    const memo = memoFixtureBare() as any;
+    memo.candidate.decision_memo_json = structuredMemoWithV5Sections();
+    const html = renderToStaticMarkup(
+      <ExpansionMemoPanel
+        loading={false}
+        memo={memo}
+        candidateRaw={{ id: "cand_2" }}
+        briefRaw={{ brand_name: "Test" }}
       />,
     );
     expect(html).not.toContain("ea-memo-advisory-cards");

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
@@ -7,7 +7,6 @@ import GateSummary from "./GateSummary";
 import CopySummaryBlock from "./CopySummaryBlock";
 import DecisionLogicCard from "./DecisionLogicCard";
 import DecisionMemoNarrative from "./DecisionMemoNarrative";
-import AdvisorySectionCards from "./AdvisorySectionCards";
 import ScoreBar from "./ScoreBar";
 import { fmtScore, fmtMeters, fmtSAR, fmtSARCompact, fmtM2, businessGateLabel, safeDistrictLabel, getDisplayScore } from "./formatHelpers";
 
@@ -187,16 +186,13 @@ export default function ExpansionMemoPanel({
                   </div>
                 )}
 
-                {/* ══ Section 1a (PR #3): Advisory section cards — collapsed
-                       <details> stack rendered between the narrative and the
-                       verdict row. Falls back to nothing when the cached memo
-                       is a v4.2 memo (no typed sections present). ══ */}
-                {cand.decision_memo_json && (
-                  <AdvisorySectionCards
-                    memo={cand.decision_memo_json}
-                    lang={effectiveLang === "ar" ? "ar" : "en"}
-                  />
-                )}
+                {/* ══ Section 1a (PR #3): Advisory section cards mount inside
+                       StructuredNarrative above — sourced from the fetched
+                       /v1/expansion-advisor/decision-memo response so cards
+                       and narrative read from the same memo_json. The earlier
+                       attempt to source from cand.decision_memo_json failed
+                       in production because that field is null until the
+                       prewarm/cache write completes. ══ */}
 
                 {/* ══ Section 1b: Verdict + confidence (always visible, compact) ══ */}
                 {(rec.verdict || cand.confidence_grade) && (


### PR DESCRIPTION
## What is wrong now

PR #1170 added `<AdvisorySectionCards>` to `ExpansionMemoPanel.tsx` mounted as:

```tsx
{cand.decision_memo_json && (
  <AdvisorySectionCards memo={cand.decision_memo_json} lang={...} />
)}
```

In production the four v5 advisory cards (`property_overview`, `financial_framing`, `market_context`, `competitive_landscape`) never render even though the POST `/v1/expansion-advisor/decision-memo` response is confirmed to contain a fully populated `memo_json` with all four sections.

## Why it happens

`cand` here is `memo.candidate` from `getExpansionCandidateMemo`. The `decision_memo_json` column on that row is `NULL` until the prewarm/cache write completes — so when the user opens the drawer it's almost always `null`, and the card mount short-circuits.

The narrative/key_evidence/risks/comparison/bottom_line render correctly because `DecisionMemoNarrative` issues its own POST and reads `memo_json` from the live response — the cards were the only consumer pinned to the cached column.

## The fix (smallest safe diff)

Move `<AdvisorySectionCards>` inside `StructuredNarrative` so it reads from the same fetched `StructuredMemo` as the rest of the narrative. Remove the broken mount in `ExpansionMemoPanel`.

To make this testable under SSR (`renderToStaticMarkup` doesn't run effects), `DecisionMemoNarrative` swaps its per-instance `cacheRef` for a module-level cache and exposes `_seedDecisionMemoCacheForTest` / `_clearDecisionMemoCacheForTest`. Same-session re-mounts also benefit (no refetch when reopening the drawer for a candidate already seen).

DOM ordering is preserved: the panel's `ea-memo-section-narrative` wrapper still precedes the cards, which still precede `ea-memo-verdict-row`. Graceful degradation still holds — `AdvisorySectionCards` returns `null` when none of the four v5 sections are present.

## Evidence

> Production POST `/v1/expansion-advisor/decision-memo` response confirmed to contain `memo_json` with `property_overview`, `financial_framing`, `market_context`, `competitive_landscape` fully populated. ExpansionMemoPanel renders narrative/risks/bottom_line correctly from this fetched memo, but mounted AdvisorySectionCards against `cand.decision_memo_json` (null until the prewarm cache write completes). One-line source-of-truth fix.

## Validation

- `cd frontend && ./node_modules/.bin/vitest run ExpansionMemoPanel AdvisorySectionCards DecisionMemoNarrative` → **73/73 passing** (3 files).
- `cd frontend && npm run build` → tsc + vite production build clean.
- Updated PR #3 panel tests now seed the module cache with a fully-populated `memo_json` and assert: cards mount between narrative wrapper and verdict row; four `<details>` cards render closed by default; cards do **not** render when the cache is empty (fetch hasn't resolved); cards do **not** render even when `cand.decision_memo_json` is populated (regression guard for the old wrong source).

## Risk

Low. Single render-tree relocation + cache scope change. No backend, no contracts, no schema. The new behavior matches what's already true for the narrative rendered above the cards.

## Test plan

- [ ] Open a memo drawer in the deployed app and confirm the four advisory cards render below the narrative.
- [ ] Confirm cards stay collapsed by default and expand on click.
- [ ] Confirm graceful degradation: a candidate whose POST response lacks v5 sections shows no cards but otherwise renders normally.
- [ ] Sanity-check Arabic locale RTL direction on the cards.

https://claude.ai/code/session_01GbVauxKDx9Co7MZnrdDrdC

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbVauxKDx9Co7MZnrdDrdC)_