### PR TITLE
Add headline validation & retry layer for structured memo generation

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -65,6 +65,24 @@ _GATE_HUMAN_LABELS: dict[str, str] = {
 }
 
 
+# Hard-fail gates: only failures of these gates flip ``overall_pass`` to
+# False. Other gate failures are advisory and must not be used by downstream
+# consumers (e.g., the LLM decision-memo generator) to instruct a "Decline"
+# headline. Kept module-level so other modules can import a single source of
+# truth instead of redefining the set.
+HARD_FAIL_GATES: frozenset[str] = frozenset({
+    "zoning_fit_pass",
+    "area_fit_pass",
+})
+
+# Advisory-only gates: presence/absence of signal must NOT collapse the
+# overall verdict to indeterminate (None). Surfaced in gate_status for the
+# UI but excluded from the unknown count used by ``overall_pass``.
+ADVISORY_ONLY_GATES: frozenset[str] = frozenset({
+    "radiance_growth_pass",
+})
+
+
 def _humanize_gate_list(values: list[Any] | None) -> list[str]:
     labels: list[str] = []
     seen: set[str] = set()
@@ -2620,18 +2638,11 @@ def _candidate_gate_status(
     passed = [k for k, v in gate_states.items() if v is True]
     unknown = [k for k, v in gate_states.items() if v is None]
 
-    # Only these should hard-fail the site.
-    hard_fail_gates = {
-        "zoning_fit_pass",
-        "area_fit_pass",
-    }
-
-    # Advisory-only gates: presence/absence of signal must NOT collapse the
-    # overall verdict to indeterminate (None). They surface in gate_status
-    # for the UI but are excluded from the unknown count used by overall_pass.
-    advisory_only_gates = {
-        "radiance_growth_pass",
-    }
+    # Source of truth for hard-fail / advisory-only gates lives at module
+    # scope (HARD_FAIL_GATES / ADVISORY_ONLY_GATES) so other modules can
+    # import the same set instead of redefining it locally.
+    hard_fail_gates = HARD_FAIL_GATES
+    advisory_only_gates = ADVISORY_ONLY_GATES
     unknown_for_overall = [g for g in unknown if g not in advisory_only_gates]
 
     # Surface advisory failures separately so the frontend can render

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -2213,6 +2213,17 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
                 headline_reason,
             )
             parsed["headline_recommendation"] = rewritten
+            # The body fields were generated under the failing rule-violation
+            # state and would contradict the rewritten headline. Empty them so
+            # the frontend renders verdict + headline only on the safety-net
+            # path. This is intentional graceful degradation, not data loss —
+            # the next view-time regeneration (after the v6 prompt-version bump
+            # invalidates the cache) will repopulate everything.
+            parsed["ranking_explanation"] = ""
+            parsed["key_evidence"] = []
+            parsed["risks"] = []
+            parsed["comparison"] = ""
+            parsed["bottom_line"] = ""
 
     cost = _record_cost(input_tokens, output_tokens)
 

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -18,6 +18,15 @@ from typing import Any, Literal
 
 from app.core.config import settings
 
+# Hard-fail gate keys. Must stay in sync with
+# ``app.services.expansion_advisor.HARD_FAIL_GATES`` (the canonical source of
+# truth). Redefined here instead of imported to keep this module's import
+# graph independent of expansion_advisor's heavy SQLAlchemy/PostGIS surface.
+HARD_FAIL_GATE_KEYS: frozenset[str] = frozenset({
+    "zoning_fit_pass",
+    "area_fit_pass",
+})
+
 logger = logging.getLogger(__name__)
 
 # ── Model & cost configuration ──────────────────────────────────────
@@ -29,7 +38,7 @@ TEMPERATURE = 0.3
 # Bumped whenever STRUCTURED_MEMO_SYSTEM_PROMPT changes meaningfully.
 # Cached memos with a different version are treated as cache-miss and
 # regenerated lazily on next view.
-MEMO_PROMPT_VERSION = "v5-sectioned-2026-04"
+MEMO_PROMPT_VERSION = "v6-headline-rules-2026-05"
 
 # Soft daily ceiling in USD.  Raises RuntimeError before calling OpenAI
 # if the running total for today exceeds this value.
@@ -1546,7 +1555,77 @@ is a meaningful capital commitment, and without peer-listing context the
 operator should rely on demand and frontage signals to underwrite the deal."
 Notice: acknowledges the gap, pivots to other signals, no invented framing.
 
