### PR TITLE
fix(expansion): allow extra keys in score_breakdown_json response model (P0 hotfix for PR #1178)

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -173,7 +173,13 @@ class CandidateGateReasonsResponse(StrictResponseModel):
     explanations: dict[str, Any] = Field(default_factory=dict)
 
 
-class CandidateScoreBreakdownResponse(StrictResponseModel):
+class CandidateScoreBreakdownResponse(FlexibleResponseModel):
+    # score_breakdown_json is a JSONB blob in the DB and intentionally
+    # loose-shaped — service code adds keys like ``value_pass`` (PR #1178)
+    # without a corresponding response-model change. Strict response
+    # validation here is a recurring bug magnet, so this model allows
+    # extra keys to flow through. Request validation does not use this
+    # model, so loosening it has no incoming-payload impact.
     weights: dict[str, Any] = Field(default_factory=dict)
     inputs: dict[str, Any] = Field(default_factory=dict)
     weighted_components: dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_expansion_advisor_api.py
+++ b/tests/test_expansion_advisor_api.py
@@ -814,3 +814,57 @@ def test_feature_snapshot_surfaces_listing_age_and_district_momentum(monkeypatch
     assert snap["district_momentum"]["sample_floor_applied"] is False
     # The original context_sources / data_completeness_score contract stays.
     assert snap["data_completeness_score"] == 90
+
+
+# ---------------------------------------------------------------------------
+# P0 hotfix for PR #1178 — score_breakdown_json carries a JSONB blob whose
+# shape is intentionally loose. _record_value_pass_marker writes a
+# ``value_pass`` key into it; production was 500'ing because the response
+# model rejected the unknown key. The fix is extra="allow" via
+# FlexibleResponseModel. These tests pin the contract so a future tightening
+# of the model is caught at test time, not in production.
+# ---------------------------------------------------------------------------
+def test_score_breakdown_response_allows_value_pass_and_unknown_keys():
+    from app.api.expansion_advisor import (
+        CandidateScoreBreakdownResponse,
+        ExpansionCandidateResponse,
+    )
+
+    breakdown = CandidateScoreBreakdownResponse.model_validate(
+        {
+            "weights": {"demand": 0.4},
+            "inputs": {"demand": 70},
+            "weighted_components": {"demand": 28.0},
+            "display": {},
+            "final_score": 82.5,
+            "value_pass": {"value_uprank_applied": True, "value_uprank_delta": 3},
+            "some_future_key": {"nested": [1, 2, 3]},
+        }
+    )
+
+    dumped = breakdown.model_dump()
+    assert dumped["value_pass"] == {
+        "value_uprank_applied": True,
+        "value_uprank_delta": 3,
+    }
+    assert dumped["some_future_key"] == {"nested": [1, 2, 3]}
+
+    # And the same blob round-trips through the candidate-level response
+    # model (which is what /searches actually serializes).
+    candidate = ExpansionCandidateResponse.model_validate(
+        {
+            "id": "cand-12",
+            "rank_position": 12,
+            "score_breakdown_json": {
+                "final_score": 73.4,
+                "value_pass": {
+                    "value_uprank_applied": True,
+                    "value_uprank_delta": 3,
+                },
+            },
+            "value_uprank_applied": True,
+            "value_uprank_delta": 3,
+        }
+    )
+    cand_dump = candidate.model_dump()
+    assert cand_dump["score_breakdown_json"]["value_pass"]["value_uprank_delta"] == 3


### PR DESCRIPTION
## Summary

P0 hotfix. PR #1178 added `_record_value_pass_marker`, which writes a `value_pass` key into the candidate's `score_breakdown_json` blob. The Pydantic response model `CandidateScoreBreakdownResponse` was strict (`extra="forbid"`), so production `POST /v1/expansion-advisor/searches` returned 500 the moment a real uprank fired:

```
ValidationError: {'type': 'extra_forbidden',
 'loc': ('response', 'items', 12, 'score_breakdown_json', 'value_pass'),
 'msg': 'Extra inputs are not permitted',
 'input': {'value_uprank_applied': True, 'value_uprank_delta': 3}}
```

The traceback also confirms PR #1178 *did* fire — `delta=3` on item 12 means an actual uprank happened. The logic is correct; only the serialization is broken.

## Fix

`app/api/expansion_advisor.py` — switch `CandidateScoreBreakdownResponse` from `StrictResponseModel` (`extra="forbid"`) to `FlexibleResponseModel` (`extra="allow"`).

Justification:
- `score_breakdown_json` is a JSONB blob in the DB, intentionally loose-shaped.
- Service code adds keys (`value_pass`, `economics_detail` sub-keys, etc.) without a response-model change. Strict validation here is a recurring bug magnet.
- The model is **only** used in response paths (verified — `ExpansionCandidateResponse`, `CandidateMemoCandidateResponse`, `RecommendationReportResponse`'s top-candidates field). Request validation is unaffected, so no split is needed.

## Test plan

- [x] Added regression test `test_score_breakdown_response_allows_value_pass_and_unknown_keys` in `tests/test_expansion_advisor_api.py` — instantiates the model with `value_pass` and an unknown future key, asserts both round-trip through `model_dump()` (and through the parent `ExpansionCandidateResponse`).
- [x] Full expansion-advisor suite green: `pytest -k expansion` → **531 passed, 1 skipped**.
- [x] No new migration, no new env flag.
- [ ] After merge, re-enable `EXPANSION_VALUE_SCORE_ENABLED` in production.

## Risk

Low. The change is response-side only, additive (allows extra keys instead of rejecting them), and the regression test pins the contract so a future tightening is caught at test time rather than in production.

**DO NOT MERGE** — opened as draft for human review per the request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AACaKQHfwTPFEh8fVBhxnv)_