### PR TITLE
feat(blackmarble): area-based confidence guards (A1)

### DIFF
--- a/app/connectors/blackmarble.py
+++ b/app/connectors/blackmarble.py
@@ -34,6 +34,46 @@ SOURCE_LABEL = "nasa_blackmarble_vnp46a3_c2"
 # falls through (no growth_rescue).
 PIXEL_COUNT_FLOOR = 10
 
+# Area guards (Patch A1). A district whose polygon is below
+# SMALL_DISTRICT_FLOOR_KM2 is too small for VNP46A3 (~500 m pixel) to
+# produce a stable signal even when the pixel-count floor passes; mark
+# unconfident. A polygon larger than LARGE_DISTRICT_OUTLIER_KM2 is almost
+# always a polygon-merge error swallowing siblings; emit an observability
+# WARNING but do not change confidence.
+SMALL_DISTRICT_FLOOR_KM2 = 0.5
+LARGE_DISTRICT_OUTLIER_KM2 = 500.0
+
+
+def evaluate_confidence(
+    pixels_cur: int,
+    pixels_prev: int,
+    area_km2: float | None,
+    district_key: str,
+) -> tuple[bool, str | None]:
+    """Decide whether a district's YoY radiance signal is confident.
+
+    Returns ``(confident, confidence_reason)`` where ``confidence_reason`` is
+    one of ``"pixel_floor"``, ``"small_district"``, or ``None`` (confident).
+
+    ``area_km2 is None`` (district missing from the polygon source) falls
+    back to the pixel-count rule alone — mirrors the missing-field-passes
+    pattern in ``_apply_market_viability_pass``.
+
+    As a side effect, emits a structured WARNING when ``area_km2`` exceeds
+    ``LARGE_DISTRICT_OUTLIER_KM2`` so polygon-merge errors are surfaced.
+    Outlier districts remain confident; this is observability only.
+    """
+    if pixels_cur < PIXEL_COUNT_FLOOR or pixels_prev < PIXEL_COUNT_FLOOR:
+        return False, "pixel_floor"
+    if area_km2 is not None and area_km2 < SMALL_DISTRICT_FLOOR_KM2:
+        return False, "small_district"
+    if area_km2 is not None and area_km2 > LARGE_DISTRICT_OUTLIER_KM2:
+        logger.warning(
+            "blackmarble.large_district_outlier",
+            extra={"district_key": district_key, "area_km2": round(area_km2, 2)},
+        )
+    return True, None
+
 RADIANCE_BAND_PATH = (
     "HDFEOS/GRIDS/VIIRS_Grid_DNB_2d/Data Fields/NearNadir_Composite_Snow_Free"
 )

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -14,7 +14,10 @@ from typing import Any, Mapping
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from app.connectors.blackmarble import QUALITY_FILTER_LABEL
+from app.connectors.blackmarble import (
+    QUALITY_FILTER_LABEL,
+    evaluate_confidence as _blackmarble_evaluate_confidence,
+)
 from app.core.config import settings
 from app.ml.name_normalization import norm_district
 from app.services.aqar_district_match import (
@@ -6615,6 +6618,50 @@ def run_expansion_search(
     # YoY). Pre-loaded in one query before the candidate loop to avoid N+1.
     # Keyed by norm_district("riyadh", district_label) — matches the key used
     # at ingest time in app.ingest.black_marble_radiance.
+    #
+    # District areas (Patch A1). One per-search query against the same
+    # polygon source the radiance ingest uses (external_feature, layer
+    # 'aqar_district_hulls'); normalized in Python via norm_district to
+    # mirror ingest semantics exactly. Used by evaluate_confidence to
+    # apply the small-district floor / large-district outlier WARNING.
+    _district_area_km2: dict[str, float] = {}
+    try:
+        _area_rows = db.execute(text("""
+            SELECT
+                TRIM(COALESCE(ef.properties->>'district_raw',
+                              ef.properties->>'district')) AS district_label,
+                ST_Area(
+                    ST_SetSRID(ST_GeomFromGeoJSON(ef.geometry::text), 4326)::geography
+                ) / 1e6 AS area_km2
+            FROM external_feature ef
+            WHERE ef.layer_name = 'aqar_district_hulls'
+              AND ef.geometry IS NOT NULL
+              AND jsonb_typeof(ef.geometry) = 'object'
+              AND COALESCE(ef.properties->>'district_raw',
+                           ef.properties->>'district') IS NOT NULL
+              AND TRIM(COALESCE(ef.properties->>'district_raw',
+                                ef.properties->>'district')) <> ''
+        """)).mappings().all()
+        for _ar in _area_rows:
+            _label = _ar["district_label"]
+            _area = _ar["area_km2"]
+            if not _label or _area is None:
+                continue
+            _key = norm_district("riyadh", str(_label).strip())
+            if not _key:
+                continue
+            # Duplicate district_label rows occasionally exist in
+            # external_feature; keep the largest polygon to be safe (a
+            # merged sibling would still be flagged by the outlier rule).
+            _area_f = float(_area)
+            if _key not in _district_area_km2 or _area_f > _district_area_km2[_key]:
+                _district_area_km2[_key] = _area_f
+    except Exception:
+        # Polygon table missing / schema mismatch — degrade silently. The
+        # confidence helper treats area_km2 is None as "unknown, don't
+        # penalize", so the legacy pixel-only rule applies.
+        logger.debug("district area lookup failed", exc_info=True)
+
     _radiance_lookup: dict[str, dict[str, Any]] = {}
     try:
         _radiance_rows = db.execute(text("""
@@ -6656,7 +6703,13 @@ def run_expansion_search(
         _dk = _r["district_key"]
         _pixels_cur = int(_r["pixels_cur"] or 0)
         _pixels_prev = int(_r["pixels_prev"] or 0)
-        _confident = _pixels_cur >= 10 and _pixels_prev >= 10
+        _area_km2 = _district_area_km2.get(_dk)
+        _confident, _confidence_reason = _blackmarble_evaluate_confidence(
+            pixels_cur=_pixels_cur,
+            pixels_prev=_pixels_prev,
+            area_km2=_area_km2,
+            district_key=_dk,
+        )
         _yoy_pct: float | None = None
         if _confident and _r["rad_prev"] and float(_r["rad_prev"]) > 0:
             _yoy_pct = (
@@ -6666,6 +6719,7 @@ def run_expansion_search(
             "value_yoy_pct": round(_yoy_pct, 2) if _yoy_pct is not None else None,
             "source_label": "blackmarble_district_yoy_simple",
             "confident": _confident and _yoy_pct is not None,
+            "confidence_reason": _confidence_reason,
             "pixel_count": _pixels_cur,
             "year_month": str(_r["ym_cur"]),
         }

--- a/tests/test_blackmarble_connector.py
+++ b/tests/test_blackmarble_connector.py
@@ -220,3 +220,122 @@ def test_aggregate_per_district_pixel_count_floor():
     # Below the consume-time floor of 10, but we still report it.
     assert r["pixel_count_valid"] == 1
     assert r["pixel_count_valid"] < blackmarble.PIXEL_COUNT_FLOOR
+
+
+# ── Patch A1: area-based confidence guards ──────────────────────────────
+
+
+def test_small_district_below_floor_is_unconfident():
+    from app.connectors import blackmarble
+
+    confident, reason = blackmarble.evaluate_confidence(
+        pixels_cur=25,
+        pixels_prev=30,
+        area_km2=0.3,
+        district_key="tiny_district",
+    )
+    assert confident is False
+    assert reason == "small_district"
+
+
+def test_small_district_at_floor_is_confident():
+    """Boundary: area exactly at SMALL_DISTRICT_FLOOR_KM2 is allowed."""
+    from app.connectors import blackmarble
+
+    confident, reason = blackmarble.evaluate_confidence(
+        pixels_cur=25,
+        pixels_prev=30,
+        area_km2=blackmarble.SMALL_DISTRICT_FLOOR_KM2,
+        district_key="boundary_district",
+    )
+    assert confident is True
+    assert reason is None
+
+
+def test_pixel_floor_takes_precedence_over_area():
+    from app.connectors import blackmarble
+
+    confident, reason = blackmarble.evaluate_confidence(
+        pixels_cur=5,  # below floor
+        pixels_prev=30,
+        area_km2=10.0,  # ample area
+        district_key="thin_pixel_district",
+    )
+    assert confident is False
+    assert reason == "pixel_floor"
+
+
+def test_missing_area_falls_back_to_pixel_only():
+    from app.connectors import blackmarble
+
+    # Pixels above floor + unknown area → confident.
+    confident, reason = blackmarble.evaluate_confidence(
+        pixels_cur=25,
+        pixels_prev=30,
+        area_km2=None,
+        district_key="unknown_area_district",
+    )
+    assert confident is True
+    assert reason is None
+
+    # Pixels below floor + unknown area → unconfident with pixel_floor.
+    confident, reason = blackmarble.evaluate_confidence(
+        pixels_cur=5,
+        pixels_prev=30,
+        area_km2=None,
+        district_key="unknown_area_district",
+    )
+    assert confident is False
+    assert reason == "pixel_floor"
+
+
+def test_large_district_logs_outlier(caplog):
+    import logging
+
+    from app.connectors import blackmarble
+
+    caplog.set_level(logging.WARNING, logger="app.connectors.blackmarble")
+
+    confident, reason = blackmarble.evaluate_confidence(
+        pixels_cur=25,
+        pixels_prev=30,
+        area_km2=750.0,
+        district_key="huge_merged_district",
+    )
+
+    # Outlier flag is observability-only: confidence is unchanged.
+    assert confident is True
+    assert reason is None
+
+    outlier_records = [
+        r for r in caplog.records
+        if r.getMessage() == "blackmarble.large_district_outlier"
+    ]
+    assert len(outlier_records) == 1
+    rec = outlier_records[0]
+    assert rec.levelno == logging.WARNING
+    assert getattr(rec, "district_key", None) == "huge_merged_district"
+    assert getattr(rec, "area_km2", None) == 750.0
+
+
+def test_large_district_does_not_log_when_below_threshold(caplog):
+    """Boundary: area = 499 km² is below the 500 km² outlier threshold."""
+    import logging
+
+    from app.connectors import blackmarble
+
+    caplog.set_level(logging.WARNING, logger="app.connectors.blackmarble")
+
+    confident, reason = blackmarble.evaluate_confidence(
+        pixels_cur=25,
+        pixels_prev=30,
+        area_km2=499.0,
+        district_key="just_under_outlier",
+    )
+
+    assert confident is True
+    assert reason is None
+    assert not [
+        r for r in caplog.records
+        if r.getMessage() == "blackmarble.large_district_outlier"
+    ]


### PR DESCRIPTION
## Phase 1 summary

- **Canonical polygon source**: `external_feature` table where `layer_name = 'aqar_district_hulls'`. The radiance ingest at `app/ingest/black_marble_radiance.py:106-186` reads polygons from this exact source and produces `district_key` via `norm_district("riyadh", district_label)`. To keep the area lookup keyed identically to the radiance signal, this patch reuses the same source + the same Python normalization.
- **Area already materialized?** No. `ST_Area` is used widely in scoring/portal code, but no district-area table or column exists. Confirmed via `grep -rnE "ST_Area" app/ alembic/`.
- **Phase 2 strategy chosen — Option α (JOIN at read time, Python-side merge)**: a single per-search SQL query against `external_feature` returning `district_label, ST_Area(::geography)/1e6 AS area_km2`, normalized in Python via `norm_district("riyadh", …)` to build a `district_key → area_km2` dict. ~132 districts; no migration; no module-level cache.
  - **Why not a pure SQL JOIN against `district_radiance_monthly`?** The `district_key` stored in `district_radiance_monthly` is produced by Python's `norm_district("riyadh", …)`. The existing `normalize_district_key_sql` mirrors `normalize_district_key`, not `norm_district`, so a SQL JOIN would risk semantic drift between ingest keys and lookup keys. Computing the merge in Python on the same `norm_district` function eliminates that risk.
  - **Why not Option β (module-level cache)?** Cleaner DB-session lifecycle and easier to reason about in tests.
  - **Why not Option γ (reference table)?** No migration is needed for ~132 rows once per search.
- **Test file**: `tests/test_blackmarble_connector.py` (existed; extended).

## Files changed

- **`app/connectors/blackmarble.py`** — added `SMALL_DISTRICT_FLOOR_KM2 = 0.5` and `LARGE_DISTRICT_OUTLIER_KM2 = 500.0` constants alongside the existing `PIXEL_COUNT_FLOOR` (`app/connectors/blackmarble.py:35-46`), plus a new `evaluate_confidence(pixels_cur, pixels_prev, area_km2, district_key) -> (bool, str | None)` helper (`app/connectors/blackmarble.py:49-78`). The helper returns `(False, "pixel_floor")` when either pixel count is below floor, `(False, "small_district")` when area is below the small-district floor, and emits a structured WARNING `"blackmarble.large_district_outlier"` (with `district_key` + `area_km2` in `extra`) when area exceeds the outlier threshold — observability only, confidence is unchanged.
- **`app/services/expansion_advisor.py`** —
  - Import: `evaluate_confidence` re-exported as `_blackmarble_evaluate_confidence` alongside the existing `QUALITY_FILTER_LABEL` import (`app/services/expansion_advisor.py:17-20`).
  - Pre-computed district areas (`app/services/expansion_advisor.py:6618-6660`): one query against `external_feature` (layer `'aqar_district_hulls'`), normalized in Python via `norm_district("riyadh", …)` into `_district_area_km2: dict[str, float]`. Failure mode: area lookup degrades silently, the helper falls back to pixel-only.
  - Confidence loop (`app/services/expansion_advisor.py:6707-6727`): replaced the old `_confident = _pixels_cur >= 10 and _pixels_prev >= 10` line with a call to `_blackmarble_evaluate_confidence(...)`, captured `_confidence_reason`, and added `"confidence_reason": _confidence_reason` to each `_radiance_lookup[_dk]` entry. The downstream snapshot write at `app/services/expansion_advisor.py:7825-7830` already does `feature_snapshot_json["radiance_growth"] = dict(_radiance_signal)`, so `confidence_reason` is propagated into `score_breakdown_json["radiance_growth"]` automatically — no change needed at the snapshot site.
- **`tests/test_blackmarble_connector.py`** — six new unit tests for `evaluate_confidence`, all from Phase 4 of the spec.

## Test output

```
$ pytest tests/test_blackmarble_connector.py -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.2
configfile: pytest.ini
collecting ... collected 13 items

tests/test_blackmarble_connector.py::test_download_h5_real SKIPPED (...) [  7%]
tests/test_blackmarble_connector.py::test_discover_h5_url_constructs_correct_path PASSED [ 15%]
tests/test_blackmarble_connector.py::test_discover_h5_url_accepts_bare_list_fallback PASSED [ 23%]
tests/test_blackmarble_connector.py::test_discover_h5_url_raises_when_content_empty PASSED [ 30%]
tests/test_blackmarble_connector.py::test_discover_h5_url_raises_when_not_published PASSED [ 38%]
tests/test_blackmarble_connector.py::test_aggregate_per_district_filters_quality_correctly SKIPPED [ 46%]
tests/test_blackmarble_connector.py::test_aggregate_per_district_pixel_count_floor SKIPPED [ 53%]
tests/test_blackmarble_connector.py::test_small_district_below_floor_is_unconfident PASSED [ 61%]
tests/test_blackmarble_connector.py::test_small_district_at_floor_is_confident PASSED [ 69%]
tests/test_blackmarble_connector.py::test_pixel_floor_takes_precedence_over_area PASSED [ 76%]
tests/test_blackmarble_connector.py::test_missing_area_falls_back_to_pixel_only PASSED [ 84%]
tests/test_blackmarble_connector.py::test_large_district_logs_outlier PASSED [ 92%]
tests/test_blackmarble_connector.py::test_large_district_does_not_log_when_below_threshold PASSED [100%]

======================== 10 passed, 3 skipped in 0.39s =========================
```

(The 3 skips are pre-existing — they require `h5py` / `rasterio`, neither installed in the harness env. They are unchanged by this patch.)

Broader expansion-advisor regression suite:

```
$ pytest -q tests/test_expansion_advisor.py
94 passed in 0.56s
```

`py_compile` clean for all three touched files.

## Run after merge

```sql
-- How many of the 132 confident districts (per Bundle B) get downgraded
-- by the 0.5 km² floor? And does the 500 km² outlier flag fire on any
-- current district?
SELECT
  district_key,
  ROUND((ST_Area(geom_4326::geography) / 1e6)::numeric, 4) AS area_km2,
  CASE
    WHEN ST_Area(geom_4326::geography) / 1e6 < 0.5  THEN 'small_unconfident'
    WHEN ST_Area(geom_4326::geography) / 1e6 > 500  THEN 'outlier_log'
    ELSE 'normal'
  END AS bucket
FROM (
  SELECT
    -- Mirrors the Python norm_district() done in app.services.expansion_advisor
    -- at read time. If your psql session has a SQL helper for this it can
    -- replace the LOWER+TRIM, but for ad-hoc inspection LOWER+TRIM is enough
    -- to spot-check the small / outlier buckets.
    LOWER(TRIM(COALESCE(ef.properties->>'district_raw',
                        ef.properties->>'district'))) AS district_key,
    ST_SetSRID(ST_GeomFromGeoJSON(ef.geometry::text), 4326) AS geom_4326
  FROM external_feature ef
  WHERE ef.layer_name = 'aqar_district_hulls'
    AND ef.geometry IS NOT NULL
) p
WHERE district_key IN (
  SELECT DISTINCT district_key FROM district_radiance_monthly
)
ORDER BY area_km2 ASC;
```

## Risk

- **Low.** The helper is purely additive; the only behavioral change for existing data is that districts with `area_km2 < 0.5` flip from `confident=true` to `confident=false`. The downstream consumer (`feature_snapshot_json["radiance_growth"]`) already tolerates `confident=false` (the leg simply falls through). No migration. No env vars. No `_apply_market_viability_pass` edits — that's B2 territory.

https://claude.ai/code/session_01KLuBuGvdbbtRqBypmaQiEo

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLuBuGvdbbtRqBypmaQiEo)_