-Now write the memo for the candidate JSON the user provides. Match the voice in the examples. Be specific to this site, not generic."""
+Now write the memo for the candidate JSON the user provides. Match the voice in the examples. Be specific to this site, not generic.
+
+══════════════════════════════════════════════════════════════════════
+CRITICAL OUTPUT FORMAT RULES — these are the most important rules in
+this prompt. Other instructions are subordinate to these.
+
+1. The `headline_recommendation` field MUST begin with exactly one of:
+   - "Recommend"
+   - "Recommend with reservations"
+   - "Decline"
+
+   Never begin with: "Consider", "Caution", "Strong", "Solid",
+   "Decent", or any descriptive adjective. Even when the candidate
+   has weak signals or mixed evidence, you MUST choose one of the
+   three allowed prefixes.
+
+2. Map the deterministic_verdict to the headline prefix as follows:
+   - deterministic_verdict == "go"
+       → "Recommend" (default)
+       → "Recommend with reservations" only if blocking gates failed
+   - deterministic_verdict == "consider"
+       → "Recommend with reservations" (default)
+       → "Decline" only if blocking gates failed AND the case for
+         the candidate is materially weaker than rank-2
+   - deterministic_verdict == "caution"
+       → "Decline" (default)
+       → "Recommend with reservations" only if there is a strong,
+         specific positive case that outweighs the deterministic
+         caution
+
+3. If `final_rank == 1` AND `final_score >= 70` AND no blocking gates
+   failed: the headline MUST be "Recommend". This is non-negotiable.
+   Do not invoke soft scores (parking, frontage, visibility) as
+   reasons to Decline a rank-1 candidate that meets these criteria.
+   Soft component scores below 50 are inputs to the deterministic
+   ranking, not standalone disqualifiers.
+
+4. If `overall_pass == false`: the headline MUST be "Decline".
+
+5. Never confabulate gate failures. The list of failed gates is
+   provided in the `gates.failed` field. If `gates.failed` is empty,
+   do not write "decline due to failed [anything]". A low soft
+   component score is not a gate failure.
+
+EXAMPLES of correct headlines:
+
+  rank=1, score=80.5, gates.failed=[]:
+    "Recommend — strong economics in a stable district with
+     manageable competition."
+
+  rank=1, score=80.5, gates.failed=[radiance_growth_pass] (advisory):
+    "Recommend — strong economics; market growth signal is weak but
+     does not block the case."
+
+  rank=2, score=72.0, gates.failed=[economics_pass] (blocking):
+    "Decline — economics gate fails; the rent burden exceeds the
+     viability threshold for this brand."
+
+  rank=4, score=65.0, gates.failed=[]:
+    "Recommend with reservations — moderate economics with high
+     competitor density; viable but not the strongest pick."
+
+EXAMPLES of incorrect headlines that violate these rules:
+
+  WRONG: "consider due to strong demand signals despite high competition"
+         (begins with "consider" — banned)
+  WRONG: "decline due to failed parking access"
+         (when gates.failed=[] — confabulated gate failure)
+  WRONG: "Decline — market growth signal fails"
+         (when overall_pass=true and final_rank=1 with score>=70)
+══════════════════════════════════════════════════════════════════════"""
 
 
 _MAX_USER_PAYLOAD_CHARS = 12000
@@ -1638,10 +1717,21 @@ def render_structured_memo_prompt(ctx: MemoContext) -> list[dict]:
     failed_entries = [e for e in (buckets.get("failed") or []) if e.get("name")]
     unknown_entries = [e for e in (buckets.get("unknown") or []) if e.get("name")]
 
-    if failed_entries:
+    # Split failures into blocking vs advisory. Only blocking failures
+    # justify a "Decline" instruction — advisory-only failures (e.g.,
+    # ``radiance_growth_pass``) leave ``overall_pass`` at True and must
+    # NOT push the LLM toward a Decline headline.
+    blocking_failed = [
+        e for e in failed_entries if str(e.get("name")) in HARD_FAIL_GATE_KEYS
+    ]
+    advisory_failed = [
+        e for e in failed_entries if str(e.get("name")) not in HARD_FAIL_GATE_KEYS
+    ]
+
+    if blocking_failed:
         failure_list = "; ".join(
             f"{e['name']}: {e.get('explanation','')}".rstrip(": ")
-            for e in failed_entries
+            for e in blocking_failed
         )
         addenda.append(
             "GATE FAILURE: This candidate fails on "
@@ -1650,6 +1740,21 @@ def render_structured_memo_prompt(ctx: MemoContext) -> list[dict]:
             "direction MUST be consistent with overall_pass=False and "
             "deterministic_verdict. You may use 'fails on...' or 'does not "
             "meet...' for the failed gates — never for unknowns."
+        )
+
+    if advisory_failed:
+        advisory_list = "; ".join(
+            f"{e['name']}: {e.get('explanation','')}".rstrip(": ")
+            for e in advisory_failed
+        )
+        addenda.append(
+            "ADVISORY GATE NOTE: This candidate has advisory-only gate "
+            "failures on " + advisory_list + ". These are informational "
+            "and do NOT flip overall_pass or deterministic_verdict. "
+            "Reflect them as risks if material to the investment thesis, "
+            "but the headline_recommendation must still follow the rules "
+            "above (rank-1 with score >= 70 must remain 'Recommend'; "
+            "overall_pass=True candidates must not be 'Decline')."
         )
 
     if unknown_entries:
@@ -1681,6 +1786,133 @@ def render_structured_memo_prompt(ctx: MemoContext) -> list[dict]:
 
 
 # ── Generation with graceful fallback ───────────────────────────────
