### PR TITLE
Add construction-proximity hard floor to market viability gates

### DIFF
--- a/.github/workflows/osm-import.yml
+++ b/.github/workflows/osm-import.yml
@@ -222,6 +222,26 @@ jobs:
             psql -v ON_ERROR_STOP=1 -c "UPDATE public.osm_import_state SET bbox='${BBOX}', tile_deg='${TILE_DEG}', last_tile=0, updated_at=now() WHERE id=1;"
           fi
 
+          # Auto-reset stale state. If LAST_IMPORTED equals the total tile
+          # count (i.e. the previous run completed) AND the state row is
+          # older than 6 days, treat the previous import as "done and stale"
+          # and reset last_tile=0 so this run actually re-imports. Without
+          # this guard the weekly cron would silently skip every tile after
+          # the first successful run and never refresh OSM data again.
+          # Threshold is 1 day below the cron interval so a slightly-late
+          # cron firing doesn't accidentally fall under it.
+          TOTAL_TILES=$(wc -l < data/osm/tiles.list)
+          STATE_AGE_HOURS=$(psql -Atc "SELECT EXTRACT(EPOCH FROM (now() - updated_at))/3600 FROM public.osm_import_state WHERE id=1;")
+          if [ -n "$LAST_IMPORTED" ] && [ -n "$TOTAL_TILES" ] && [ -n "$STATE_AGE_HOURS" ]; then
+            # Bash arithmetic doesn't handle floats; truncate to int.
+            STATE_AGE_HOURS_INT=${STATE_AGE_HOURS%.*}
+            if [ "$LAST_IMPORTED" -ge "$TOTAL_TILES" ] && [ "$STATE_AGE_HOURS_INT" -ge 144 ]; then
+              echo "Previous import completed (last_tile=$LAST_IMPORTED, total=$TOTAL_TILES) and state is stale (${STATE_AGE_HOURS_INT}h old, threshold=144h). Resetting last_tile=0 to force fresh import."
+              psql -v ON_ERROR_STOP=1 -c "UPDATE public.osm_import_state SET last_tile=0, updated_at=now() WHERE id=1;"
+              LAST_IMPORTED=0
+            fi
+          fi
+
           TILE_IDX=0
           while IFS= read -r TILE_BBOX; do
             TILE_IDX=$((TILE_IDX+1))

--- a/.github/workflows/osm-import.yml
+++ b/.github/workflows/osm-import.yml
@@ -15,6 +15,8 @@ on:
         description: "Tile size in degrees (smaller = more Overpass calls)"
         required: false
         default: "0.10"
+  schedule:
+    - cron: '0 4 * * 0'  # Sundays at 04:00 UTC — low-traffic window for SCCC pipeline
 
 env:
   # south,west,north,east (Overpass ordering) — Riyadh metro

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -194,6 +194,18 @@ class Settings:
     EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR: int = int(
         os.getenv("EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR", "1")
     )
+    # Construction-proximity hard floor (CEO directive — exclude areas with
+    # heavy construction). Drops any candidate that has at least one
+    # ``planet_osm_polygon`` row tagged ``landuse='construction'`` or
+    # ``building='construction'`` within this radius (meters). 0 disables
+    # the gate entirely (every candidate emits
+    # ``construction_proximity_pass=True``). Same "missing field → pass"
+    # semantics as the population/commercial floors above: when the OSM
+    # bulk pre-compute is skipped (table missing, buffer disabled) or
+    # the snapshot block is absent, the candidate passes defensively.
+    EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M: float = float(
+        os.getenv("EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M", "75.0")
+    )
     # Centroid clip radius (km) used by ``_query_commercial_unit_candidates``
     # when a target district is named. 0 disables the clip entirely,
     # letting the search reach all of Riyadh. When no target district is

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -65,6 +65,7 @@ _GATE_HUMAN_LABELS: dict[str, str] = {
     "radiance_growth_pass": "Market growth signal",
     "population_floor_pass": "Population reach floor",
     "commercial_floor_pass": "Commercial activity floor",
+    "construction_proximity_pass": "Construction proximity floor",
 }
 
 
