### PR TITLE
Handle LAADS JSON response wrapper and bare list fallback

### DIFF
--- a/app/connectors/blackmarble.py
+++ b/app/connectors/blackmarble.py
@@ -102,11 +102,22 @@ def discover_h5_url(year_month: date, token: str) -> str:
     resp.raise_for_status()
 
     try:
-        entries = resp.json()
+        payload = resp.json()
     except ValueError as exc:
         raise BlackMarbleError(
             f"LAADS listing for {ym.isoformat()} did not return JSON"
         ) from exc
+
+    # LAADS .json listings are wrapped: {"content": [{"name": ..., ...}, ...]}
+    # Defensive: also accept a bare list in case any LAADS endpoint variant
+    # returns one. See LAADS DAAC's official bash download script
+    # (jq '.content | .[] | .name') for the canonical wrapper shape.
+    if isinstance(payload, dict):
+        entries = payload.get("content") or []
+    elif isinstance(payload, list):
+        entries = payload
+    else:
+        entries = []
 
     for entry in entries:
         name = entry.get("name") if isinstance(entry, dict) else None

--- a/tests/test_blackmarble_connector.py
+++ b/tests/test_blackmarble_connector.py
@@ -21,15 +21,17 @@ def test_download_h5_real():
 def test_discover_h5_url_constructs_correct_path():
     from app.connectors import blackmarble
 
-    # Mock LAADS directory listing JSON for 2026-03 (DOY 60 for first-of-month).
-    fake_entries = [
-        {"name": "VNP46A3.A2026060.h22v06.002.2026105050000.h5", "size": 80_000_000},
-        {"name": "VNP46A3.A2026060.h21v06.002.2026105050000.h5", "size": 80_000_000},
-    ]
+    # Real LAADS .json listing shape: {"content": [{"name": ..., ...}, ...]}
+    fake_payload = {
+        "content": [
+            {"name": "VNP46A3.A2026060.h22v06.002.2026105050000.h5", "size": 80_000_000},
+            {"name": "VNP46A3.A2026060.h21v06.002.2026105050000.h5", "size": 80_000_000},
+        ]
+    }
 
     fake_resp = MagicMock()
     fake_resp.status_code = 200
-    fake_resp.json.return_value = fake_entries
+    fake_resp.json.return_value = fake_payload
     fake_resp.raise_for_status.return_value = None
 
     fake_session = MagicMock()
@@ -45,6 +47,50 @@ def test_discover_h5_url_constructs_correct_path():
     # Listing URL passed to GET should be the .json variant for that DOY.
     listing_url = fake_session.get.call_args[0][0]
     assert listing_url.endswith("/2026/060.json")
+
+
+def test_discover_h5_url_accepts_bare_list_fallback():
+    """Defensive: if a LAADS endpoint variant returns a flat list, the parser
+    should still find the tile. Production hits the wrapper shape (see
+    test_discover_h5_url_constructs_correct_path), but the parser supports
+    either."""
+    from app.connectors import blackmarble
+
+    fake_payload = [
+        {"name": "VNP46A3.A2026060.h22v06.002.2026105050000.h5", "size": 80_000_000},
+    ]
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = fake_payload
+    fake_resp.raise_for_status.return_value = None
+
+    fake_session = MagicMock()
+    fake_session.get.return_value = fake_resp
+
+    with patch.object(blackmarble, "_LAADSSession", return_value=fake_session):
+        url = blackmarble.discover_h5_url(date(2026, 3, 1), token="dummy")
+
+    assert "h22v06" in url
+    assert "/2026/060/" in url
+
+
+def test_discover_h5_url_raises_when_content_empty():
+    """Empty content list should raise BlackMarbleNotAvailableError, same as a
+    listing that legitimately has no h22v06 entry."""
+    from app.connectors import blackmarble
+
+    fake_resp = MagicMock()
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {"content": []}
+    fake_resp.raise_for_status.return_value = None
+
+    fake_session = MagicMock()
+    fake_session.get.return_value = fake_resp
+
+    with patch.object(blackmarble, "_LAADSSession", return_value=fake_session):
+        with pytest.raises(blackmarble.BlackMarbleNotAvailableError):
+            blackmarble.discover_h5_url(date(2026, 3, 1), token="dummy")
 
 
 def test_discover_h5_url_raises_when_not_published():


### PR DESCRIPTION
## Summary
Updated the Black Marble connector to properly handle the LAADS API's JSON response format, which wraps file listings in a `{"content": [...]}` object. Added defensive parsing to also accept bare list responses from potential endpoint variants.

## Changes
- **Updated `discover_h5_url()` parsing logic** to extract entries from the `content` key in the LAADS JSON response wrapper, with fallback support for bare list responses
- **Enhanced test coverage** with three test cases:
  - Updated existing test to use the correct wrapped payload format (`{"content": [...]}`)
  - Added test for bare list fallback to ensure robustness against endpoint variants
  - Added test to verify `BlackMarbleNotAvailableError` is raised when content is empty

## Implementation Details
The parser now handles three cases:
1. **Wrapped format** (production): `{"content": [{"name": "...", ...}, ...]}`
2. **Bare list fallback**: `[{"name": "...", ...}, ...]` (defensive for endpoint variants)
3. **Invalid/empty**: Returns empty list, allowing downstream logic to raise appropriate error

This approach maintains backward compatibility while being defensive against LAADS API variations, as documented in the official LAADS bash download script.

https://claude.ai/code/session_01K2UTBn9chHasiRYj8Gietr