### PR TITLE
Expansion Advisor value_score: fix uprank pass timing + report economics_detail projection

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -1304,11 +1304,25 @@ def _normalize_candidate_payload(
     )
     # Per-search ordering metadata (set by _apply_value_band_pass; absent
     # on rows that didn't move). Default to False/0 so the response shape
-    # is stable.
-    payload["value_downrank_applied"] = bool(payload.get("value_downrank_applied", False))
-    payload["value_downrank_delta"] = _safe_int(payload.get("value_downrank_delta"), 0)
-    payload["value_uprank_applied"] = bool(payload.get("value_uprank_applied", False))
-    payload["value_uprank_delta"] = _safe_int(payload.get("value_uprank_delta"), 0)
+    # is stable. The markers persist inside score_breakdown_json["value_pass"]
+    # because expansion_candidate has no dedicated columns for them; read
+    # from the nested location and fall back to top-level (set in-memory
+    # during the pass before persistence).
+    _vp = (payload.get("score_breakdown_json") or {}).get("value_pass") or {}
+    if not isinstance(_vp, dict):
+        _vp = {}
+    payload["value_downrank_applied"] = bool(
+        payload.get("value_downrank_applied") or _vp.get("value_downrank_applied", False)
+    )
+    payload["value_downrank_delta"] = _safe_int(
+        payload.get("value_downrank_delta") or _vp.get("value_downrank_delta"), 0
+    )
+    payload["value_uprank_applied"] = bool(
+        payload.get("value_uprank_applied") or _vp.get("value_uprank_applied", False)
+    )
+    payload["value_uprank_delta"] = _safe_int(
+        payload.get("value_uprank_delta") or _vp.get("value_uprank_delta"), 0
+    )
 
     # ── Display-consistent annual rent (presentation only) ──
     # The UI rounds rent/m² to whole SAR for display.  Compute a matching
@@ -4264,6 +4278,53 @@ def _value_band_is_low_confidence(source_label: Any, n_comparable: Any) -> bool:
     return source_label in {"city_band_type", "city"}
 
 
