### PR TITLE
fix(memo): plumb search_id+parcel_id from FE so cache lookup activates

### DIFF
--- a/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx
@@ -30,6 +30,10 @@ type Props = {
   candidate: Record<string, unknown>;
   brief: Record<string, unknown>;
   lang: string;
+  // Optional: when provided, plumbed into the POST /decision-memo body so the
+  // backend's (search_id, parcel_id, MEMO_PROMPT_VERSION) cache lookup
+  // activates and the prewarmed memo is served instead of regenerating.
+  searchId?: string | null;
 };
 
 export function isValidStructuredMemo(
@@ -251,9 +255,11 @@ export function LegacyNarrative({ memo, lang }: { memo: LLMDecisionMemo; lang: s
   );
 }
 
-export default function DecisionMemoNarrative({ candidate, brief, lang }: Props) {
+export default function DecisionMemoNarrative({ candidate, brief, lang, searchId }: Props) {
   const { t } = useTranslation();
   const candidateId = String((candidate as Record<string, unknown>).id ?? "");
+  const candidateParcelId =
+    typeof candidate.parcel_id === "string" ? candidate.parcel_id : null;
   // Seed initial state from the module cache so tests (and same-session
   // re-mounts) can render synchronously without re-fetching.
   const [result, setResult] = useState<GeneratedDecisionMemo | null>(
@@ -277,7 +283,7 @@ export default function DecisionMemoNarrative({ candidate, brief, lang }: Props)
     setError(null);
     setResult(null);
 
-    generateDecisionMemo(candidate, brief, lang)
+    generateDecisionMemo(candidate, brief, lang, searchId, candidateParcelId)
       .then((fetched) => {
         if (cancelled) return;
         memoModuleCache.set(candidateId, fetched);

--- a/frontend/src/features/expansion-advisor/ExpansionAdvisorPage.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionAdvisorPage.tsx
@@ -748,6 +748,7 @@ export default function ExpansionAdvisorPage({
           candidateRaw={selectedCandidate as unknown as Record<string, unknown>}
           briefRaw={brief as unknown as Record<string, unknown>}
           lang={i18n.language?.startsWith("ar") ? "ar" : "en"}
+          searchId={searchId || null}
           initialSection={memoSection}
           onClose={() => { setActiveDrawer("none"); setMemoSection(undefined); }}
           onBackToDetail={() => { setActiveDrawer("none"); setMemoSection(undefined); }}

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
@@ -60,6 +60,7 @@ export default function ExpansionMemoPanel({
   candidateRaw,
   briefRaw,
   lang,
+  searchId,
   onClose,
   onBackToDetail,
   onBackToCompare,
@@ -76,6 +77,10 @@ export default function ExpansionMemoPanel({
   candidateRaw?: Record<string, unknown> | null;
   briefRaw?: Record<string, unknown> | null;
   lang?: string;
+  // Optional: forwarded into <DecisionMemoNarrative> so the on-demand
+  // POST /v1/expansion-advisor/decision-memo call is search-keyed and the
+  // backend serves the prewarmed memo instead of regenerating.
+  searchId?: string | null;
   onClose?: () => void;
   onBackToDetail?: () => void;
   onBackToCompare?: () => void;
@@ -182,6 +187,7 @@ export default function ExpansionMemoPanel({
                       candidate={candidateRaw}
                       brief={briefRaw}
                       lang={effectiveLang}
+                      searchId={searchId}
                     />
                   </div>
                 )}

--- a/frontend/src/lib/api/expansionAdvisor.generateDecisionMemo.test.ts
+++ b/frontend/src/lib/api/expansionAdvisor.generateDecisionMemo.test.ts
@@ -62,3 +62,85 @@ describe("generateDecisionMemo — memo_json / memo_text passthrough", () => {
     expect(result.memo_json).toBeNull();
   });
 });
+
+/* ─── Cache-key plumbing: search_id / parcel_id reach the request body ─── */
+
+describe("generateDecisionMemo — search_id / parcel_id body plumbing", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function lastBody(): Record<string, unknown> {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    return JSON.parse(init.body as string) as Record<string, unknown>;
+  }
+
+  it("includes explicit search_id and parcel_id at the top level when both are passed", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockJsonResponse({ memo: legacyMemo }),
+    );
+    await generateDecisionMemo(
+      { id: "cand-1", parcel_id: "parcel-from-candidate" },
+      { brand_name: "X" },
+      "en",
+      "search-123",
+      "parcel-explicit",
+    );
+    const body = lastBody();
+    expect(body.search_id).toBe("search-123");
+    // Explicit parcel_id wins over candidate.parcel_id
+    expect(body.parcel_id).toBe("parcel-explicit");
+    expect(body.candidate).toBeDefined();
+    expect(body.brief).toBeDefined();
+    expect(body.lang).toBe("en");
+  });
+
+  it("falls back to candidate.parcel_id when parcel_id arg is omitted", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockJsonResponse({ memo: legacyMemo }),
+    );
+    await generateDecisionMemo(
+      { id: "cand-1", parcel_id: "parcel-from-candidate" },
+      { brand_name: "X" },
+      "en",
+      "search-123",
+    );
+    const body = lastBody();
+    expect(body.search_id).toBe("search-123");
+    expect(body.parcel_id).toBe("parcel-from-candidate");
+  });
+
+  it("omits search_id and parcel_id from the body (not null) when neither is available", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockJsonResponse({ memo: legacyMemo }),
+    );
+    await generateDecisionMemo({ id: "cand-1" }, { brand_name: "X" }, "en");
+    const body = lastBody();
+    expect("search_id" in body).toBe(false);
+    expect("parcel_id" in body).toBe(false);
+    expect(body.candidate).toBeDefined();
+    expect(body.brief).toBeDefined();
+    expect(body.lang).toBe("en");
+  });
+
+  it("omits null/empty search_id and parcel_id rather than sending null", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      mockJsonResponse({ memo: legacyMemo }),
+    );
+    await generateDecisionMemo(
+      { id: "cand-1" },
+      { brand_name: "X" },
+      "en",
+      null,
+      "",
+    );
+    const body = lastBody();
+    expect("search_id" in body).toBe(false);
+    expect("parcel_id" in body).toBe(false);
+  });
+});

--- a/frontend/src/lib/api/expansionAdvisor.ts
+++ b/frontend/src/lib/api/expansionAdvisor.ts
@@ -790,11 +790,26 @@ export async function generateDecisionMemo(
   candidate: Record<string, unknown>,
   brief: Record<string, unknown>,
   lang: string,
+  search_id?: string | null,
+  parcel_id?: string | null,
 ): Promise<GeneratedDecisionMemo> {
+  // search_id is search-level state; the caller must pass it for the backend
+  // cache lookup to activate. parcel_id falls back to candidate.parcel_id so
+  // callers that already hold the candidate dict don't have to extract it.
+  const candidateParcelId =
+    typeof candidate.parcel_id === "string" && candidate.parcel_id
+      ? candidate.parcel_id
+      : null;
+  const resolvedParcelId = parcel_id || candidateParcelId;
+
+  const body: Record<string, unknown> = { candidate, brief, lang };
+  if (search_id) body.search_id = search_id;
+  if (resolvedParcelId) body.parcel_id = resolvedParcelId;
+
   const res = await fetchWithAuth(buildApiUrl("/v1/expansion-advisor/decision-memo"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ candidate, brief, lang }),
+    body: JSON.stringify(body),
   });
   const data = await readJson<{
     memo: LLMDecisionMemo;


### PR DESCRIPTION
## Summary

The on-demand `POST /v1/expansion-advisor/decision-memo` path never benefited from the prewarmed memo cache: the frontend client only posted `{ candidate, brief, lang }`, while the backend gates its cache lookup and persist on `cache_keyed = bool(search_id and parcel_id)`. With `search_id` missing, every panel open triggered a fresh LLM regeneration even though a v5 memo was already sitting in `expansion_candidate.decision_memo_json`.

This patch plumbs `search_id` from `ExpansionAdvisorPage` (where it already lives) down through `ExpansionMemoPanel` → `DecisionMemoNarrative`, and forwards it + `candidate.parcel_id` into the request body. The backend already supports both fields, so the cache path activates with no backend changes.

## Changes

- `frontend/src/lib/api/expansionAdvisor.ts` (+15 / -2): `generateDecisionMemo` now accepts optional `search_id` and `parcel_id` params. `parcel_id` falls back to `candidate.parcel_id`. Both are included in the body only when truthy — never sent as `null`.
- `frontend/src/features/expansion-advisor/DecisionMemoNarrative.tsx` (+8 / -2): new optional `searchId` prop; derives `parcel_id` from `candidate.parcel_id`; forwards both into the client call.
- `frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx` (+6 / -0): new optional `searchId` prop, threaded into `<DecisionMemoNarrative>`.
- `frontend/src/features/expansion-advisor/ExpansionAdvisorPage.tsx` (+1 / -0): passes the existing `searchId` state into `<ExpansionMemoPanel>`.
- `frontend/src/lib/api/expansionAdvisor.generateDecisionMemo.test.ts` (+82): four new tests asserting the request body shape:
  - explicit `search_id` and `parcel_id` reach the body
  - `parcel_id` falls back to `candidate.parcel_id` when not passed
  - body **omits** (not nulls) `search_id`/`parcel_id` when neither is available
  - empty/null inputs are also omitted

## Behavior

- Truthy `search_id` + a `parcel_id` (explicit or from `candidate.parcel_id`) → backend cache path activates → prewarmed v5 memo is served.
- Either missing → backend falls through to the existing `cache_keyed=False` branch, byte-for-byte identical to today's behavior. Old FE builds mid-deploy keep working with no cache.
- `MEMO_PROMPT_VERSION`, the cache key, the lookup query, and the prewarm path are all unchanged. `lang` is intentionally not part of the cache key (renderer applies it post-cache).

## Validation

- `tsc --noEmit` clean.
- `vitest run` for `expansionAdvisor.generateDecisionMemo.test.ts`, `ExpansionMemoPanel.test.tsx`, `DecisionMemoNarrative.structured.test.tsx` — 74/74 passing.
- `npm run build` clean.
- Pre-existing failures in `ExpansionAdvisorPage.test.tsx` (15 tests) reproduce on the base branch and are unrelated to this change.

## Test plan

- [ ] Reproduce the bug with curl: POST `/v1/expansion-advisor/decision-memo` without `search_id` returns a freshly generated memo (same shape, different output from the prewarmed row).
- [ ] Repeat the curl with `search_id` + `parcel_id` for a candidate that has `decision_memo_json` populated at `MEMO_PROMPT_VERSION='v5-sectioned-2026-04'` — response should be `cached: true` and match the DB row.
- [ ] Open the Decision Memo drawer in the UI for reference search `f1f502cf-1acd-41b4-9fd1-7cc85386bea9` → headline should match the "leads with demand" prewarmed version.

## Out of scope

Tracked separately per spec: cache-state observability, brief-edit staleness on cache key, historical-row backfill on prompt-version bumps, brief-builder unification between prewarm and on-demand, headline structural ban (PR #1175), comparables scope qualifier (PR #1175), competitor canonical-name thread (PR #1176).

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHSZAd49VdyFB5eLHH26p8)_