+
+
+# Allowed prefixes for ``headline_recommendation``. Order matters: the
+# more specific "Recommend with reservations" must precede "Recommend"
+# so prefix-detection logic distinguishes the two correctly.
+_ALLOWED_HEADLINE_PREFIXES: tuple[str, ...] = (
+    "Recommend with reservations",
+    "Recommend",
+    "Decline",
+)
+
+
+def _headline_validity_reason(
+    headline: str | None,
+    *,
+    final_rank: int | None,
+    final_score: float | None,
+    overall_pass: bool | None,
+    blocking_failed: list,
+) -> str | None:
+    """Return None when ``headline`` satisfies the format rules; otherwise
+    a short reason string suitable for logging and retry-prompt context.
+
+    Catches the three failure modes observed in production:
+      1. Headlines that don't begin with an allowed prefix (e.g.,
+         "consider due to ...").
+      2. Rank-1 high-score Decline headlines with no blocking failures.
+      3. Confabulated gate failures (Decline citing "failed [X]" when
+         ``gates.failed`` is empty).
+    """
+    if not isinstance(headline, str) or not headline.strip():
+        return "headline missing or empty"
+
+    stripped = headline.strip()
+    lowered = stripped.lower()
+
+    if not any(
+        lowered.startswith(prefix.lower()) for prefix in _ALLOWED_HEADLINE_PREFIXES
+    ):
+        return f"headline does not start with an allowed prefix: {stripped[:60]!r}"
+
+    starts_with_decline = lowered.startswith("decline")
+    starts_with_recommend_with_reservations = lowered.startswith(
+        "recommend with reservations"
+    )
+    starts_with_recommend_only = (
+        lowered.startswith("recommend") and not starts_with_recommend_with_reservations
+    )
+
+    # Rank-1 high-score guarantee.
+    if (
+        final_rank == 1
+        and isinstance(final_score, (int, float))
+        and final_score >= 70
+        and not blocking_failed
+        and starts_with_decline
+    ):
+        return (
+            f"rank-1 with score={float(final_score):.1f} and no blocking "
+            f"failures must not have a Decline headline"
+        )
+
+    # overall_pass=False guarantee.
+    if overall_pass is False and (
+        starts_with_recommend_only or starts_with_recommend_with_reservations
+    ):
+        return (
+            "overall_pass=False candidate must have a Decline headline, "
+            "not Recommend"
+        )
+
+    # Confabulation guard: a Decline headline citing failed gates when
+    # no blocking gate actually failed is a fabrication.
+    if starts_with_decline and not blocking_failed:
+        if "failed " in lowered or "fails on" in lowered:
+            return "headline cites failed gates but no blocking gates failed"
+
+    return None
+
+
+def _rewrite_headline_locally(
+    original: dict[str, Any],
+    *,
+    final_rank: int | None,
+    final_score: float | None,
+    overall_pass: bool | None,
+    blocking_failed: list,
+) -> str:
+    """Safety-net rewrite when both LLM attempts fail validation.
+
+    Produces an awkward but format-compliant headline so a
+    contradicting recommendation never reaches the user.
+    """
+    body = ""
+    raw_explanation = original.get("ranking_explanation")
+    if isinstance(raw_explanation, str):
+        body = raw_explanation.strip()[:80].rstrip(" ,.;:—-")
+
+    if (
+        final_rank == 1
+        and isinstance(final_score, (int, float))
+        and final_score >= 70
+        and not blocking_failed
+    ):
+        return f"Recommend — {body}" if body else "Recommend"
+    if overall_pass is False:
+        return f"Decline — {body}" if body else "Decline"
+    # Fallback: strip any leading banned word and prepend the soft-yes prefix.
+    raw_headline = original.get("headline_recommendation")
+    tail = body
+    if isinstance(raw_headline, str) and raw_headline.strip():
+        cleaned = raw_headline.strip()
+        # Prefer dropping a connector phrase (e.g., "consider due to ...");
+        # otherwise drop just the leading banned word so the rest reads.
+        connector_split = None
+        for connector in (" due to ", " — ", " - ", ": "):
+            if connector in cleaned:
+                connector_split = cleaned.split(connector, 1)[1]
+                break
+        if connector_split is not None:
+            cleaned = connector_split
+        else:
+            parts = cleaned.split(" ", 1)
+            if len(parts) == 2:
+                cleaned = parts[1]
+        tail = cleaned[:80].rstrip(" ,.;:—-") or body
+    return f"Recommend with reservations — {tail}" if tail else "Recommend with reservations"
 
 
 _STRUCTURED_REQUIRED_KEYS: tuple[str, ...] = (
@@ -1731,11 +1963,102 @@ def _advisory_section_invalid_reason(parsed: dict[str, Any]) -> str | None:
     return None
 
 
+def _parse_and_validate_memo_shape(
+    response: Any, candidate_id: str
+) -> dict | None:
+    """Pull the JSON content out of an OpenAI chat-completion response and
+    enforce the structural / required-key checks. Returns the parsed dict
+    on success, or ``None`` (with a warning logged) on any shape failure.
+    """
+    try:
+        content = (response.choices[0].message.content or "").strip()
+    except Exception as exc:
+        logger.warning(
+            "Structured memo response malformed for %s: %s",
+            candidate_id, exc,
+        )
+        return None
+
+    try:
+        parsed = json.loads(content)
+    except (json.JSONDecodeError, TypeError) as exc:
+        # TypeError guards against a client returning a non-string for
+        # ``content`` (real OpenAI always returns str; defensive only).
+        logger.warning(
+            "Structured memo JSON parse failed for %s: %s | raw=%s",
+            candidate_id, exc, str(content)[:500],
+        )
+        return None
+
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "Structured memo returned non-object JSON for %s",
+            candidate_id,
+        )
+        return None
+
+    missing = [k for k in _STRUCTURED_REQUIRED_KEYS if k not in parsed]
+    if missing:
+        logger.warning(
+            "Structured memo missing keys for %s: %s",
+            candidate_id, missing,
+        )
+        return None
+
+    if not isinstance(parsed.get("key_evidence"), list) or not parsed["key_evidence"]:
+        logger.warning(
+            "Structured memo key_evidence invalid/empty for %s",
+            candidate_id,
+        )
+        return None
+
+    if not isinstance(parsed.get("risks"), list):
+        logger.warning(
+            "Structured memo risks not a list for %s",
+            candidate_id,
+        )
+        return None
+
+    advisory_invalid = _advisory_section_invalid_reason(parsed)
+    if advisory_invalid is not None:
+        logger.warning(
+            "Structured memo advisory section invalid for %s: %s",
+            candidate_id, advisory_invalid,
+        )
+        return None
+
+    return parsed
+
+
+def _blocking_failed_from_buckets(buckets: dict | None) -> list[dict]:
+    """Return the subset of ``buckets["failed"]`` whose gate name is in
+    HARD_FAIL_GATE_KEYS — i.e., failures that flipped overall_pass to False.
+    Mirrors the same split used in render_structured_memo_prompt so the
+    retry layer's view of "blocking" stays consistent with what the LLM
+    saw in the prompt addendum.
+    """
+    if not isinstance(buckets, dict):
+        return []
+    failed = buckets.get("failed") or []
+    return [
+        e for e in failed
+        if isinstance(e, dict) and str(e.get("name")) in HARD_FAIL_GATE_KEYS
+    ]
+
+
 def generate_structured_memo(ctx: MemoContext) -> dict | None:
     """Call the LLM for a structured memo, or return None on any failure.
 
     Never raises — logs a warning and returns None so the caller can fall
     back to the legacy ``generate_decision_memo`` path.
+
+    On a successful shape-validated response, run an additional headline-
+    validity check. If the headline violates the format / consistency
+    rules (banned prefix, rank-1 high-score Decline, overall_pass=False
+    Recommend, or confabulated gate failure), retry the call once with a
+    corrective preamble. If the retry also fails, log an error and rewrite
+    the headline locally so a contradicting recommendation never reaches
+    the user.
 
     Returns the parsed JSON dict on success. Token usage is recorded against
     the same ``_daily_cost_tracker`` as the legacy path so the $/day ceiling
@@ -1781,66 +2104,116 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
         )
         return None
 
-    try:
-        content = (response.choices[0].message.content or "").strip()
-    except Exception as exc:
-        logger.warning(
-            "Structured memo response malformed for %s: %s",
-            ctx.candidate_id, exc,
-        )
+    parsed = _parse_and_validate_memo_shape(response, ctx.candidate_id)
+    if parsed is None:
         return None
 
-    try:
-        parsed = json.loads(content)
-    except (json.JSONDecodeError, TypeError) as exc:
-        # TypeError guards against a client returning a non-string for
-        # ``content`` (real OpenAI always returns str; defensive only).
-        logger.warning(
-            "Structured memo JSON parse failed for %s: %s | raw=%s",
-            ctx.candidate_id, exc, str(content)[:500],
-        )
-        return None
+    blocking_failed = _blocking_failed_from_buckets(ctx.gate_buckets)
 
-    if not isinstance(parsed, dict):
-        logger.warning(
-            "Structured memo returned non-object JSON for %s",
-            ctx.candidate_id,
-        )
-        return None
-
-    missing = [k for k in _STRUCTURED_REQUIRED_KEYS if k not in parsed]
-    if missing:
-        logger.warning(
-            "Structured memo missing keys for %s: %s",
-            ctx.candidate_id, missing,
-        )
-        return None
-
-    if not isinstance(parsed.get("key_evidence"), list) or not parsed["key_evidence"]:
-        logger.warning(
-            "Structured memo key_evidence invalid/empty for %s",
-            ctx.candidate_id,
-        )
-        return None
-
-    if not isinstance(parsed.get("risks"), list):
-        logger.warning(
-            "Structured memo risks not a list for %s",
-            ctx.candidate_id,
-        )
-        return None
-
-    advisory_invalid = _advisory_section_invalid_reason(parsed)
-    if advisory_invalid is not None:
-        logger.warning(
-            "Structured memo advisory section invalid for %s: %s",
-            ctx.candidate_id, advisory_invalid,
-        )
-        return None
+    headline_reason = _headline_validity_reason(
+        parsed.get("headline_recommendation"),
+        final_rank=ctx.final_rank,
+        final_score=ctx.final_score,
+        overall_pass=ctx.overall_pass,
+        blocking_failed=blocking_failed,
+    )
 
     usage = getattr(response, "usage", None)
     input_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
     output_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+
+    if headline_reason is not None:
+        logger.warning(
+            "Structured memo headline rejected for %s: %s | headline=%r",
+            ctx.candidate_id,
+            headline_reason,
+            parsed.get("headline_recommendation"),
+        )
+        retry_messages = [
+            messages[0],
+            {
+                "role": "user",
+                "content": (
+                    "PREVIOUS RESPONSE WAS REJECTED. Reason: "
+                    f"{headline_reason}.\n\n"
+                    "The headline_recommendation field must follow the format "
+                    "rules exactly. Do not begin with \"Consider\" or any "
+                    "other word outside the three allowed prefixes "
+                    "(\"Recommend\", \"Recommend with reservations\", "
+                    "\"Decline\"). Do not cite gate failures unless they "
+                    "appear in gates.failed. Re-emit the full structured "
+                    "memo with a corrected headline."
+                ),
+            },
+            messages[1],
+        ]
+
+        try:
+            retry_response = client.chat.completions.create(
+                model=settings.EXPANSION_MEMO_MODEL,
+                messages=retry_messages,
+                temperature=settings.EXPANSION_MEMO_TEMPERATURE,
+                max_tokens=settings.EXPANSION_MEMO_MAX_TOKENS,
+                response_format={"type": "json_object"},
+            )
+        except Exception as exc:
+            logger.warning(
+                "Structured memo retry call failed for %s: %s",
+                ctx.candidate_id, exc,
+            )
+            retry_response = None
+
+        if retry_response is not None:
+            retry_parsed = _parse_and_validate_memo_shape(
+                retry_response, ctx.candidate_id
+            )
+            if retry_parsed is not None:
+                retry_reason = _headline_validity_reason(
+                    retry_parsed.get("headline_recommendation"),
+                    final_rank=ctx.final_rank,
+                    final_score=ctx.final_score,
+                    overall_pass=ctx.overall_pass,
+                    blocking_failed=blocking_failed,
+                )
+                retry_usage = getattr(retry_response, "usage", None)
+                input_tokens += int(
+                    getattr(retry_usage, "prompt_tokens", 0) or 0
+                )
+                output_tokens += int(
+                    getattr(retry_usage, "completion_tokens", 0) or 0
+                )
+                if retry_reason is None:
+                    parsed = retry_parsed
+                    headline_reason = None
+                else:
+                    logger.error(
+                        "Structured memo retry headline still invalid for "
+                        "%s: %s | headline=%r — applying local rewrite",
+                        ctx.candidate_id,
+                        retry_reason,
+                        retry_parsed.get("headline_recommendation"),
+                    )
+                    # Use the retry's body but rewrite the headline locally.
+                    parsed = retry_parsed
+
+        if headline_reason is not None:
+            rewritten = _rewrite_headline_locally(
+                parsed,
+                final_rank=ctx.final_rank,
+                final_score=ctx.final_score,
+                overall_pass=ctx.overall_pass,
+                blocking_failed=blocking_failed,
+            )
+            logger.error(
+                "Structured memo headline locally rewritten for %s: "
+                "old=%r new=%r reason=%s",
+                ctx.candidate_id,
+                parsed.get("headline_recommendation"),
+                rewritten,
+                headline_reason,
+            )
+            parsed["headline_recommendation"] = rewritten
+
     cost = _record_cost(input_tokens, output_tokens)
 
     logger.info(

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -2011,6 +2011,61 @@ class TestHeadlineRetryConsiderPrefixBanned:
         assert mock_get_client.return_value.chat.completions.create.call_count == 2
 
 
+class TestHeadlineLocalRewriteNullsBody:
+    """Bug-fix invariant — when the local-rewrite safety net fires
+    (both LLM attempts violate the format rules), the body fields
+    must be cleared so they cannot contradict the rewritten headline."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_local_rewrite_empties_body_fields(self, mock_get_client, monkeypatch):
+        _enable_structured_memo(monkeypatch)
+        bad_first = _memo_with_headline("Decline — market growth signal fails")
+        bad_second = _memo_with_headline("Decline — market growth gate did not pass")
+        mock_get_client.return_value = _two_response_client(bad_first, bad_second)
+
+        ctx = build_memo_context(
+            candidate=_RANK1_ADVISORY_FAILURE_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert memo["headline_recommendation"].lower().startswith("recommend")
+        # Body fields must be cleared so they cannot contradict the
+        # rewritten headline.
+        assert memo["ranking_explanation"] == ""
+        assert memo["key_evidence"] == []
+        assert memo["risks"] == []
+        assert memo["comparison"] == ""
+        assert memo["bottom_line"] == ""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_happy_path_retry_keeps_body(self, mock_get_client, monkeypatch):
+        """Control: when the retry succeeds, the body is preserved
+        from the retry response (not nulled). Null-out only happens
+        on the local-rewrite path."""
+        _enable_structured_memo(monkeypatch)
+        bad_first = _memo_with_headline("consider due to moderate signals")
+        good_second = _memo_with_headline(
+            "Recommend — strong economics in a stable district."
+        )
+        mock_get_client.return_value = _two_response_client(bad_first, good_second)
+
+        ctx = build_memo_context(
+            candidate=_RANK1_ALL_PASS_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert memo["headline_recommendation"].lower().startswith("recommend")
+        # Retry succeeded → body from retry is preserved.
+        assert memo["ranking_explanation"] != ""
+        assert memo["key_evidence"]
+
+
 class TestHeadlineNoRetryWhenOverallPassFalseDecline:
     """A genuine "Decline" headline on an overall_pass=False candidate
     passes the validity check on the first try; no retry occurs."""

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -1684,3 +1684,415 @@ def test_feature_snapshot_whitelist_alias_points_at_memo_whitelist():
     )
 
     assert _FEATURE_SNAPSHOT_WHITELIST is _MEMO_WHITELIST
+
+
+# ---------------------------------------------------------------------------
+# Headline-validity post-validate-and-retry layer (Bugs 1, 2, 3 fix).
+# ---------------------------------------------------------------------------
+
+# Imported lazily inside tests where they're used so the module stays
+# importable even if these helpers are renamed in the future. These
+# fixtures intentionally piggyback on the existing _MINIMAL_ADVISORY_SECTIONS
+# block so the shape passes _advisory_section_invalid_reason.
+
+_HEADLINE_RETRY_BASE_BODY = {
+    "ranking_explanation": (
+        "occupancy_economics contributed 24.6 out of 30 and brand_fit 8.6 out of 11, "
+        "driving rank 1 with a final_score of 80."
+    ),
+    "key_evidence": [
+        {"signal": "final_score", "value": "80/100",
+         "implication": "top-ranked candidate in this search", "polarity": "positive"},
+    ],
+    "risks": [
+        {"risk": "Market growth signal weak.", "mitigation": "Monitor district momentum quarterly."},
+    ],
+    "comparison": "Comfortably ahead of rank 2 on economics.",
+    "bottom_line": "Proceed with a site visit to confirm on-the-ground conditions.",
+    **_MINIMAL_ADVISORY_SECTIONS,
+}
+
+
+def _memo_with_headline(headline: str) -> dict:
+    return {"headline_recommendation": headline, **_HEADLINE_RETRY_BASE_BODY}
+
+
+_RANK1_ADVISORY_FAILURE_CANDIDATE = {
+    "id": "advisory-rank1",
+    "parcel_id": "advisory-rank1",
+    "final_rank": 1,
+    "final_score": 80.0,
+    "economics_score": 75,
+    "cannibalization_score": 40,
+    "feature_snapshot_json": {
+        "district": "Al Olaya",
+        "area_m2": 120,
+        "estimated_annual_rent_sar": 480000,
+        "district_median_rent": 560000,
+    },
+    "score_breakdown_json": {
+        "occupancy_economics": 80,
+        "listing_quality": 70,
+        "brand_fit": 78,
+        "competition_whitespace": 65,
+        "demand_potential": 80,
+        "access_visibility": 72,
+        "landlord_signal": 60,
+        "delivery_demand": 65,
+        "confidence": 70,
+    },
+    "gate_status_json": {
+        "zoning_fit_pass": True,
+        "area_fit_pass": True,
+        "frontage_access_pass": True,
+        "parking_pass": True,
+        "district_pass": True,
+        "cannibalization_pass": True,
+        "delivery_market_pass": True,
+        "economics_pass": True,
+        "radiance_growth_pass": False,
+        "overall_pass": True,
+    },
+    "gate_reasons_json": {
+        "passed": [
+            "zoning_fit_pass", "area_fit_pass", "frontage_access_pass",
+            "parking_pass", "district_pass", "cannibalization_pass",
+            "delivery_market_pass", "economics_pass",
+        ],
+        "failed": ["radiance_growth_pass"],
+        "unknown": [],
+        "blocking_failures": [],
+        "advisory_failures": ["radiance_growth_pass"],
+        "thresholds": {},
+        "explanations": {
+            "radiance_growth_pass": "Advisory market-growth signal — does not block.",
+        },
+    },
+    "comparable_competitors_json": [],
+}
+
+
+_RANK1_ALL_PASS_CANDIDATE = {
+    "id": "rank1-all-pass",
+    "parcel_id": "rank1-all-pass",
+    "final_rank": 1,
+    "final_score": 80.0,
+    "economics_score": 75,
+    "cannibalization_score": 40,
+    "feature_snapshot_json": {
+        "district": "Al Olaya",
+        "area_m2": 120,
+        "estimated_annual_rent_sar": 480000,
+        "district_median_rent": 560000,
+    },
+    "score_breakdown_json": _RANK1_ADVISORY_FAILURE_CANDIDATE["score_breakdown_json"],
+    "gate_status_json": {
+        "zoning_fit_pass": True,
+        "area_fit_pass": True,
+        "frontage_access_pass": True,
+        "parking_pass": True,
+        "district_pass": True,
+        "cannibalization_pass": True,
+        "delivery_market_pass": True,
+        "economics_pass": True,
+        "overall_pass": True,
+    },
+    "gate_reasons_json": {
+        "passed": [
+            "zoning_fit_pass", "area_fit_pass", "frontage_access_pass",
+            "parking_pass", "district_pass", "cannibalization_pass",
+            "delivery_market_pass", "economics_pass",
+        ],
+        "failed": [],
+        "unknown": [],
+        "blocking_failures": [],
+        "advisory_failures": [],
+        "thresholds": {},
+        "explanations": {},
+    },
+    "comparable_competitors_json": [],
+}
+
+
+_CONSIDER_BAND_CANDIDATE = {
+    "id": "consider-band",
+    "parcel_id": "consider-band",
+    "final_rank": 4,
+    "final_score": 65.0,
+    "economics_score": 50,
+    "cannibalization_score": 60,
+    "feature_snapshot_json": {
+        "district": "Al Naseem",
+        "area_m2": 110,
+        "estimated_annual_rent_sar": 420000,
+        "district_median_rent": 420000,
+    },
+    "score_breakdown_json": {
+        "occupancy_economics": 60,
+        "listing_quality": 55,
+        "brand_fit": 60,
+        "competition_whitespace": 50,
+        "demand_potential": 65,
+        "access_visibility": 60,
+        "landlord_signal": 50,
+        "delivery_demand": 50,
+        "confidence": 60,
+    },
+    "gate_status_json": {
+        "zoning_fit_pass": True,
+        "area_fit_pass": True,
+        "economics_pass": True,
+        "overall_pass": True,
+    },
+    "gate_reasons_json": {
+        "passed": ["zoning_fit_pass", "area_fit_pass", "economics_pass"],
+        "failed": [],
+        "unknown": [],
+        "blocking_failures": [],
+        "advisory_failures": [],
+        "thresholds": {},
+        "explanations": {},
+    },
+    "comparable_competitors_json": [],
+}
+
+
+_BLOCKING_FAILURE_CANDIDATE = {
+    "id": "blocking-fail",
+    "parcel_id": "blocking-fail",
+    "final_rank": 8,
+    "final_score": 50.0,
+    "economics_score": 35,
+    "cannibalization_score": 70,
+    "feature_snapshot_json": {
+        "district": "Edge District",
+        "area_m2": 60,
+        "estimated_annual_rent_sar": 900000,
+        "district_median_rent": 400000,
+    },
+    "score_breakdown_json": {
+        "occupancy_economics": 30,
+        "listing_quality": 40,
+        "brand_fit": 50,
+        "competition_whitespace": 40,
+        "demand_potential": 45,
+        "access_visibility": 50,
+        "landlord_signal": 30,
+        "delivery_demand": 40,
+        "confidence": 50,
+    },
+    "gate_status_json": {
+        "zoning_fit_pass": False,
+        "area_fit_pass": True,
+        "economics_pass": False,
+        "overall_pass": False,
+    },
+    "gate_reasons_json": {
+        "passed": ["area_fit_pass"],
+        "failed": ["zoning_fit_pass", "economics_pass"],
+        "unknown": [],
+        "blocking_failures": ["zoning_fit_pass"],
+        "advisory_failures": ["economics_pass"],
+        "thresholds": {},
+        "explanations": {
+            "zoning_fit_pass": "Zoning class disallows F&B.",
+            "economics_pass": "Economics score below minimum threshold.",
+        },
+    },
+    "comparable_competitors_json": [],
+}
+
+
+def _enable_structured_memo(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.llm_decision_memo.settings.EXPANSION_MEMO_STRUCTURED_ENABLED",
+        True,
+        raising=False,
+    )
+    _daily_cost_tracker.clear()
+
+
+def _two_response_client(first_content, second_content):
+    """Mock client whose first .create() returns ``first_content`` and
+    whose second returns ``second_content``. Both are dicts (will be
+    JSON-encoded by _make_mock_response)."""
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _make_mock_response(first_content),
+        _make_mock_response(second_content),
+    ]
+    return client
+
+
+class TestHeadlineRetryAdvisoryFailureNotDecline:
+    """Bug 1 — advisory-only gate failure must not produce a Decline.
+
+    LLM returns "Decline ..." on both attempts; the post-validate layer
+    rewrites the headline locally so the user never sees a contradicting
+    recommendation."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_decline_on_advisory_failure_is_rewritten(self, mock_get_client, monkeypatch, caplog):
+        _enable_structured_memo(monkeypatch)
+        bad_first = _memo_with_headline("Decline — market growth signal fails")
+        bad_second = _memo_with_headline("Decline — market growth gate did not pass")
+        mock_get_client.return_value = _two_response_client(bad_first, bad_second)
+
+        ctx = build_memo_context(
+            candidate=_RANK1_ADVISORY_FAILURE_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        with caplog.at_level("WARNING"):
+            memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        # Final headline starts with "Recommend" (rank-1, score >= 70, no
+        # blocking failures → guaranteed Recommend).
+        assert memo["headline_recommendation"].lower().startswith("recommend")
+        assert not memo["headline_recommendation"].lower().startswith("recommend with reservations")
+        # The retry was attempted (client called twice).
+        assert mock_get_client.return_value.chat.completions.create.call_count == 2
+
+
+class TestHeadlineRetryRank1ConfabulatedGateFailure:
+    """Bug 3 — rank-1 with empty failed_gates must not Decline citing
+    fabricated failures (e.g., "decline due to failed parking access")."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_confabulated_decline_is_rewritten(self, mock_get_client, monkeypatch, caplog):
+        _enable_structured_memo(monkeypatch)
+        bad_first = _memo_with_headline("Decline due to failed parking access")
+        bad_second = _memo_with_headline("Decline — parking fails on-site")
+        mock_get_client.return_value = _two_response_client(bad_first, bad_second)
+
+        ctx = build_memo_context(
+            candidate=_RANK1_ALL_PASS_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        with caplog.at_level("WARNING"):
+            memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert memo["headline_recommendation"].lower().startswith("recommend")
+        assert not memo["headline_recommendation"].lower().startswith("recommend with reservations")
+        assert mock_get_client.return_value.chat.completions.create.call_count == 2
+
+
+class TestHeadlineRetryConsiderPrefixBanned:
+    """Bug 2 — headlines starting with "consider " violate the format rule
+    and must be rewritten to start with one of the three allowed prefixes."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_consider_prefix_is_rewritten(self, mock_get_client, monkeypatch, caplog):
+        _enable_structured_memo(monkeypatch)
+        bad_first = _memo_with_headline(
+            "consider due to moderate competition and acceptable economics"
+        )
+        bad_second = _memo_with_headline(
+            "Consider — moderate competition and acceptable economics"
+        )
+        mock_get_client.return_value = _two_response_client(bad_first, bad_second)
+
+        ctx = build_memo_context(
+            candidate=_CONSIDER_BAND_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        with caplog.at_level("WARNING"):
+            memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        headline_lower = memo["headline_recommendation"].lower()
+        # Not rank-1 high-score, not overall_pass=False — falls through to
+        # the soft-yes safety-net rewrite.
+        assert headline_lower.startswith("recommend with reservations")
+        assert mock_get_client.return_value.chat.completions.create.call_count == 2
+
+
+class TestHeadlineNoRetryWhenOverallPassFalseDecline:
+    """A genuine "Decline" headline on an overall_pass=False candidate
+    passes the validity check on the first try; no retry occurs."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_valid_decline_passes_through_no_retry(self, mock_get_client, monkeypatch):
+        _enable_structured_memo(monkeypatch)
+        good = _memo_with_headline(
+            "Decline — zoning gate fails for this listing's land-use class."
+        )
+        client = MagicMock()
+        client.chat.completions.create.return_value = _make_mock_response(good)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_BLOCKING_FAILURE_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert memo["headline_recommendation"].lower().startswith("decline")
+        assert client.chat.completions.create.call_count == 1
+
+
+class TestHeadlineNoRetryWhenAllGatesPassRecommend:
+    """A valid "Recommend" headline on a clean candidate passes through
+    unchanged with a single LLM call."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_valid_recommend_passes_through_no_retry(self, mock_get_client, monkeypatch):
+        _enable_structured_memo(monkeypatch)
+        good = _memo_with_headline(
+            "Recommend — strong economics in a stable district with manageable competition."
+        )
+        client = MagicMock()
+        client.chat.completions.create.return_value = _make_mock_response(good)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_RANK1_ALL_PASS_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert memo["headline_recommendation"].lower().startswith("recommend")
+        assert client.chat.completions.create.call_count == 1
+
+
+class TestRenderPromptAdvisoryFailureNoGateFailureAddendum:
+    """Bug 1 prompt-side fix — an advisory-only gate failure must NOT
+    inject the "GATE FAILURE ... overall_pass=False" addendum."""
+
+    def test_advisory_failure_uses_softer_addendum(self):
+        ctx = build_memo_context(
+            candidate=_RANK1_ADVISORY_FAILURE_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        messages = render_structured_memo_prompt(ctx)
+        system_content = messages[0]["content"]
+
+        assert "GATE FAILURE" not in system_content
+        assert "ADVISORY GATE NOTE" in system_content
+        assert "radiance_growth_pass" in system_content
+
+
+class TestRenderPromptBlockingFailureKeepsGateFailureAddendum:
+    """Bug 1 prompt-side fix — a blocking gate failure (zoning) must
+    still inject the strong "GATE FAILURE" addendum."""
+
+    def test_blocking_failure_triggers_gate_failure_addendum(self):
+        ctx = build_memo_context(
+            candidate=_BLOCKING_FAILURE_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        messages = render_structured_memo_prompt(ctx)
+        system_content = messages[0]["content"]
+
+        assert "GATE FAILURE" in system_content
+        assert "zoning_fit_pass" in system_content


### PR DESCRIPTION
## Summary

This PR adds a post-validation and retry mechanism for LLM-generated structured memo headlines to prevent contradictory recommendations from reaching users. It also refactors gate failure handling to distinguish between blocking (hard-fail) and advisory-only gate failures, ensuring the LLM receives correct context about which failures should influence the recommendation.

## Key Changes

- **Headline Validation Rules**: Introduced strict format rules for `headline_recommendation` field:
  - Must begin with exactly one of: "Recommend", "Recommend with reservations", or "Decline"
  - Rank-1 candidates with score ≥70 and no blocking failures must be "Recommend"
  - Candidates with `overall_pass=False` must be "Decline"
  - Cannot cite gate failures that didn't actually occur (confabulation guard)

- **Gate Failure Categorization**: 
  - Defined `HARD_FAIL_GATE_KEYS` in `llm_decision_memo.py` (zoning_fit_pass, area_fit_pass) that flip `overall_pass` to False
  - Extracted `HARD_FAIL_GATES` and `ADVISORY_ONLY_GATES` constants in `expansion_advisor.py` as canonical source of truth
  - Split failed gates into blocking vs. advisory in prompt rendering to give LLM correct context

- **Retry & Fallback Logic**:
  - Added `_headline_validity_reason()` to detect format violations
  - On validation failure, automatically retry once with corrective preamble
  - If retry also fails, locally rewrite headline to guarantee format compliance
  - All rewrites are logged at ERROR level for observability

- **Helper Functions**:
  - `_parse_and_validate_memo_shape()`: Extracted shape validation logic for reuse in retry path
  - `_blocking_failed_from_buckets()`: Filters gate failures to blocking-only subset
  - `_rewrite_headline_locally()`: Safety-net headline rewriting based on rank/score/pass status

- **Prompt Enhancement**: Updated system prompt with detailed headline format rules and examples showing correct vs. incorrect headlines

- **Test Coverage**: Added comprehensive test suite covering:
  - Advisory-only failures not producing Decline headlines
  - Confabulated gate failures being caught and rewritten
  - Banned prefixes (e.g., "consider") being rejected and rewritten
  - Valid headlines passing through without retry
  - Prompt rendering correctly distinguishing blocking vs. advisory failures

## Implementation Details

- Memo prompt version bumped to `v6-headline-rules-2026-05` to invalidate cached memos
- Retry uses same LLM model/temperature/tokens as initial call
- Token usage from both initial and retry calls are accumulated for cost tracking
- Advisory gate failures now generate softer "ADVISORY GATE NOTE" addendum instead of hard "GATE FAILURE" addendum
- All validation and rewrite logic is deterministic and doesn't require additional LLM calls beyond the single retry attempt

https://claude.ai/code/session_01Vgn8Ges3Ch1Z41JiVQJLjY