### PR TITLE
Add NASA Black Marble VNP46A3 radiance as third leg of market-viability gate

### DIFF
--- a/.github/workflows/ingest-blackmarble.yml
+++ b/.github/workflows/ingest-blackmarble.yml
@@ -1,0 +1,72 @@
+# Ingest NASA Black Marble VNP46A3 monthly nighttime radiance (single h22v06
+# tile, all of Riyadh) into district_radiance_monthly. Used as the third
+# (growth) leg of the Expansion Advisor's market-viability conjunction.
+#
+# Requires *.nasa.gov egress allowlist on Actions runners. Specifically
+# ladsweb.modaps.eosdis.nasa.gov and urs.earthdata.nasa.gov. Without that
+# allowlist the ingest step will fail; the workflow itself can still merge
+# and the schedule can still fire (it will simply error until allowlist
+# is in place).
+
+name: Ingest Black Marble VNP46A3
+
+on:
+  schedule:
+    - cron: "0 5 15 * *"  # 15th of each month at 05:00 UTC
+  workflow_dispatch:
+    inputs:
+      year_month:
+        description: "YYYY-MM (e.g. 2026-03). If empty, ingests latest available month."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install h5py rasterio numpy shapely
+
+      - name: Configure DB env
+        env:
+          PGHOST_S: ${{ secrets.POSTGRES_HOST }}
+          PGPORT_S: ${{ secrets.POSTGRES_PORT }}
+          PGDB_S:   ${{ secrets.POSTGRES_DB }}
+          PGUSER_S: ${{ secrets.POSTGRES_USER }}
+          PGPASS_S: ${{ secrets.POSTGRES_PASSWORD }}
+        run: |
+          {
+            echo "POSTGRES_HOST=${PGHOST_S}"
+            echo "POSTGRES_PORT=${PGPORT_S}"
+            echo "POSTGRES_DB=${PGDB_S}"
+            echo "POSTGRES_USER=${PGUSER_S}"
+            echo "POSTGRES_PASSWORD=${PGPASS_S}"
+            echo "POSTGRES_SSLMODE=require"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Alembic migrations
+        run: alembic upgrade heads
+
+      - name: Ingest Black Marble month
+        env:
+          EDL_TOKEN: ${{ secrets.EDL_TOKEN }}
+        run: |
+          YM="${{ inputs.year_month }}"
+          if [ -z "$YM" ]; then
+            # Default: 2 months ago (Black Marble has ~6-8 week production lag)
+            YM=$(date -d "2 months ago" +%Y-%m)
+          fi
+          echo "Ingesting Black Marble VNP46A3 for $YM"
+          python -m app.ingest.black_marble_radiance --year-month "$YM"

--- a/alembic/versions/20260501_add_district_radiance_monthly.py
+++ b/alembic/versions/20260501_add_district_radiance_monthly.py
@@ -1,0 +1,64 @@
+"""Create district_radiance_monthly table for Black Marble VNP46A3 ingest.
+
+Stores monthly per-district nighttime radiance aggregates used as the third
+(growth) leg of the market-viability conjunction in the Expansion Advisor.
+
+revision: 20260501_district_radiance_monthly
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic
+revision = "20260501_district_radiance_monthly"
+down_revision = "0020_candidate_location"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "district_radiance_monthly",
+        sa.Column("district_key", sa.Text(), nullable=False),
+        sa.Column("year_month", sa.Date(), nullable=False),
+        sa.Column("radiance_mean", sa.Numeric(12, 4), nullable=True),
+        sa.Column("radiance_median", sa.Numeric(12, 4), nullable=True),
+        sa.Column("radiance_sum", sa.Numeric(14, 4), nullable=True),
+        sa.Column("radiance_p90", sa.Numeric(12, 4), nullable=True),
+        sa.Column("pixel_count_total", sa.Integer(), nullable=False),
+        sa.Column("pixel_count_valid", sa.Integer(), nullable=False),
+        sa.Column("quality_filter", sa.String(32), nullable=False),
+        sa.Column("source", sa.String(64), nullable=False),
+        sa.Column("tile", sa.String(16), nullable=False),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.PrimaryKeyConstraint("district_key", "year_month", "source"),
+    )
+    op.create_index(
+        "ix_district_radiance_monthly_year_month",
+        "district_radiance_monthly",
+        ["year_month"],
+        postgresql_using="btree",
+        postgresql_ops={"year_month": "DESC"},
+    )
+    op.create_index(
+        "ix_district_radiance_monthly_year_month_district",
+        "district_radiance_monthly",
+        ["year_month", "district_key"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_district_radiance_monthly_year_month_district",
+        table_name="district_radiance_monthly",
+    )
+    op.drop_index(
+        "ix_district_radiance_monthly_year_month",
+        table_name="district_radiance_monthly",
+    )
+    op.drop_table("district_radiance_monthly")

--- a/app/connectors/blackmarble.py
+++ b/app/connectors/blackmarble.py
@@ -1,0 +1,269 @@
+"""
+Connector for NASA Black Marble VNP46A3 monthly nighttime-radiance data.
+
+Single tile h22v06 covers all of Riyadh. Data is fetched from the LAADS DAAC
+archive (collection 5200, Black Marble Collection 2.0). Quality filter is
+"lenient" (quality < 2, Good + Poor combined); confidence floor is 10 valid
+pixels per district per month.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Riyadh metro bounding box (west, south, east, north).
+RIYADH_BBOX = (46.20, 24.20, 47.30, 25.10)
+
+# Single VIIRS tile covering all of Riyadh.
+TILE = "h22v06"
+# h22v06 lon/lat envelope (10 deg x 10 deg sinusoidal grid expressed in WGS84).
+TILE_BOUNDS = (40.0, 20.0, 50.0, 30.0)  # west, south, east, north
+
+QUALITY_FILTER_LABEL = "lenient_qa_lt_2"
+SOURCE_LABEL = "nasa_blackmarble_vnp46a3_c2"
+
+# Confidence floor: a district needs >= this many valid pixels in a given
+# month to produce a confident radiance signal. Below the floor, the leg
+# falls through (no growth_rescue).
+PIXEL_COUNT_FLOOR = 10
+
+RADIANCE_BAND_PATH = (
+    "HDFEOS/GRIDS/VIIRS_Grid_DNB_2d/Data Fields/NearNadir_Composite_Snow_Free"
+)
+QUALITY_BAND_PATH = (
+    "HDFEOS/GRIDS/VIIRS_Grid_DNB_2d/Data Fields/NearNadir_Composite_Snow_Free_Quality"
+)
+
+# Confirmed from POC.
+RADIANCE_FILL_VALUE = -999.9
+
+LAADS_BASE_URL = "https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/5200/VNP46A3"
+
+# Magic bytes at the start of every HDF5 file.
+_HDF5_SIGNATURE = b"\x89HDF\r\n\x1a\n"
+_MIN_FILE_BYTES = 50 * 1024 * 1024  # 50 MB
+
+
+class BlackMarbleError(Exception):
+    """Base error for Black Marble connector."""
+
+
+class BlackMarbleNotAvailableError(BlackMarbleError):
+    """Raised when a requested month has not yet been published to LAADS."""
+
+
+class BlackMarbleDownloadCorruptError(BlackMarbleError):
+    """Raised when a downloaded H5 file fails magic-byte or size checks."""
+
+
+class _LAADSSession(requests.Session):
+    """Session that re-attaches the bearer token across cross-origin redirects.
+
+    LAADS file downloads return a 302 to a signed URL on a different subdomain.
+    Default ``requests`` strips the Authorization header on cross-origin
+    redirects (RFC 7235); override ``rebuild_auth`` to keep it attached.
+    """
+
+    def __init__(self, token: str):
+        super().__init__()
+        self._token = token
+        self.headers.update({"Authorization": f"Bearer {token}"})
+
+    def rebuild_auth(self, prepared_request, response):
+        # Re-attach the bearer token unconditionally on any redirect hop.
+        prepared_request.headers["Authorization"] = f"Bearer {self._token}"
+
+
+def discover_h5_url(year_month: date, token: str) -> str:
+    """Resolve the LAADS download URL for the h22v06 file of ``year_month``.
+
+    Uses LAADS's ``.json`` directory listing under
+    ``/archive/allData/5200/VNP46A3/<year>/<DOY>/`` to find the h22v06 file.
+    Raises :class:`BlackMarbleNotAvailableError` if the month has not yet
+    been published.
+    """
+    ym = date(year_month.year, year_month.month, 1)
+    doy = ym.timetuple().tm_yday  # 1..365 for first-of-month
+    listing_url = f"{LAADS_BASE_URL}/{ym.year}/{doy:03d}.json"
+
+    session = _LAADSSession(token)
+    resp = session.get(listing_url, timeout=60)
+    if resp.status_code == 404:
+        raise BlackMarbleNotAvailableError(
+            f"LAADS listing not found for {ym.isoformat()} (url={listing_url})"
+        )
+    resp.raise_for_status()
+
+    try:
+        entries = resp.json()
+    except ValueError as exc:
+        raise BlackMarbleError(
+            f"LAADS listing for {ym.isoformat()} did not return JSON"
+        ) from exc
+
+    for entry in entries:
+        name = entry.get("name") if isinstance(entry, dict) else None
+        if not name:
+            continue
+        if name.endswith(".h5") and TILE in name:
+            return f"{LAADS_BASE_URL}/{ym.year}/{doy:03d}/{name}"
+
+    raise BlackMarbleNotAvailableError(
+        f"No {TILE} file found in LAADS listing for {ym.isoformat()}"
+    )
+
+
+def download_h5(url: str, token: str, dest_path: str | Path) -> None:
+    """Download an H5 file from LAADS to ``dest_path``, streaming.
+
+    Validates magic bytes and a minimum size after write; raises
+    :class:`BlackMarbleDownloadCorruptError` on failure.
+    """
+    dest = Path(dest_path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    session = _LAADSSession(token)
+    with session.get(url, stream=True, timeout=600, allow_redirects=True) as resp:
+        resp.raise_for_status()
+        with dest.open("wb") as fh:
+            for chunk in resp.iter_content(chunk_size=1 << 20):
+                if chunk:
+                    fh.write(chunk)
+
+    size = dest.stat().st_size
+    if size < _MIN_FILE_BYTES:
+        raise BlackMarbleDownloadCorruptError(
+            f"Downloaded file too small ({size} bytes < {_MIN_FILE_BYTES}): {dest}"
+        )
+
+    with dest.open("rb") as fh:
+        head = fh.read(len(_HDF5_SIGNATURE))
+    if head != _HDF5_SIGNATURE:
+        raise BlackMarbleDownloadCorruptError(
+            f"Downloaded file is not HDF5 (bad magic bytes): {dest}"
+        )
+
+
+def aggregate_per_district(
+    h5_path: str | Path,
+    district_polygons: list[dict[str, Any]],
+    year_month: date,
+) -> Iterator[dict[str, Any]]:
+    """Aggregate per-district radiance stats from a Black Marble H5 file.
+
+    ``district_polygons`` is a list of ``{"district_key": str, "geometry":
+    shapely_geom_in_4326}``. Yields one dict per district with keys matching
+    :class:`DistrictRadianceMonthly` columns. ``pixel_count_valid`` is
+    reported regardless of the threshold; the threshold check is enforced at
+    consume-time.
+    """
+    try:
+        import h5py
+        import numpy as np
+        from rasterio.features import geometry_mask
+        from rasterio.transform import from_bounds
+    except ImportError as exc:
+        logger.error("Missing dependency for Black Marble aggregation: %s", exc)
+        return
+
+    ym = date(year_month.year, year_month.month, 1)
+    path = Path(h5_path)
+    if not path.exists():
+        logger.error("H5 file not found: %s", path)
+        return
+
+    with h5py.File(path, "r") as fh:
+        radiance_ds = fh[RADIANCE_BAND_PATH]
+        quality_ds = fh[QUALITY_BAND_PATH]
+        radiance = np.asarray(radiance_ds[...], dtype=np.float64)
+        quality = np.asarray(quality_ds[...])
+
+    if radiance.shape != quality.shape:
+        raise BlackMarbleError(
+            f"Radiance/quality shape mismatch in {path}: "
+            f"{radiance.shape} vs {quality.shape}"
+        )
+
+    height, width = radiance.shape
+    west, south, east, north = TILE_BOUNDS
+    transform = from_bounds(west, south, east, north, width, height)
+
+    valid_mask_global = (radiance != RADIANCE_FILL_VALUE) & (quality < 2)
+
+    out_shape = radiance.shape
+
+    for poly in district_polygons:
+        dk = poly.get("district_key")
+        geom = poly.get("geometry")
+        if not dk or geom is None:
+            continue
+
+        try:
+            poly_mask = geometry_mask(
+                [geom.__geo_interface__],
+                out_shape=out_shape,
+                transform=transform,
+                invert=True,
+                all_touched=False,
+            )
+        except Exception as exc:  # noqa: BLE001 - one bad polygon shouldn't fail batch
+            logger.warning("geometry_mask failed for district_key=%s: %s", dk, exc)
+            continue
+
+        pixel_count_total = int(poly_mask.sum())
+        if pixel_count_total == 0:
+            yield {
+                "district_key": dk,
+                "year_month": ym,
+                "radiance_mean": None,
+                "radiance_median": None,
+                "radiance_sum": None,
+                "radiance_p90": None,
+                "pixel_count_total": 0,
+                "pixel_count_valid": 0,
+                "quality_filter": QUALITY_FILTER_LABEL,
+                "source": SOURCE_LABEL,
+                "tile": TILE,
+            }
+            continue
+
+        valid_in_poly = poly_mask & valid_mask_global
+        pixel_count_valid = int(valid_in_poly.sum())
+
+        if pixel_count_valid == 0:
+            yield {
+                "district_key": dk,
+                "year_month": ym,
+                "radiance_mean": None,
+                "radiance_median": None,
+                "radiance_sum": None,
+                "radiance_p90": None,
+                "pixel_count_total": pixel_count_total,
+                "pixel_count_valid": 0,
+                "quality_filter": QUALITY_FILTER_LABEL,
+                "source": SOURCE_LABEL,
+                "tile": TILE,
+            }
+            continue
+
+        values = radiance[valid_in_poly]
+        yield {
+            "district_key": dk,
+            "year_month": ym,
+            "radiance_mean": float(np.mean(values)),
+            "radiance_median": float(np.median(values)),
+            "radiance_sum": float(np.sum(values)),
+            "radiance_p90": float(np.percentile(values, 90)),
+            "pixel_count_total": pixel_count_total,
+            "pixel_count_valid": pixel_count_valid,
+            "quality_filter": QUALITY_FILTER_LABEL,
+            "source": SOURCE_LABEL,
+            "tile": TILE,
+        }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -175,6 +175,13 @@ class Settings:
     EXPANSION_VIABILITY_DEMOTION_STEPS: int = int(
         os.getenv("EXPANSION_VIABILITY_DEMOTION_STEPS", "6")
     )
+    # Minimum YoY radiance growth pct (0-100 scale) for the third leg (NASA
+    # Black Marble VNP46A3) to rescue a candidate from market-viability
+    # flagging. Default 0 means any positive growth rescues; raise to e.g.
+    # 5.0 to require meaningful growth before granting a rescue.
+    EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD: float = float(
+        os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD", "0.0")
+    )
 
     # --- Expansion Advisor decision-memo pre-warm (Phase 3) ---
     # After POST /searches returns, schedule a background task that

--- a/app/ingest/black_marble_radiance.py
+++ b/app/ingest/black_marble_radiance.py
@@ -1,0 +1,240 @@
+"""
+Ingestion pipeline for NASA Black Marble VNP46A3 monthly nighttime radiance.
+
+Downloads one h22v06 H5 file per month from the LAADS DAAC archive, aggregates
+per-district radiance using OSM-first district polygons, and inserts into
+``district_radiance_monthly``. Idempotent per (year_month, source).
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.connectors import blackmarble
+from app.connectors.blackmarble import (
+    PIXEL_COUNT_FLOOR,
+    RIYADH_BBOX,
+    SOURCE_LABEL,
+)
+from app.ml.name_normalization import norm_district
+
+logger = logging.getLogger(__name__)
+
+
+def ingest_blackmarble_month(db: Session, year_month: date, token: str) -> int:
+    """Ingest one month of Black Marble VNP46A3 radiance into district_radiance_monthly.
+
+    Idempotent: re-running for an already-ingested month deletes prior rows for that
+    (year_month, source) combination and re-inserts. Mirrors the population pre-purge
+    pattern.
+
+    Returns: number of rows inserted (one per district).
+    """
+    ym = date(year_month.year, year_month.month, 1)
+
+    deleted = db.execute(
+        text(
+            "DELETE FROM district_radiance_monthly "
+            "WHERE year_month = :ym AND source = :src"
+        ),
+        {"ym": ym, "src": SOURCE_LABEL},
+    ).rowcount
+    logger.info(
+        "Pre-purged %s existing rows for year_month=%s source=%s",
+        deleted,
+        ym.isoformat(),
+        SOURCE_LABEL,
+    )
+
+    url = blackmarble.discover_h5_url(ym, token)
+    logger.info("Resolved Black Marble URL for %s: %s", ym.isoformat(), url)
+
+    polygons = _load_district_polygons(db)
+    if not polygons:
+        logger.warning("No district polygons loaded; aborting Black Marble ingest")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="blackmarble_") as tmpdir:
+        h5_path = Path(tmpdir) / f"VNP46A3.{ym.isoformat()}.{blackmarble.TILE}.h5"
+        blackmarble.download_h5(url, token, h5_path)
+        _validate_h5(h5_path)
+
+        rows: list[dict[str, Any]] = list(
+            blackmarble.aggregate_per_district(h5_path, polygons, ym)
+        )
+
+    if not rows:
+        logger.warning("Aggregation produced 0 rows for %s", ym.isoformat())
+        return 0
+
+    db.execute(
+        text(
+            """
+            INSERT INTO district_radiance_monthly (
+                district_key, year_month, radiance_mean, radiance_median,
+                radiance_sum, radiance_p90, pixel_count_total, pixel_count_valid,
+                quality_filter, source, tile
+            ) VALUES (
+                :district_key, :year_month, :radiance_mean, :radiance_median,
+                :radiance_sum, :radiance_p90, :pixel_count_total, :pixel_count_valid,
+                :quality_filter, :source, :tile
+            )
+            """
+        ),
+        rows,
+    )
+    db.commit()
+
+    confident = sum(1 for r in rows if r["pixel_count_valid"] >= PIXEL_COUNT_FLOOR)
+    logger.info(
+        "black marble ingest: year_month=%s districts=%d rows_with_pixels>=%d=%d",
+        ym.isoformat()[:7],
+        len(rows),
+        PIXEL_COUNT_FLOOR,
+        confident,
+    )
+    return len(rows)
+
+
+def _load_district_polygons(db: Session) -> list[dict[str, Any]]:
+    """Load Riyadh district polygons (OSM-first) for radiance aggregation.
+
+    Mirrors the osm-first DISTINCT ON pattern in
+    ``app/services/expansion_advisor.py:387-409``. Each district name is run
+    through :func:`app.ml.name_normalization.norm_district` to produce
+    ``district_key``. Polygons whose envelopes fall entirely outside
+    ``RIYADH_BBOX`` are rejected.
+    """
+    try:
+        from shapely import wkb as shapely_wkb
+    except ImportError as exc:
+        logger.error("Missing shapely dependency: %s", exc)
+        return []
+
+    west, south, east, north = RIYADH_BBOX
+
+    sql = text(
+        """
+        SELECT DISTINCT ON (district_label)
+            TRIM(COALESCE(ef.properties->>'district_raw',
+                          ef.properties->>'district')) AS district_label,
+            ST_AsBinary(ef.geom) AS geom_wkb
+        FROM external_feature ef
+        WHERE ef.layer_name IN ('osm_districts', 'aqar_district_hulls')
+          AND ef.geom IS NOT NULL
+          AND COALESCE(ef.properties->>'district_raw',
+                       ef.properties->>'district') IS NOT NULL
+          AND TRIM(COALESCE(ef.properties->>'district_raw',
+                            ef.properties->>'district')) <> ''
+          AND ST_Intersects(
+                ef.geom,
+                ST_MakeEnvelope(:west, :south, :east, :north, 4326)
+              )
+        ORDER BY
+            district_label,
+            CASE ef.layer_name
+                WHEN 'osm_districts'       THEN 1
+                WHEN 'aqar_district_hulls' THEN 2
+                ELSE 3
+            END
+        """
+    )
+
+    out: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    rows = db.execute(
+        sql, {"west": west, "south": south, "east": east, "north": north}
+    ).mappings().all()
+
+    for row in rows:
+        district_label = row["district_label"]
+        geom_wkb = row["geom_wkb"]
+        if not district_label or geom_wkb is None:
+            continue
+        try:
+            geom = shapely_wkb.loads(bytes(geom_wkb))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Skipping polygon with bad WKB: %s", exc)
+            continue
+
+        # Reject polygons that fall entirely outside the Riyadh metro bbox.
+        minx, miny, maxx, maxy = geom.bounds
+        if maxx < west or minx > east or maxy < south or miny > north:
+            continue
+
+        district_key = norm_district("riyadh", district_label)
+        if not district_key or district_key in seen_keys:
+            continue
+        seen_keys.add(district_key)
+        out.append({"district_key": district_key, "geometry": geom})
+
+    logger.info("Loaded %d district polygons for Black Marble aggregation", len(out))
+    return out
+
+
+def _validate_h5(path: str | Path) -> None:
+    """Validate that a file is a readable HDF5 container before loading."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"H5 file not found: {p}")
+
+    try:
+        import h5py
+    except ImportError as exc:
+        raise RuntimeError("h5py is required to validate Black Marble H5 files") from exc
+
+    try:
+        with h5py.File(p, "r") as fh:
+            keys = list(fh.keys())
+            print(f"H5 OK: {p.name} top_level_keys={keys}")
+    except Exception as exc:
+        head_bytes = p.read_bytes()[:32]
+        raise RuntimeError(
+            f"Cannot open {p} as HDF5.\n"
+            f"  first 32 bytes: {head_bytes!r}\n"
+            f"  original error: {exc}\n"
+            f"Hint: re-run the download or check the LAADS source URL."
+        ) from exc
+
+
+if __name__ == "__main__":
+    import argparse
+    import os
+
+    from app.db.session import SessionLocal
+
+    parser = argparse.ArgumentParser(
+        description="Ingest one month of Black Marble VNP46A3 radiance."
+    )
+    parser.add_argument(
+        "--year-month",
+        required=True,
+        help="YYYY-MM (e.g. 2026-03)",
+    )
+    args = parser.parse_args()
+
+    try:
+        year, month = (int(x) for x in args.year_month.split("-", 1))
+    except ValueError:
+        raise SystemExit(f"Invalid --year-month value: {args.year_month!r}")
+    ym = date(year, month, 1)
+
+    token = os.environ.get("EDL_TOKEN")
+    if not token:
+        raise SystemExit("EDL_TOKEN environment variable is required")
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    db = SessionLocal()
+    try:
+        n = ingest_blackmarble_month(db, ym, token)
+        print(f"Black Marble ingestion complete: {n} district rows for {ym.isoformat()[:7]}")
+    finally:
+        db.close()

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -348,6 +348,25 @@ class PopulationDensity(Base):
     observed_at = Column(DateTime)
 
 
+class DistrictRadianceMonthly(Base):
+    """Monthly NASA Black Marble VNP46A3 radiance aggregates per district."""
+
+    __tablename__ = "district_radiance_monthly"
+
+    district_key = Column(Text, primary_key=True, nullable=False)
+    year_month = Column(Date, primary_key=True, nullable=False)
+    source = Column(String(64), primary_key=True, nullable=False)
+    radiance_mean = Column(Numeric(12, 4))
+    radiance_median = Column(Numeric(12, 4))
+    radiance_sum = Column(Numeric(14, 4))
+    radiance_p90 = Column(Numeric(12, 4))
+    pixel_count_total = Column(Integer, nullable=False)
+    pixel_count_valid = Column(Integer, nullable=False)
+    quality_filter = Column(String(32), nullable=False)
+    tile = Column(String(16), nullable=False)
+    ingested_at = Column(DateTime(timezone=True), server_default=text("NOW()"), nullable=False)
+
+
 class RestaurantHeatmapCache(Base):
     """Cached city-wide opportunity heatmap payload per category + radius."""
 

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -15,6 +15,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.ml.name_normalization import norm_district
 from app.services.aqar_district_match import (
     is_mojibake,
     normalize_district_key,
@@ -60,6 +61,7 @@ _GATE_HUMAN_LABELS: dict[str, str] = {
     "cannibalization_pass": "cannibalization",
     "delivery_market_pass": "delivery market",
     "economics_pass": "economics",
+    "radiance_growth_pass": "Market growth signal",
 }
 
 
@@ -2517,6 +2519,8 @@ def _candidate_gate_status(
     is_listing: bool = False,
     unit_street_width_m: float | None = None,
     zoning_verdict_hint: str | None = None,
+    radiance_growth: dict[str, Any] | None = None,
+    radiance_yoy_threshold: float | None = None,
 ) -> tuple[dict[str, bool | None], dict[str, Any]]:
     thresholds = {
         "area_fit_min": 55.0,
@@ -2605,6 +2609,22 @@ def _candidate_gate_status(
 
     economics_pass = economics_score >= thresholds["economics_min"]
 
+    # Radiance growth gate (advisory only). True/False when the signal is
+    # confident; None when no radiance data is available for the district.
+    _radiance_threshold = (
+        radiance_yoy_threshold
+        if radiance_yoy_threshold is not None
+        else getattr(settings, "EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD", 0.0)
+    )
+    radiance_growth_pass: bool | None = None
+    if isinstance(radiance_growth, dict) and radiance_growth.get("confident"):
+        _yoy = radiance_growth.get("value_yoy_pct")
+        if _yoy is not None:
+            try:
+                radiance_growth_pass = float(_yoy) >= float(_radiance_threshold)
+            except (TypeError, ValueError):
+                radiance_growth_pass = None
+
     gate_states: dict[str, bool | None] = {
         "zoning_fit_pass": zoning_fit_pass,
         "area_fit_pass": area_fit_pass,
@@ -2614,6 +2634,7 @@ def _candidate_gate_status(
         "cannibalization_pass": cannibalization_pass,
         "delivery_market_pass": delivery_market_pass,
         "economics_pass": economics_pass,
+        "radiance_growth_pass": radiance_growth_pass,
     }
     failed = [k for k, v in gate_states.items() if v is False]
     passed = [k for k, v in gate_states.items() if v is True]
@@ -2624,6 +2645,14 @@ def _candidate_gate_status(
         "zoning_fit_pass",
         "area_fit_pass",
     }
+
+    # Advisory-only gates: presence/absence of signal must NOT collapse the
+    # overall verdict to indeterminate (None). They surface in gate_status
+    # for the UI but are excluded from the unknown count used by overall_pass.
+    advisory_only_gates = {
+        "radiance_growth_pass",
+    }
+    unknown_for_overall = [g for g in unknown if g not in advisory_only_gates]
 
     # Surface advisory failures separately so the frontend can render
     # caution/attention states without labeling the site as a hard FAIL.
@@ -2636,7 +2665,7 @@ def _candidate_gate_status(
     #   None  – no blocking failures, but some gates are unknown/indeterminate
     if len(blocking_failures) > 0:
         overall_pass: bool | None = False
-    elif len(unknown) > 0:
+    elif len(unknown_for_overall) > 0:
         overall_pass = None
     else:
         overall_pass = True
@@ -2652,6 +2681,7 @@ def _candidate_gate_status(
         "cannibalization_pass": cannibalization_pass,
         "delivery_market_pass": delivery_market_pass,
         "economics_pass": economics_pass,
+        "radiance_growth_pass": radiance_growth_pass,
         "overall_pass": overall_pass,
     }
     # Determine delivery observation status for honest gate explanations.
@@ -2692,6 +2722,12 @@ def _candidate_gate_status(
         "cannibalization_pass": "Cannibalization gate checks minimum spacing from existing branches.",
         "delivery_market_pass": delivery_explanation,
         "economics_pass": "Economics gate requires minimum economics score.",
+        "radiance_growth_pass": (
+            "Advisory market-growth signal from NASA Black Marble VNP46A3 "
+            "monthly nighttime radiance (district YoY). Confident positive "
+            "growth rescues a candidate from the market-viability conjunction; "
+            "this gate is not a hard fail."
+        ),
     }
     reasons = {
         "passed": passed,
@@ -4429,17 +4465,19 @@ def _apply_market_viability_pass(
     rent_pct_threshold: float | None = None,
     pop_percentile_threshold: float | None = None,
     demotion_steps: int | None = None,
+    radiance_yoy_threshold: float | None = None,
 ) -> list[dict[str, Any]]:
-    """Demote candidates that are confidently bad on both CEO-directive legs
-    we currently measure: high rent percentile AND low population reach.
+    """Demote candidates that are confidently bad on the CEO-directive legs.
 
-    Conservative: only fires when each leg has CONFIDENT signal. Mirrors
-    _apply_value_band_pass — positional reorder only, does not mutate
-    final_score. Writes 'market_viability_flag' to score_breakdown_json.
+    3-of-3 form: high rent percentile AND low population reach AND no positive
+    growth signal. The third leg ("market growth") reads
+    ``feature_snapshot_json["radiance_growth"]`` (NASA Black Marble VNP46A3).
+    When that signal is confident and YoY growth meets the threshold, the
+    candidate is rescued from the conjunction (not flagged at all).
 
-    The directive's third leg (market growth potential) is not enforced here
-    because the repo has no honest growth signal as of 2026-04-30. When one
-    lands, add it as a third condition; the rest of this function is stable.
+    Conservative: each leg requires CONFIDENT signal. Positional reorder only,
+    does not mutate final_score. Writes 'market_viability_flag' to
+    score_breakdown_json (with radiance fields included for observability).
     """
     if not candidates or len(candidates) < 4:
         return candidates
@@ -4458,6 +4496,11 @@ def _apply_market_viability_pass(
         demotion_steps
         if demotion_steps is not None
         else settings.EXPANSION_VIABILITY_DEMOTION_STEPS
+    )
+    radiance_yoy_threshold = (
+        radiance_yoy_threshold
+        if radiance_yoy_threshold is not None
+        else settings.EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD
     )
 
     out = list(candidates)
@@ -4489,34 +4532,73 @@ def _apply_market_viability_pass(
     except Exception:
         return out
 
-    def _flag_inputs(c: dict[str, Any]) -> tuple[bool, float, str | None, float]:
+    def _flag_inputs(
+        c: dict[str, Any]
+    ) -> tuple[bool, float, str | None, float, dict[str, Any]]:
         sb = c.get("score_breakdown_json")
         ed = sb.get("economics_detail") if isinstance(sb, dict) else None
         rb = ed.get("rent_burden") if isinstance(ed, dict) else None
+        radiance_meta: dict[str, Any] = {
+            "radiance_growth_pct": None,
+            "radiance_confident": None,
+            "radiance_pixel_count": None,
+            "radiance_year_month": None,
+        }
         if not isinstance(rb, dict):
-            return False, 0.0, None, 0.0
+            return False, 0.0, None, 0.0, radiance_meta
         rent_scope = rb.get("source_label")
         rent_pct_val = rb.get("percentile")
         if rent_pct_val is None:
-            return False, 0.0, rent_scope, 0.0
+            return False, 0.0, rent_scope, 0.0, radiance_meta
         rent_pct = _safe_float(rent_pct_val, default=-1.0)
 
         fs = c.get("feature_snapshot_json")
         if not isinstance(fs, dict):
-            return False, rent_pct, rent_scope, 0.0
+            return False, rent_pct, rent_scope, 0.0, radiance_meta
         pop_raw = fs.get("population_reach")
         if pop_raw is None:
-            return False, rent_pct, rent_scope, 0.0
+            return False, rent_pct, rent_scope, 0.0, radiance_meta
         pop_reach = _safe_float(pop_raw, default=-1.0)
+
+        # Third leg: NASA Black Marble VNP46A3 YoY radiance growth.
+        rad = fs.get("radiance_growth") if isinstance(fs, dict) else None
+        rad_confident = False
+        rad_yoy_pct: float | None = None
+        if isinstance(rad, dict):
+            rad_confident = bool(rad.get("confident"))
+            yoy_raw = rad.get("value_yoy_pct")
+            if yoy_raw is not None:
+                try:
+                    candidate_yoy = float(yoy_raw)
+                    if not (math.isnan(candidate_yoy) or math.isinf(candidate_yoy)):
+                        rad_yoy_pct = candidate_yoy
+                except (TypeError, ValueError):
+                    rad_yoy_pct = None
+            radiance_meta = {
+                "radiance_growth_pct": rad_yoy_pct,
+                "radiance_confident": rad_confident,
+                "radiance_pixel_count": rad.get("pixel_count"),
+                "radiance_year_month": rad.get("year_month"),
+            }
+
+        growth_rescue = bool(
+            rad_confident
+            and rad_yoy_pct is not None
+            and rad_yoy_pct >= radiance_yoy_threshold
+        )
 
         rent_confident = rent_scope not in ("city_band_type", "city")
         pop_confident = pop_reach > 0
         rent_high = rent_pct >= rent_pct_threshold
         pop_low = pop_reach < pop_threshold
         flagged = bool(
-            rent_confident and pop_confident and rent_high and pop_low
+            rent_confident
+            and pop_confident
+            and rent_high
+            and pop_low
+            and not growth_rescue
         )
-        return flagged, rent_pct, rent_scope, pop_reach
+        return flagged, rent_pct, rent_scope, pop_reach, radiance_meta
 
     pre_eval = [_flag_inputs(c) for c in out]
     demote_indices = [i for i in range(n) if pre_eval[i][0]]
@@ -4525,7 +4607,7 @@ def _apply_market_viability_pass(
     for i in reversed(demote_indices):
         target = min(i + demotion_steps, n - 1)
         c = out[i]
-        _, rent_pct, rent_scope, pop_reach = pre_eval[i]
+        _, rent_pct, rent_scope, pop_reach, radiance_meta = pre_eval[i]
         sb = c.get("score_breakdown_json")
         if not isinstance(sb, dict):
             sb = {}
@@ -4538,6 +4620,10 @@ def _apply_market_viability_pass(
             "population_reach": float(pop_reach),
             "population_threshold": float(pop_threshold),
             "reason": "high_rent_low_population",
+            "radiance_growth_pct": radiance_meta["radiance_growth_pct"],
+            "radiance_confident": radiance_meta["radiance_confident"],
+            "radiance_pixel_count": radiance_meta["radiance_pixel_count"],
+            "radiance_year_month": radiance_meta["radiance_year_month"],
         }
         if target > i:
             out.pop(i)
@@ -6313,6 +6399,64 @@ def run_expansion_search(
         t_rent_prewarm_done - t_district_momentum_done, len(_norm_to_raw), search_id,
     )
 
+    # ── Pre-compute Black Marble VNP46A3 radiance YoY signal per district ──
+    # Latest available month vs. same calendar month one year earlier (simple
+    # YoY). Pre-loaded in one query before the candidate loop to avoid N+1.
+    # Keyed by norm_district("riyadh", district_label) — matches the key used
+    # at ingest time in app.ingest.black_marble_radiance.
+    _radiance_lookup: dict[str, dict[str, Any]] = {}
+    try:
+        _radiance_rows = db.execute(text("""
+            WITH latest_month AS (
+                SELECT MAX(year_month) AS ym
+                FROM district_radiance_monthly
+                WHERE source = :src
+            ),
+            prev_year AS (
+                SELECT (SELECT ym FROM latest_month) - INTERVAL '1 year' AS ym_prev
+            )
+            SELECT
+                cur.district_key,
+                cur.radiance_mean AS rad_cur,
+                cur.pixel_count_valid AS pixels_cur,
+                cur.year_month AS ym_cur,
+                prev.radiance_mean AS rad_prev,
+                prev.pixel_count_valid AS pixels_prev
+            FROM district_radiance_monthly cur
+            LEFT JOIN district_radiance_monthly prev
+              ON prev.district_key = cur.district_key
+             AND prev.source = cur.source
+             AND prev.year_month = (SELECT ym_prev FROM prev_year)::date
+            WHERE cur.year_month = (SELECT ym FROM latest_month)
+              AND cur.source = :src
+        """), {"src": "nasa_blackmarble_vnp46a3_c2"}).mappings().all()
+    except Exception:
+        # Table may not exist yet (migration not applied) — degrade silently.
+        logger.debug("district_radiance_monthly lookup failed", exc_info=True)
+        _radiance_rows = []
+
+    for _r in _radiance_rows:
+        _dk = _r["district_key"]
+        _pixels_cur = int(_r["pixels_cur"] or 0)
+        _pixels_prev = int(_r["pixels_prev"] or 0)
+        _confident = _pixels_cur >= 10 and _pixels_prev >= 10
+        _yoy_pct: float | None = None
+        if _confident and _r["rad_prev"] and float(_r["rad_prev"]) > 0:
+            _yoy_pct = (
+                float(_r["rad_cur"]) - float(_r["rad_prev"])
+            ) / float(_r["rad_prev"]) * 100.0
+        _radiance_lookup[_dk] = {
+            "value_yoy_pct": round(_yoy_pct, 2) if _yoy_pct is not None else None,
+            "source_label": "blackmarble_district_yoy_simple",
+            "confident": _confident and _yoy_pct is not None,
+            "pixel_count": _pixels_cur,
+            "year_month": str(_r["ym_cur"]),
+        }
+    logger.info(
+        "expansion_search radiance lookup: districts=%d search_id=%s",
+        len(_radiance_lookup), search_id,
+    )
+
     for row in rows:
       try:
         area_m2 = _safe_float(row.get("area_m2"))
@@ -7338,6 +7482,17 @@ def run_expansion_search(
                 "district_label": district if isinstance(district, str) else None,
                 "sample_floor_applied": True,
             }
+        # Black Marble VNP46A3 radiance growth (third leg of market viability).
+        # Key produced via norm_district mirrors the ingest path (see
+        # app/ingest/black_marble_radiance.py). Width mismatch note for the
+        # underlying join: expansion_candidate.parcel_id is varchar(128) and
+        # commercial_unit.aqar_id is varchar(64); the lookup is keyed by
+        # district string here, not id, so widths don't apply at this site.
+        if _radiance_lookup and isinstance(district, str) and district:
+            _district_key_for_radiance = norm_district("riyadh", district)
+            _radiance_signal = _radiance_lookup.get(_district_key_for_radiance)
+            if _radiance_signal is not None:
+                feature_snapshot_json["radiance_growth"] = dict(_radiance_signal)
         # Brand presence in the candidate's 500m micro-market (PR C).
         # Top 5 by branch count, with unique brand count and total branch
         # count summarized for the Breakdown tab header.
@@ -7533,6 +7688,7 @@ def run_expansion_search(
             is_listing=_is_listing,
             unit_street_width_m=_unit_street_width,
             zoning_verdict_hint=zoning_hint,
+            radiance_growth=feature_snapshot_json.get("radiance_growth"),
         )
         confidence_grade = _confidence_grade(
             confidence_score=confidence_score,

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -411,6 +411,7 @@ _RERANK_WHITELIST: tuple[str, ...] = (
     "zoning_fit",
     "parking_score",
     "frontage_score",
+    "radiance_growth",
 )
 
 _MEMO_WHITELIST: tuple[str, ...] = _RERANK_WHITELIST + (

--- a/docs/market_viability_validation.md
+++ b/docs/market_viability_validation.md
@@ -1,0 +1,128 @@
+# Market-viability conjunction — validation playbook
+
+This document covers both the existing 2-of-3 form (rent x population, shipped
+2026-05-01 in commit `59320ae2a`) and the new 3-of-3 form that adds NASA
+Black Marble VNP46A3 monthly nighttime-radiance growth as the third leg.
+
+The pass is implemented in
+`app/services/expansion_advisor.py::_apply_market_viability_pass` and runs
+after rerank. It is a **positional demotion** (does not mutate `final_score`)
+that fires only when each leg has a confident signal.
+
+## How the conjunction works
+
+A candidate is flagged when **all three** are true and confident:
+
+1. **Rent leg.** `economics_detail.rent_burden.percentile >=
+   EXPANSION_VIABILITY_RENT_PCT_THRESHOLD` and `rent_burden.source_label`
+   is **not** in the deny-list `("city_band_type", "city")` (those scopes
+   are too coarse to be confident).
+2. **Population leg.** `population_reach > 0` and below the cohort's
+   `EXPANSION_VIABILITY_POP_PERCENTILE` cutoff.
+3. **Growth leg (third leg).** *Inverted* — the candidate's district has
+   `radiance_growth.confident == false` **or** `value_yoy_pct <
+   EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD`. Confident positive growth
+   **rescues** the candidate from the conjunction (no flag).
+
+If a confident signal is missing on any leg, that leg falls through; the
+pre-existing 2-of-3 behavior governs.
+
+## Source labels
+
+- Rent: `district`, `district_band_type`, `district_type`, `city`,
+  `city_band_type`, `conservative_default`. Confident scopes are everything
+  except `city_band_type` and `city`.
+- Radiance: `blackmarble_district_yoy_simple` (current, single-month YoY)
+  or `blackmarble_district_yoy_12mo` (future, trailing-12-month average
+  once 24 months of backfill is loaded).
+
+## SQL recipes
+
+### 1. Flag rate by rent scope (applies to both 2-of-3 and 3-of-3)
+
+```sql
+SELECT
+  score_breakdown_json #>> '{economics_detail,rent_burden,source_label}' AS rent_scope,
+  COUNT(*) FILTER (WHERE score_breakdown_json ? 'market_viability_flag') AS flagged,
+  COUNT(*) AS total,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE score_breakdown_json ? 'market_viability_flag') / COUNT(*), 1) AS pct
+FROM expansion_candidate
+WHERE computed_at > NOW() - INTERVAL '24 hours'
+GROUP BY 1
+ORDER BY 1;
+```
+
+Expected: 5-15% flag rate among district-confident scopes
+(`district`, `district_band_type`, `district_type`); 0% among
+`city_band_type` / `city` (those scopes never enter the conjunction).
+
+### 2. Third-leg rescue rate (3-of-3 only)
+
+```sql
+SELECT
+  COUNT(*) AS total_district_confident,
+  COUNT(*) FILTER (WHERE score_breakdown_json ? 'market_viability_flag') AS still_flagged,
+  COUNT(*) FILTER (
+    WHERE feature_snapshot_json ? 'radiance_growth'
+      AND (feature_snapshot_json #>> '{radiance_growth,confident}')::boolean = true
+  ) AS has_radiance_signal,
+  COUNT(*) FILTER (
+    WHERE feature_snapshot_json ? 'radiance_growth'
+      AND (feature_snapshot_json #>> '{radiance_growth,confident}')::boolean = true
+      AND (feature_snapshot_json #>> '{radiance_growth,value_yoy_pct}')::numeric > 0
+  ) AS has_positive_growth
+FROM expansion_candidate
+WHERE computed_at > NOW() - INTERVAL '24 hours'
+  AND score_breakdown_json #>> '{economics_detail,rent_burden,source_label}'
+      NOT IN ('city_band_type', 'city');
+```
+
+Compare `still_flagged / total_district_confident` between the pre-3-of-3
+baseline (~5-15%) and post-3-of-3 (expected lower by some margin reflecting
+growth rescues).
+
+### 3. Per-district radiance distribution sanity check
+
+```sql
+SELECT
+  district_key,
+  year_month,
+  pixel_count_valid,
+  ROUND(radiance_mean::numeric, 2) AS rad_mean
+FROM district_radiance_monthly
+WHERE source = 'nasa_blackmarble_vnp46a3_c2'
+  AND year_month = (SELECT MAX(year_month) FROM district_radiance_monthly)
+ORDER BY radiance_mean DESC NULLS LAST
+LIMIT 20;
+```
+
+Expected (per POC, 2026-05-01): top 10-20 districts include Hittin, Olaya,
+KKIA airport, Qurtubah. Pixel counts should mostly be > 10 in the lenient
+(`quality < 2`) regime; below-floor districts produce
+`confident=false` and silently fall through.
+
+## Gate status surface
+
+`_candidate_gate_status` exposes `radiance_growth_pass` alongside the existing
+gates. It is **advisory**, not in `hard_fail_gates`.
+
+- `True`: confident signal, YoY >= threshold (rescue would apply).
+- `False`: confident signal, YoY < threshold.
+- `None`: no radiance data for the district (advisory unknown).
+
+## Tuning the rescue threshold
+
+`EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD` defaults to `0.0` — any positive
+growth rescues. If the false-rescue rate is high (i.e., flagged-and-rescued
+candidates that under-perform after launch), raise to `5.0` or `10.0` to
+require meaningful growth.
+
+## Operational notes
+
+- The monthly cron (`.github/workflows/ingest-blackmarble.yml`) fires on the
+  15th of each month, ingesting the latest available month of VNP46A3.
+- Black Marble has a ~6-8 week production lag; the workflow defaults to
+  `2 months ago` if no `year_month` input is provided.
+- Allowlisted NASA domains: `ladsweb.modaps.eosdis.nasa.gov`,
+  `urs.earthdata.nasa.gov`. The patch can merge before the allowlist lands;
+  only the workflow's ingest step will fail until the allowlist is active.

--- a/scripts/backfill_blackmarble.sh
+++ b/scripts/backfill_blackmarble.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# One-shot backfill of 24 months of Black Marble VNP46A3 (Apr 2024 -> Mar 2026).
+# Run after the new migration is deployed and EDL_TOKEN is set in env.
+# Sequential: ~80 MB per file x 24 = ~2 GB total, ~30 min wall time.
+# NOT for production cron use; the monthly Actions workflow handles ongoing
+# ingest. Re-running is safe (each month pre-purges its own rows).
+
+set -euo pipefail
+
+if [ -z "${EDL_TOKEN:-}" ]; then
+  echo "ERROR: EDL_TOKEN not set" >&2
+  exit 1
+fi
+
+for ym in 2024-04 2024-05 2024-06 2024-07 2024-08 2024-09 2024-10 2024-11 2024-12 \
+          2025-01 2025-02 2025-03 2025-04 2025-05 2025-06 2025-07 2025-08 2025-09 \
+          2025-10 2025-11 2025-12 2026-01 2026-02 2026-03; do
+  echo "=== Ingesting $ym ==="
+  python -m app.ingest.black_marble_radiance --year-month "$ym"
+done
+
+echo "Backfill complete. 24 months ingested."

--- a/tests/test_blackmarble_connector.py
+++ b/tests/test_blackmarble_connector.py
@@ -1,0 +1,176 @@
+"""Lightweight tests for the Black Marble VNP46A3 connector.
+
+Network-dependent tests are skipped. Tests focus on URL construction and
+quality-filter / pixel-count behavior of the aggregator using a small
+synthetic raster + polygon.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.mark.skip(reason="requires NASA EDL token and network")
+def test_download_h5_real():
+    pass
+
+
+def test_discover_h5_url_constructs_correct_path():
+    from app.connectors import blackmarble
+
+    # Mock LAADS directory listing JSON for 2026-03 (DOY 60 for first-of-month).
+    fake_entries = [
+        {"name": "VNP46A3.A2026060.h22v06.002.2026105050000.h5", "size": 80_000_000},
+        {"name": "VNP46A3.A2026060.h21v06.002.2026105050000.h5", "size": 80_000_000},
+    ]
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = fake_entries
+    fake_resp.raise_for_status.return_value = None
+
+    fake_session = MagicMock()
+    fake_session.get.return_value = fake_resp
+
+    with patch.object(blackmarble, "_LAADSSession", return_value=fake_session):
+        url = blackmarble.discover_h5_url(date(2026, 3, 1), token="dummy")
+
+    assert "ladsweb.modaps.eosdis.nasa.gov" in url
+    assert "VNP46A3" in url
+    assert "/2026/060/" in url
+    assert "h22v06" in url
+    # Listing URL passed to GET should be the .json variant for that DOY.
+    listing_url = fake_session.get.call_args[0][0]
+    assert listing_url.endswith("/2026/060.json")
+
+
+def test_discover_h5_url_raises_when_not_published():
+    from app.connectors import blackmarble
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 404
+
+    fake_session = MagicMock()
+    fake_session.get.return_value = fake_resp
+
+    with patch.object(blackmarble, "_LAADSSession", return_value=fake_session):
+        with pytest.raises(blackmarble.BlackMarbleNotAvailableError):
+            blackmarble.discover_h5_url(date(2099, 1, 1), token="dummy")
+
+
+def _build_synthetic_h5(tmp_path, radiance, quality):
+    """Write a tiny H5 with the expected band paths."""
+    import h5py
+
+    p = tmp_path / "synth.h5"
+    with h5py.File(p, "w") as fh:
+        # h5py creates intermediate groups implicitly when paths are nested.
+        from app.connectors.blackmarble import RADIANCE_BAND_PATH, QUALITY_BAND_PATH
+
+        fh.create_dataset(RADIANCE_BAND_PATH, data=radiance)
+        fh.create_dataset(QUALITY_BAND_PATH, data=quality)
+    return p
+
+
+def test_aggregate_per_district_filters_quality_correctly():
+    # Skip if optional deps missing.
+    h5py = pytest.importorskip("h5py")
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("rasterio")
+    shapely_geom = pytest.importorskip("shapely.geometry")
+
+    from app.connectors import blackmarble
+
+    # 4x4 synthetic raster.
+    # Quality: top-left 2x2 = 0 (Good), top-right 2x2 = 1 (Poor),
+    # bottom-left 2x2 = 2 (Bad), bottom-right 2x2 = 0 (Good).
+    radiance = np.array(
+        [
+            [10.0, 11.0, 20.0, 21.0],
+            [12.0, 13.0, 22.0, 23.0],
+            [30.0, 31.0, 40.0, 41.0],
+            [32.0, 33.0, 42.0, 43.0],
+        ],
+        dtype=float,
+    )
+    quality = np.array(
+        [
+            [0, 0, 1, 1],
+            [0, 0, 1, 1],
+            [2, 2, 0, 0],
+            [2, 2, 0, 0],
+        ],
+        dtype=int,
+    )
+
+    # Polygon covering the entire tile envelope.
+    poly = shapely_geom.box(40.0, 20.0, 50.0, 30.0)
+
+    import tempfile
+    import os
+
+    with tempfile.TemporaryDirectory() as tmp:
+        from pathlib import Path
+
+        h5_path = _build_synthetic_h5(Path(tmp), radiance, quality)
+
+        rows = list(
+            blackmarble.aggregate_per_district(
+                h5_path,
+                [{"district_key": "all", "geometry": poly}],
+                year_month=date(2026, 3, 1),
+            )
+        )
+
+    assert len(rows) == 1
+    r = rows[0]
+    # Lenient filter (quality < 2) excludes the bottom-left 2x2 (quality=2).
+    # 16 total, 12 valid.
+    assert r["pixel_count_total"] == 16
+    assert r["pixel_count_valid"] == 12
+    # Mean of the 12 valid pixels.
+    valid_vals = [10, 11, 20, 21, 12, 13, 22, 23, 40, 41, 42, 43]
+    assert abs(r["radiance_mean"] - sum(valid_vals) / len(valid_vals)) < 1e-6
+    assert r["quality_filter"] == "lenient_qa_lt_2"
+    assert r["source"] == "nasa_blackmarble_vnp46a3_c2"
+    assert r["tile"] == "h22v06"
+
+
+def test_aggregate_per_district_pixel_count_floor():
+    # Verifies pixel_count_valid is reported regardless of the
+    # PIXEL_COUNT_FLOOR; the floor check happens at consume-time.
+    pytest.importorskip("h5py")
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("rasterio")
+    shapely_geom = pytest.importorskip("shapely.geometry")
+
+    from app.connectors import blackmarble
+
+    radiance = np.full((4, 4), -999.9, dtype=float)
+    radiance[0, 0] = 5.0  # one valid pixel
+    quality = np.zeros((4, 4), dtype=int)
+
+    poly = shapely_geom.box(40.0, 20.0, 50.0, 30.0)
+
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        h5_path = _build_synthetic_h5(Path(tmp), radiance, quality)
+        rows = list(
+            blackmarble.aggregate_per_district(
+                h5_path,
+                [{"district_key": "tiny", "geometry": poly}],
+                year_month=date(2026, 3, 1),
+            )
+        )
+
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["pixel_count_total"] == 16
+    # Below the consume-time floor of 10, but we still report it.
+    assert r["pixel_count_valid"] == 1
+    assert r["pixel_count_valid"] < blackmarble.PIXEL_COUNT_FLOOR

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -2691,6 +2691,111 @@ def test_viability_pass_stacks_with_value_band_pass():
 
 
 # ---------------------------------------------------------------------------
+# CEO directive #1 (3-of-3): Black Marble VNP46A3 third (growth) leg.
+# Tests that confident positive YoY radiance growth rescues a candidate that
+# would otherwise be flagged 2-of-2 (high rent + low population).
+# ---------------------------------------------------------------------------
+
+
+def _make_viability_candidate_with_radiance(
+    *,
+    id_: str,
+    final_score: float,
+    rent_pct: float,
+    pop_reach: float,
+    radiance_confident: bool,
+    radiance_yoy_pct: float | None,
+    rent_scope: str = "district_band_type",
+) -> dict:
+    c = _make_viability_candidate(
+        id_=id_,
+        final_score=final_score,
+        rent_pct=rent_pct,
+        rent_scope=rent_scope,
+        pop_reach=pop_reach,
+    )
+    c["feature_snapshot_json"]["radiance_growth"] = {
+        "value_yoy_pct": radiance_yoy_pct,
+        "source_label": "blackmarble_district_yoy_simple",
+        "confident": radiance_confident,
+        "pixel_count": 132 if radiance_confident else 5,
+        "year_month": "2026-03",
+    }
+    return c
+
+
+def _viability_cohort_with_radiance_target(
+    target_radiance_confident: bool,
+    target_radiance_yoy_pct: float | None,
+) -> list[dict]:
+    """Build a cohort like _viability_cohort but the target carries a radiance signal."""
+    pops = [5000, 6000, 7000, 8000, 50000, 60000, 70000, 80000]
+    cohort = [
+        _make_viability_candidate(
+            id_=f"bg{i}",
+            final_score=80.0 - i,
+            rent_pct=0.40,
+            rent_scope="district_band_type",
+            pop_reach=p,
+        )
+        for i, p in enumerate(pops)
+    ]
+    target = _make_viability_candidate_with_radiance(
+        id_="target",
+        final_score=78.5,
+        rent_pct=0.85,
+        pop_reach=4500.0,
+        radiance_confident=target_radiance_confident,
+        radiance_yoy_pct=target_radiance_yoy_pct,
+    )
+    cohort.insert(2, target)
+    return cohort
+
+
+def test_market_viability_third_leg_rescue():
+    # Confident, positive growth >= threshold (default 0.0) → not flagged.
+    cohort = _viability_cohort_with_radiance_target(
+        target_radiance_confident=True,
+        target_radiance_yoy_pct=4.2,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    assert "market_viability_flag" not in target["score_breakdown_json"]
+
+
+def test_market_viability_third_leg_no_rescue_when_not_confident():
+    # Below pixel-count floor → confident=False → leg falls through, still flagged.
+    cohort = _viability_cohort_with_radiance_target(
+        target_radiance_confident=False,
+        target_radiance_yoy_pct=8.0,  # ignored when not confident
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["radiance_confident"] is False
+    assert flag["radiance_pixel_count"] == 5
+    assert flag["radiance_year_month"] == "2026-03"
+
+
+def test_market_viability_third_leg_no_rescue_when_growth_below_threshold():
+    # Confident but YoY < threshold → still flagged. Use threshold=5.0 with
+    # actual yoy=2.0 to exercise the comparison.
+    cohort = _viability_cohort_with_radiance_target(
+        target_radiance_confident=True,
+        target_radiance_yoy_pct=2.0,
+    )
+    out = _apply_market_viability_pass(
+        list(cohort), search_id="t", radiance_yoy_threshold=5.0
+    )
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["radiance_confident"] is True
+    assert flag["radiance_growth_pct"] == 2.0
+
+
+# ---------------------------------------------------------------------------
 # Bug A & Bug B regression coverage.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Integrates NASA Black Marble VNP46A3 monthly nighttime-radiance data as the third (growth) leg of the Expansion Advisor's market-viability conjunction. Candidates with confident positive YoY radiance growth are rescued from the 2-of-2 conjunction (high rent + low population), enabling growth signal to override market-viability flags.

## Key Changes

**New Black Marble Connector** (`app/connectors/blackmarble.py`)
- Downloads h22v06 tile (covers all of Riyadh) from LAADS DAAC archive (collection 5200, VNP46A3 v2.0)
- Implements `discover_h5_url()` to resolve monthly file URLs from LAADS directory listings
- Implements `download_h5()` with streaming, magic-byte validation, and minimum-size checks
- Implements `aggregate_per_district()` to extract per-district radiance stats (mean, median, sum, p90) using lenient quality filter (`quality < 2`) and rasterio geometry masking
- Defines `PIXEL_COUNT_FLOOR = 10` for confidence thresholds (enforced at consume-time, not aggregation-time)

**Ingestion Pipeline** (`app/ingest/black_marble_radiance.py`)
- `ingest_blackmarble_month()`: idempotent monthly ingest with pre-purge pattern
- `_load_district_polygons()`: loads OSM-first district polygons (mirrors expansion_advisor pattern), filters by Riyadh bbox, normalizes district keys via `norm_district()`
- `_validate_h5()`: validates HDF5 file integrity before aggregation
- Runnable as CLI script with `--year-month` argument; requires `EDL_TOKEN` env var

**Database Schema** (`alembic/versions/20260501_add_district_radiance_monthly.py`, `app/models/tables.py`)
- New `district_radiance_monthly` table: stores monthly per-district aggregates (radiance stats, pixel counts, quality/source metadata)
- Primary key: `(district_key, year_month, source)`
- Indexes on `year_month` (DESC) and `(year_month, district_key)` for efficient lookups

**Market-Viability Gate Enhancement** (`app/services/expansion_advisor.py`)
- Extended `_apply_market_viability_pass()` to 3-of-3 form: high rent AND low population AND **no positive growth signal**
- Growth leg is **inverted**: confident positive YoY growth rescues the candidate (no flag)
- Reads `feature_snapshot_json["radiance_growth"]` with fields: `value_yoy_pct`, `source_label`, `confident`, `pixel_count`, `year_month`
- Writes radiance metadata to `market_viability_flag` for observability
- `_candidate_gate_status()` exposes `radiance_growth_pass` as advisory-only gate (not in hard-fail set, does not collapse overall verdict to indeterminate when missing)
- New config: `EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD` (default 0.0, tunable for false-rescue rate)

**Monthly Ingest Workflow** (`.github/workflows/ingest-blackmarble.yml`)
- Scheduled cron: 15th of each month at 05:00 UTC (accounts for ~6-8 week Black Marble production lag)
- Supports manual dispatch with optional `year_month` override
- Installs h5py, rasterio, numpy, shapely; requires EDL_TOKEN secret and *.nasa.gov egress allowlist

**Backfill Script** (`scripts/backfill_blackmarble.sh`)
- One-shot 24-month backfill (Apr 2024 – Mar 2026) for historical radiance data
- Sequential ingest; ~30 min wall time

**Tests** (`tests/test_blackmarble_connector.py`, `tests/test_expansion_advisor_service.

https://claude.ai/code/session_01JctLpiwuQJxb4kRDtPziaB