### PR TITLE
Disable Decision Memo prewarming in production

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -28,6 +28,15 @@ spec:
               value: "geom"
             - name: PARCEL_TARGET_SRID
               value: "4326"
+            # Decision Memo prewarm is disabled in production: memos are
+            # regenerated on-demand when the user opens the memo panel
+            # (Ahmed's product decision — prewarmed rows were never read
+            # by the FE after the search_id/parcel_id cache-key revert,
+            # so the background LLM calls were pure cost waste). Flip to
+            # "true" or remove this entry to re-enable. Explicit env
+            # entries override values from the oaktree-app-env secret.
+            - name: EXPANSION_MEMO_PREWARM_ENABLED
+              value: "false"
           envFrom:
             - secretRef:
                 name: oaktree-db-env


### PR DESCRIPTION
## Summary
Disables the Decision Memo prewarming feature in production by adding an explicit environment variable configuration. This change reflects a product decision to generate memos on-demand instead of prewarming them in the background.

## Key Changes
- Added `EXPANSION_MEMO_PREWARM_ENABLED` environment variable set to `"false"` in the Kubernetes deployment configuration
- Included detailed documentation explaining the rationale: prewarmed memo rows were not being utilized by the frontend after the search_id/parcel_id cache-key revert, resulting in unnecessary LLM API costs
- Documented how to re-enable the feature if needed in the future

## Implementation Details
- The environment variable is explicitly defined in the deployment spec, which overrides any default values from the `oaktree-app-env` secret
- Memos will now be generated on-demand when users open the memo panel, reducing unnecessary background processing and associated costs
- The change is backward compatible and can be easily reverted by removing the entry or setting the value to `"true"`

https://claude.ai/code/session_012QbSnT9UukjosVyiCpSkaB