@@ -88,6 +89,8 @@ if int(getattr(settings, "EXPANSION_VIABILITY_POPULATION_HARD_FLOOR", 0) or 0) >
     _OPTIONAL_HARD_GATES.add("population_floor_pass")
 if int(getattr(settings, "EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR", 0) or 0) > 0:
     _OPTIONAL_HARD_GATES.add("commercial_floor_pass")
+if float(getattr(settings, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M", 0) or 0) > 0:
+    _OPTIONAL_HARD_GATES.add("construction_proximity_pass")
 HARD_FAIL_GATES: frozenset[str] = _HARD_FAIL_GATES_BASE | frozenset(_OPTIONAL_HARD_GATES)
 
 # Advisory-only gates: presence/absence of signal must NOT collapse the
@@ -4474,6 +4477,7 @@ def _apply_market_viability_pass(
     radiance_yoy_threshold: float | None = None,
     population_hard_floor: int | None = None,
     commercial_hard_floor: int | None = None,
+    construction_buffer_m: float | None = None,
 ) -> list[dict[str, Any]]:
     """Demote candidates that are confidently bad on the CEO-directive legs.
 
@@ -4526,10 +4530,16 @@ def _apply_market_viability_pass(
         if commercial_hard_floor is not None
         else int(getattr(settings, "EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR", 0) or 0)
     )
+    cp_buffer_m = (
+        float(construction_buffer_m)
+        if construction_buffer_m is not None
+        else float(getattr(settings, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M", 0) or 0)
+    )
 
     survivors: list[dict[str, Any]] = []
     dropped_population = 0
     dropped_commercial = 0
+    dropped_construction = 0
     for c in candidates:
         fs = c.get("feature_snapshot_json") if isinstance(c, dict) else None
 
@@ -4566,12 +4576,30 @@ def _apply_market_viability_pass(
                 unique_brands = 0
             commercial_floor_pass = unique_brands >= bp_floor
 
+        # Construction-proximity floor: pass when disabled, when the
+        # construction_proximity block is missing/malformed (defensive —
+        # backfill cliff cohort, OSM table absent, bulk query failed), or
+        # when zero polygons were observed within the buffer. Otherwise
+        # fail (drop the candidate).
+        cp_block = fs.get("construction_proximity") if isinstance(fs, dict) else None
+        if cp_buffer_m <= 0:
+            construction_proximity_pass = True
+        elif not isinstance(cp_block, dict) or "polygon_count" not in cp_block:
+            construction_proximity_pass = True
+        else:
+            try:
+                cp_count = int(cp_block.get("polygon_count") or 0)
+            except (TypeError, ValueError):
+                cp_count = 0
+            construction_proximity_pass = cp_count <= 0
+
         gate_status = c.get("gate_status_json")
         if not isinstance(gate_status, dict):
             gate_status = {}
             c["gate_status_json"] = gate_status
         gate_status["population_floor_pass"] = population_floor_pass
         gate_status["commercial_floor_pass"] = commercial_floor_pass
+        gate_status["construction_proximity_pass"] = construction_proximity_pass
 
         if not population_floor_pass:
             dropped_population += 1
@@ -4579,18 +4607,23 @@ def _apply_market_viability_pass(
         if not commercial_floor_pass:
             dropped_commercial += 1
             continue
+        if not construction_proximity_pass:
+            dropped_construction += 1
+            continue
         survivors.append(c)
 
-    if dropped_population or dropped_commercial:
+    if dropped_population or dropped_commercial or dropped_construction:
         logger.info(
             "market_viability_hard_floors",
             extra={
                 "search_id": search_id,
                 "dropped_population": dropped_population,
                 "dropped_commercial": dropped_commercial,
+                "dropped_construction": dropped_construction,
                 "remaining": len(survivors),
                 "pop_floor": pop_floor,
                 "bp_floor": bp_floor,
+                "construction_buffer_m": cp_buffer_m,
             },
         )
 
@@ -7413,6 +7446,79 @@ def run_expansion_search(
                 len(_bulk_brand_presence), len(_shortlist_coords), search_id,
             )
 
+    # ───────────────────────────────────────────────────────────────────
+    # Construction proximity (CEO directive — exclude areas with heavy
+    # construction). For each shortlisted candidate count the number of
+    # ``planet_osm_polygon`` rows tagged ``landuse='construction'`` OR
+    # ``building='construction'`` within ``buffer_m`` meters of the
+    # candidate point, and capture the nearest distance. Result is
+    # written to ``feature_snapshot_json["construction_proximity"]`` and
+    # consumed by the gate in ``_apply_market_viability_pass``.
+    #
+    # SRID note: ``planet_osm_polygon.way`` is SRID 3857 (Web Mercator)
+    # — every geography cast must be preceded by ST_Transform(way, 4326).
+    # Mirrors the brand-presence Shape A pattern above.
+    # ───────────────────────────────────────────────────────────────────
+    _construction_buffer_m = float(
+        getattr(settings, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M", 0) or 0
+    )
+    _bulk_construction_proximity: dict[str, dict[str, Any]] = {}
+    if (
+        _construction_buffer_m > 0
+        and _shortlist_coords
+        and _cached_table_available(db, "planet_osm_polygon")
+    ):
+        _cp_union_parts: list[str] = []
+        _cp_params: dict = {"buffer_m": _construction_buffer_m}
+        for _cpi, (_cp_pid, (_cp_lon, _cp_lat)) in enumerate(_shortlist_coords.items()):
+            _cp_params[f"cp_pid_{_cpi}"] = str(_cp_pid)
+            _cp_params[f"cp_lon_{_cpi}"] = _cp_lon
+            _cp_params[f"cp_lat_{_cpi}"] = _cp_lat
+            _cp_union_parts.append(f"""
+                (SELECT :cp_pid_{_cpi} AS candidate_pid,
+                        COUNT(*) AS polygon_count,
+                        COALESCE(MIN(
+                            ST_Distance(
+                                ST_Transform(p.way, 4326)::geography,
+                                ST_SetSRID(ST_MakePoint(:cp_lon_{_cpi}, :cp_lat_{_cpi}), 4326)::geography
+                            )
+                        ), -1) AS nearest_distance_m
+                 FROM planet_osm_polygon p
+                 WHERE (p.landuse = 'construction' OR p.building = 'construction')
+                   AND ST_DWithin(
+                       ST_Transform(p.way, 4326)::geography,
+                       ST_SetSRID(ST_MakePoint(:cp_lon_{_cpi}, :cp_lat_{_cpi}), 4326)::geography,
+                       :buffer_m
+                   ))
+            """)
+
+        if _cp_union_parts:
+            _cp_sql = " UNION ALL ".join(_cp_union_parts)
+            try:
+                with db.begin_nested():
+                    _cp_rows = db.execute(text(_cp_sql), _cp_params).mappings().all()
+                for _r in _cp_rows:
+                    _key = str(_r["candidate_pid"])
+                    _nd_raw = _r.get("nearest_distance_m")
+                    try:
+                        _nd_val = float(_nd_raw) if _nd_raw is not None else -1.0
+                    except (TypeError, ValueError):
+                        _nd_val = -1.0
+                    _bulk_construction_proximity[_key] = {
+                        "polygon_count": int(_r.get("polygon_count") or 0),
+                        "nearest_distance_m": _nd_val if _nd_val >= 0 else None,
+                    }
+                logger.info(
+                    "expansion_search bulk construction_proximity: enriched=%d/%d search_id=%s",
+                    len(_bulk_construction_proximity), len(_shortlist_coords), search_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "expansion_search bulk construction_proximity query failed (continuing): %s",
+                    exc,
+                )
+                _bulk_construction_proximity = {}
+
     t_bulk_enrich_done = time.monotonic()
 
     for prepared_item in prepared[:shortlist_size]:
@@ -7620,6 +7726,29 @@ def run_expansion_search(
                 "unique_brands": 0,
                 "total_branches": 0,
                 "top_chains": [],
+            }
+        # Construction proximity (CEO directive — exclude areas with heavy
+        # construction). Every persisted candidate must have this key set,
+        # mirroring the brand_presence pattern above. When the bulk query
+        # was skipped (buffer disabled, table missing) the candidate falls
+        # through to the zero-block branch and the gate later passes it on
+        # the "field absent / zero polygons" semantics.
+        _cp_data = _bulk_construction_proximity.get(_pid_str)
+        if _cp_data is not None:
+            feature_snapshot_json["construction_proximity"] = {
+                "buffer_m": int(_construction_buffer_m),
+                "polygon_count": int(_cp_data["polygon_count"]),
+                "nearest_distance_m": (
+                    float(_cp_data["nearest_distance_m"])
+                    if _cp_data["nearest_distance_m"] is not None
+                    else None
+                ),
+            }
+        else:
+            feature_snapshot_json["construction_proximity"] = {
+                "buffer_m": int(_construction_buffer_m),
+                "polygon_count": 0,
+                "nearest_distance_m": None,
             }
         # Enrich feature snapshot with candidate_location metadata
         if row.get("source_tier") is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,10 +28,12 @@ def _reset_parcel_tile_table() -> None:
 def disable_market_viability_floors(monkeypatch):
     """Opt-in fixture to disable the production market-viability hard floors.
 
-    Production sets EXPANSION_VIABILITY_POPULATION_HARD_FLOOR=20000 and
-    EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR=1, which would drop
+    Production sets EXPANSION_VIABILITY_POPULATION_HARD_FLOOR=20000,
+    EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR=1, and
+    EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M=75.0, which would drop
     regression-test cohorts that use population_reach values well below
-    20k for compactness. Tests that pre-date the new gates and don't
+    20k for compactness or that happen to share coordinates with OSM
+    construction polygons. Tests that pre-date the new gates and don't
     care about them should request this fixture; tests that explicitly
     cover the hard floors must NOT use this fixture.
 
@@ -58,6 +60,10 @@ def disable_market_viability_floors(monkeypatch):
         seen_ids.add(id(candidate))
         monkeypatch.setattr(candidate, "EXPANSION_VIABILITY_POPULATION_HARD_FLOOR", 0)
         monkeypatch.setattr(candidate, "EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR", 0)
+        if hasattr(candidate, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M"):
+            monkeypatch.setattr(candidate, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M", 0)
     if id(config.settings) not in seen_ids:
         monkeypatch.setattr(config.settings, "EXPANSION_VIABILITY_POPULATION_HARD_FLOOR", 0)
         monkeypatch.setattr(config.settings, "EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR", 0)
+        if hasattr(config.settings, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M"):
+            monkeypatch.setattr(config.settings, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M", 0)


### PR DESCRIPTION
## Summary
Implements a new CEO-directive hard floor that excludes expansion candidates located in areas with heavy construction activity. This gate filters candidates based on proximity to OpenStreetMap construction polygons (landuse='construction' or building='construction').

## Key Changes

- **New configuration setting**: `EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M` (default 75.0m) controls the radius within which construction polygons trigger candidate rejection
- **Gate registration**: Added `construction_proximity_pass` to the hard-fail gates system, conditionally enabled when the buffer setting is > 0
- **Bulk data enrichment**: Implemented efficient SQL query pattern (mirroring brand-presence logic) that:
  - Queries `planet_osm_polygon` table for construction-tagged features within the buffer radius
  - Counts matching polygons and captures nearest distance for each candidate
  - Stores results in `feature_snapshot_json["construction_proximity"]`
  - Gracefully handles missing OSM table or disabled buffer (defensive pass-through)
- **Gate logic**: In `_apply_market_viability_pass()`, candidates are dropped if construction polygons are detected within the buffer; passes defensively when buffer is disabled, data is missing, or polygon count is zero
- **Logging**: Added construction-proximity drop counts and buffer distance to market viability gate logging
- **Test fixture**: Updated `disable_market_viability_floors` to also disable the new construction buffer setting for regression tests

## Implementation Details

- Uses SRID 3857→4326 transformation for OSM polygon geometries (Web Mercator to WGS84)
- Employs `ST_DWithin()` for efficient geographic distance filtering
- Follows existing hard-floor patterns for consistency (population, brand presence)
- Includes defensive handling for malformed/missing data blocks
- Scheduled OSM import workflow now runs weekly (Sundays 04:00 UTC) to keep construction data current

https://claude.ai/code/session_018PuTXhX4ru8xKBx5FXmyZv