### PR TITLE
Mark large districts as unconfident in Black Marble radiance

### DIFF
--- a/app/connectors/blackmarble.py
+++ b/app/connectors/blackmarble.py
@@ -53,15 +53,19 @@ def evaluate_confidence(
     """Decide whether a district's YoY radiance signal is confident.
 
     Returns ``(confident, confidence_reason)`` where ``confidence_reason`` is
-    one of ``"pixel_floor"``, ``"small_district"``, or ``None`` (confident).
+    one of ``"pixel_floor"``, ``"small_district"``, ``"large_district"``, or
+    ``None`` (confident).
 
     ``area_km2 is None`` (district missing from the polygon source) falls
     back to the pixel-count rule alone — mirrors the missing-field-passes
     pattern in ``_apply_market_viability_pass``.
 
     As a side effect, emits a structured WARNING when ``area_km2`` exceeds
-    ``LARGE_DISTRICT_OUTLIER_KM2`` so polygon-merge errors are surfaced.
-    Outlier districts remain confident; this is observability only.
+    ``LARGE_DISTRICT_OUTLIER_KM2`` so polygon-merge errors and very large
+    districts (e.g. KKIA, Hayit, Ash Sharq, An Nadhim, Banban) are surfaced
+    for diagnostic review. The radiance YoY signal for those districts is
+    not used for ranking because it averages over too large an area to be
+    meaningful at a candidate's micro-location.
     """
     if pixels_cur < PIXEL_COUNT_FLOOR or pixels_prev < PIXEL_COUNT_FLOOR:
         return False, "pixel_floor"
@@ -72,6 +76,7 @@ def evaluate_confidence(
             "blackmarble.large_district_outlier",
             extra={"district_key": district_key, "area_km2": round(area_km2, 2)},
         )
+        return False, "large_district"
     return True, None
 
 RADIANCE_BAND_PATH = (

--- a/tests/test_blackmarble_connector.py
+++ b/tests/test_blackmarble_connector.py
@@ -303,9 +303,11 @@ def test_large_district_logs_outlier(caplog):
         district_key="huge_merged_district",
     )
 
-    # Outlier flag is observability-only: confidence is unchanged.
-    assert confident is True
-    assert reason is None
+    # Large-district outliers are unconfident: their district-wide radiance
+    # YoY averages over too much empty land to be meaningful at a candidate's
+    # micro-location. The WARNING log is retained for observability.
+    assert confident is False
+    assert reason == "large_district"
 
     outlier_records = [
         r for r in caplog.records
@@ -316,6 +318,33 @@ def test_large_district_logs_outlier(caplog):
     assert rec.levelno == logging.WARNING
     assert getattr(rec, "district_key", None) == "huge_merged_district"
     assert getattr(rec, "area_km2", None) == 750.0
+
+
+def test_large_district_at_threshold_is_confident(caplog):
+    """Boundary: area exactly at LARGE_DISTRICT_OUTLIER_KM2 is allowed.
+
+    The rule fires strictly above the threshold; equality stays confident
+    and emits no WARNING.
+    """
+    import logging
+
+    from app.connectors import blackmarble
+
+    caplog.set_level(logging.WARNING, logger="app.connectors.blackmarble")
+
+    confident, reason = blackmarble.evaluate_confidence(
+        pixels_cur=25,
+        pixels_prev=30,
+        area_km2=blackmarble.LARGE_DISTRICT_OUTLIER_KM2,
+        district_key="threshold_district",
+    )
+
+    assert confident is True
+    assert reason is None
+    assert not [
+        r for r in caplog.records
+        if r.getMessage() == "blackmarble.large_district_outlier"
+    ]
 
 
 def test_large_district_does_not_log_when_below_threshold(caplog):


### PR DESCRIPTION
## Summary
Updated the Black Marble connector to mark districts exceeding the large-district outlier threshold as unconfident, preventing their radiance YoY signals from being used in candidate ranking.

## Key Changes
- Modified `evaluate_confidence()` to return `(False, "large_district")` when `area_km2` exceeds `LARGE_DISTRICT_OUTLIER_KM2`, instead of remaining confident
- Updated docstring to clarify that large districts are excluded from ranking because their district-wide radiance averages over too much empty land to be meaningful at a candidate's micro-location
- Added boundary test `test_large_district_at_threshold_is_confident()` to verify that areas exactly at the threshold remain confident (strict inequality check)
- Updated existing test `test_large_district_logs_outlier()` to assert the new unconfident behavior and verify the "large_district" reason is returned

## Implementation Details
- The WARNING log for observability is retained when large districts are detected
- The threshold check uses strict inequality (`>` not `>=`), so districts at exactly `LARGE_DISTRICT_OUTLIER_KM2` remain confident
- This addresses polygon-merge errors and very large districts (e.g. KKIA, Hayit, Ash Sharq, An Nadhim, Banban) that should not influence candidate ranking

https://claude.ai/code/session_01WHoYb71WHDtcnTg2diJdEQ