+def _candidate_value_band(c: dict[str, Any]) -> tuple[str | None, bool]:
+    """Read (value_band, low_confidence) for a candidate.
+
+    Production candidates carry the band inside
+    ``score_breakdown_json["economics_detail"]`` (the persisted source of
+    truth). The top-level keys are only set after _normalize_candidate_payload
+    runs, which is post-persistence and post-pass. Read from the nested
+    location first, then fall back to top-level so synthetic test fixtures
+    that set value_band directly continue to work.
+    """
+    sb = c.get("score_breakdown_json")
+    ed = sb.get("economics_detail") if isinstance(sb, dict) else None
+    if isinstance(ed, dict):
+        band = ed.get("value_band")
+        low_conf = bool(ed.get("value_band_low_confidence"))
+        if band is not None:
+            return band, low_conf
+    return c.get("value_band"), bool(c.get("value_band_low_confidence"))
+
+
+def _record_value_pass_marker(
+    c: dict[str, Any],
+    *,
+    direction: str,
+    delta: int,
+) -> None:
+    """Stash the uprank/downrank marker on the candidate dict AND inside
+    ``score_breakdown_json`` so the flag survives DB round-trips. The
+    expansion_candidate table has no dedicated columns for these markers;
+    score_breakdown_json is JSONB and is already persisted.
+    """
+    applied_key = f"value_{direction}_applied"
+    delta_key = f"value_{direction}_delta"
+    c[applied_key] = True
+    c[delta_key] = int(delta)
+    sb = c.get("score_breakdown_json")
+    if not isinstance(sb, dict):
+        sb = {}
+        c["score_breakdown_json"] = sb
+    vp = sb.get("value_pass")
+    if not isinstance(vp, dict):
+        vp = {}
+        sb["value_pass"] = vp
+    vp[applied_key] = True
+    vp[delta_key] = int(delta)
+
+
 def _apply_value_band_pass(
     candidates: list[dict[str, Any]],
     *,
@@ -4287,12 +4348,28 @@ def _apply_value_band_pass(
     out = list(candidates)
     n = len(out)
 
+    bands = [_candidate_value_band(c) for c in out]
+
+    # Diagnostic pre-trace: log every row that carries a value_band so
+    # production triage can confirm the pass saw the same picture the
+    # response reports. INFO level is intentional — this fires once per
+    # search and the volume is bounded.
+    flagged = [
+        (i, _safe_float(out[i].get("final_score")), bands[i][0], bands[i][1])
+        for i in range(n)
+        if bands[i][0] is not None
+    ]
+    if flagged:
+        logger.info(
+            "expansion_value_band_pass entry: search_id=%s n=%d flagged=%s",
+            search_id, n, flagged,
+        )
+
     # Pass 1: downrank above_market (high-confidence only). Process from
     # bottom up so earlier pops don't shift later indices.
     demote_indices = [
-        i for i, c in enumerate(out)
-        if c.get("value_band") == "above_market"
-        and not c.get("value_band_low_confidence")
+        i for i in range(n)
+        if bands[i][0] == "above_market" and not bands[i][1]
     ]
     demoted = 0
     for i in reversed(demote_indices):
@@ -4300,17 +4377,18 @@ def _apply_value_band_pass(
         if target > i:
             c = out.pop(i)
             out.insert(target, c)
-            c["value_downrank_applied"] = True
-            c["value_downrank_delta"] = target - i
+            _record_value_pass_marker(c, direction="downrank", delta=target - i)
             demoted += 1
+
+    # Re-index after demotions so promote_indices reference current positions.
+    bands = [_candidate_value_band(c) for c in out]
 
     # Pass 2: uprank best_value (high-confidence only). Promote up to
     # _VALUE_UPRANK_MAX_POSITIONS but never past a peer whose final_score is
     # more than _FUZZY_TIE_WINDOW points higher.
     promote_indices = [
-        i for i, c in enumerate(out)
-        if c.get("value_band") == "best_value"
-        and not c.get("value_band_low_confidence")
+        i for i in range(len(out))
+        if bands[i][0] == "best_value" and not bands[i][1]
     ]
     promoted = 0
     fuzzy_window = _FUZZY_TIE_WINDOW
@@ -4330,8 +4408,7 @@ def _apply_value_band_pass(
         if new_idx < i:
             c = out.pop(i)
             out.insert(new_idx, c)
-            c["value_uprank_applied"] = True
-            c["value_uprank_delta"] = i - new_idx
+            _record_value_pass_marker(c, direction="uprank", delta=i - new_idx)
             promoted += 1
 
     if demoted or promoted:
@@ -9003,6 +9080,11 @@ def get_recommendation_report(db: Session, search_id: str) -> dict[str, Any] | N
                     "weighted_components": score_breakdown.get("weighted_components") or {},
                     "display": score_breakdown.get("display") or {},
                     "final_score": _safe_float(score_breakdown.get("final_score"), _safe_float(item.get("final_score"))),
+                    # economics_detail carries rent_burden / value_score /
+                    # value_band — the report panel renders these on the
+                    # top-3 cards, so projecting them is required for parity
+                    # with /candidates.
+                    "economics_detail": score_breakdown.get("economics_detail") or {},
                 },
                 # value_score / value_band lifted from the normalized
                 # candidate so the report panel's top-3 cards can render

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -2653,3 +2653,103 @@ def test_get_recommendation_report_best_value_none_when_no_value_score(monkeypat
     report = get_recommendation_report(FakeDB(), "search-1")
     assert report is not None
     assert report["recommendation"]["best_value_candidate_id"] is None
+
+
+def test_value_band_pass_uprank_reads_band_from_score_breakdown_json():
+    """Regression for the production bug where value_uprank_applied is always
+    False. In production the candidate dict carries value_band inside
+    score_breakdown_json["economics_detail"], not at the top level. The pass
+    must consult that nested location, otherwise the promote_indices set is
+    empty and no row is ever upranked."""
+    # Index 4: peer with final_score equal to the best_value below it.
+    # Index 5: high-confidence best_value, value_band only inside
+    # score_breakdown_json["economics_detail"] (the persisted layout).
+    candidates = [
+        {"id": f"c{i}", "parcel_id": f"c{i}", "final_score": 80.0 - i, "score_breakdown_json": {}}
+        for i in range(5)
+    ]
+    candidates.append({
+        "id": "c5-best-value",
+        "parcel_id": "c5-best-value",
+        "final_score": 75.98,
+        "score_breakdown_json": {
+            "economics_detail": {
+                "value_score": 80.0,
+                "value_band": "best_value",
+                "value_band_low_confidence": False,
+            },
+        },
+    })
+    # Tighten the gap between index 4 and the best_value so the swap is
+    # within the fuzzy window.
+    candidates[4]["final_score"] = 75.98
+
+    out = _apply_value_band_pass(list(candidates), search_id="t")
+    moved = next(c for c in out if c["id"] == "c5-best-value")
+    new_idx = out.index(moved)
+    assert new_idx < 5, f"best_value did not move (still at {new_idx})"
+    assert moved.get("value_uprank_applied") is True
+    assert moved.get("value_uprank_delta", 0) >= 1
+    # Marker must also be persisted inside score_breakdown_json so it
+    # survives the DB round-trip (no dedicated column for these fields).
+    vp = moved.get("score_breakdown_json", {}).get("value_pass") or {}
+    assert vp.get("value_uprank_applied") is True
+    assert vp.get("value_uprank_delta", 0) >= 1
+
+
+def test_recommendation_report_top_payload_preserves_economics_detail(monkeypatch):
+    """Regression for Bug 2: top_candidates[0].score_breakdown_json
+    .economics_detail was empty because get_recommendation_report's
+    top_payload projection forgot to copy economics_detail from the source
+    candidate's score_breakdown_json."""
+    economics_detail = {
+        "rent_burden": {
+            "mode": "percentile",
+            "percentile_rank": 35.0,
+            "n_comparable": 24,
+            "source_label": "district_band_type",
+        },
+        "value_score": 82.5,
+        "value_band": "best_value",
+        "value_band_low_confidence": False,
+    }
+    candidates = [
+        {
+            "id": "cand-1",
+            "parcel_id": "p1",
+            "rank_position": 1,
+            "final_score": 80.0,
+            "demand_score": 70.0,
+            "economics_score": 75.0,
+            "brand_fit_score": 70.0,
+            "provider_whitespace_score": 60.0,
+            "confidence_grade": "A",
+            "confidence_score": 90.0,
+            "value_score": 82.5,
+            "value_band": "best_value",
+            "gate_status_json": {"overall_pass": True},
+            "gate_reasons_json": {},
+            "feature_snapshot_json": {},
+            "score_breakdown_json": {
+                "weights": {"demand": 0.3},
+                "inputs": {},
+                "weighted_components": {},
+                "display": {},
+                "final_score": 80.0,
+                "economics_detail": economics_detail,
+            },
+        },
+    ]
+    monkeypatch.setattr(expansion_service, "get_search", lambda *_a, **_kw: {"id": "search-1", "brand_profile": {}})
+    monkeypatch.setattr(expansion_service, "get_candidates", lambda *_a, **_kw: candidates)
+
+    report = get_recommendation_report(FakeDB(), "search-1")
+    assert report is not None
+    top = report["top_candidates"]
+    assert len(top) == 1
+    sb = top[0]["score_breakdown_json"]
+    assert sb.get("economics_detail") == economics_detail
+    # Sanity: rent_burden / value_score / value_band specifically must round-trip.
+    assert sb["economics_detail"]["rent_burden"]["mode"] == "percentile"
+    assert sb["economics_detail"]["value_score"] == 82.5
+    assert sb["economics_detail"]["value_band"] == "best_value"


### PR DESCRIPTION
## Summary

Two follow-up bugs from the post-merge validation. Same branch, both fixed in one PR.

### Bug 1 — `value_uprank_applied` always False

**Repro:** search `0c95dfd2-67d7-4a45-8c69-5aa936956bc4`, rank 6 (parcel `e67cf1a0…`, الورود) — `value_band="best_value"`, `final_score=75.98`, but `value_uprank_applied=false` even though both potential swap targets sit inside the fuzzy window.

**Root cause (different from the original hypothesis):** The hypothesis was that `_apply_value_band_pass` runs before deterministic ordering settles. That's not what's happening — the pass is correctly placed after `_rank_sort_key`, dedupe, fuzzy tiebreak and district balancing, and before truncation + LLM rerank. The actual root cause is that the pass reads the band from `c.get("value_band")`, but production candidates carry the band inside `score_breakdown_json["economics_detail"]["value_band"]` (the persisted source of truth). The top-level `value_band` key is only set by `_normalize_candidate_payload` *after* the pass runs (post-persistence), so `promote_indices` was always empty and the pass was a no-op for every candidate.

**Secondary issue:** Even when the pass *did* mutate a candidate (e.g. in unit tests that set top-level `value_band`), `expansion_candidate` has no dedicated columns for `value_uprank_applied`/`value_uprank_delta`/`value_downrank_applied`/`value_downrank_delta`, so the markers were lost on persist. The `/candidates` endpoint loads from DB and the markers came back missing → defaults to `False/0`.

**Fix:**
- New `_candidate_value_band(c)` helper reads from `score_breakdown_json["economics_detail"]` first, then falls back to the top-level key (so existing synthetic-candidate tests continue to pass).
- New `_record_value_pass_marker` stashes both the top-level mutation *and* a copy under `score_breakdown_json["value_pass"]`. Because `score_breakdown_json` is `JSONB` and already round-trips through DB, the marker now survives persist → fetch.
- `_normalize_candidate_payload` reads the markers from `score_breakdown_json["value_pass"]` with backward-compat for the in-memory top-level case (immediate POST `/searches` response).
- Added the diagnostic INFO log requested in the brief.

### Bug 2 — `economics_detail` empty in `/report` top_candidates

**Root cause:** `get_recommendation_report`'s `top_payload` builder rebuilt `score_breakdown_json` from a hand-written subset (`weights`, `inputs`, `weighted_components`, `display`, `final_score`) and omitted `economics_detail`. `/candidates` returned the full nested object; `/report` did not.

**Fix:** Copy `economics_detail` (defaulting to `{}`) through the projection.

### Notes
- No new migration. No new env flag.
- Verified spec section 2.1 placement reasoning was correct — the pass *is* in the right pipeline position. Documented the correction in the commit message.

## Test plan

Unit:
- [x] `test_value_band_pass_uprank_reads_band_from_score_breakdown_json` — synthesizes a high-confidence `best_value` at index 5 with `value_band` only inside `score_breakdown_json["economics_detail"]`, peer at index 4 with equal `final_score`. Asserts the row moves up at least one position, gets `value_uprank_applied=True`, and the marker is also persisted inside `score_breakdown_json["value_pass"]`.
- [x] `test_recommendation_report_top_payload_preserves_economics_detail` — feeds a candidate with full `economics_detail` (rent_burden, value_score, value_band) into `get_recommendation_report`. Asserts the projected `top_candidates[0].score_breakdown_json.economics_detail` is preserved end-to-end.
- [x] All four pre-existing `value_band_pass_*` tests still pass (top-level fallback path).

Suite summary (run locally; results trimmed to scope-relevant + environment caveats):
- `tests/test_expansion_advisor*.py` + `tests/test_expansion_*.py` + `tests/services/test_expansion_*.py`: **454 passed, 0 failed**.
- Broader run with collectible tests: **955 passed, 13 failed, 19 errors, 5 skipped**. All failures + errors are environment-only (`sklearn`, `psycopg`, `mapbox_vector_tile`, etc. not installed in the sandbox); unrelated to this diff.

## Acceptance

- [ ] For search `0c95dfd2…`, rank 6 `e67cf1a0…` shows `value_uprank_applied=true` and `value_uprank_delta>=1` in `/v1/expansion-advisor/searches/{id}/candidates`. Needs production validation (existing rows persisted before this fix won't backfill — only candidates inserted after deploy will carry the marker in `score_breakdown_json["value_pass"]`).
- [ ] For any percentile-mode candidate in the top 3, `/report` `top_candidates[].score_breakdown_json.economics_detail` contains `rent_burden`, `value_score`, `value_band`.

Status: **draft, needs validation.**

https://claude.ai/code/session_01PYXAjSNQLo1pKvXohetHQt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYXAjSNQLo1pKvXohetHQt)_