### PR TITLE
feat(expansion): realized-demand soft-demote leg + flag flip (B3)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -77,12 +77,21 @@ class Settings:
 
     # --- Realized demand (rating_count Δ) signal ---
     # When enabled AND the ``expansion_delivery_rating_history`` table has
-    # ≥2 snapshots for the candidate's catchment, the service layer blends a
-    # realized-demand score (rating_count growth per category per radius over
-    # the last N days) into the supply-based _delivery_score().  Default OFF
-    # so behavior is unchanged until history has accumulated.
+    # ≥3 contributing branches in the candidate's catchment, the snapshot
+    # writer publishes ``realized_demand_30d`` / ``realized_demand_branches``
+    # to feature_snapshot_json and the service layer blends a realized-demand
+    # score (rating_count growth per category per radius over the last N
+    # days) into the supply-based _delivery_score().
+    #
+    # Default flipped ON (B3): the production coverage check confirmed
+    # 100% of recent candidates carry ≥3 branches in the 1200 m catchment
+    # (median realized_demand_30d ≈ 797, p90 ≈ 2,293 — well above the
+    # _delivery_score calibration reference of 200). The signal is now
+    # first-class, not opt-in. Set EXPANSION_REALIZED_DEMAND_ENABLED=false
+    # to restore the legacy behavior (snapshot fields suppressed and
+    # realized_demand_source reported as ``history_unavailable``).
     EXPANSION_REALIZED_DEMAND_ENABLED: bool = (
-        os.getenv("EXPANSION_REALIZED_DEMAND_ENABLED", "").strip().lower()
+        os.getenv("EXPANSION_REALIZED_DEMAND_ENABLED", "true").strip().lower()
         in {"1", "true", "yes", "on"}
     )
     EXPANSION_REALIZED_DEMAND_WINDOW_DAYS: int = int(
@@ -171,6 +180,29 @@ class Settings:
     )
     EXPANSION_VIABILITY_POP_PERCENTILE: float = float(
         os.getenv("EXPANSION_VIABILITY_POP_PERCENTILE", "0.25")
+    )
+    # Bottom-quartile cutoff for the realized-demand soft-demote leg
+    # (clause 2 "strong potential for sales"). Mirrors
+    # EXPANSION_VIABILITY_POP_PERCENTILE.
+    EXPANSION_VIABILITY_DEMAND_PERCENTILE: float = float(
+        os.getenv("EXPANSION_VIABILITY_DEMAND_PERCENTILE", "0.25")
+    )
+    # Minimum number of distinct delivery-platform branches with rating-
+    # count delta capability inside the candidate's catchment for the
+    # demand leg to consider the signal confident. Mirrors the snapshot-
+    # writer gate at app/services/expansion_advisor.py:7933 and lets us
+    # tighten/loosen the leg without touching the snapshot path.
+    EXPANSION_VIABILITY_DEMAND_MIN_BRANCHES: int = int(
+        os.getenv("EXPANSION_VIABILITY_DEMAND_MIN_BRANCHES", "3")
+    )
+    # Kill switch for the demand_demote leg only. Disabling this leaves
+    # the realized-demand data pipeline (snapshots, memo phrasing, rerank
+    # emission) fully intact — only the soft-demote behavior is suppressed.
+    # Use when production ranking moves are problematic but the data is
+    # still wanted for audit / observability.
+    EXPANSION_VIABILITY_DEMAND_LEG_ENABLED: bool = (
+        os.getenv("EXPANSION_VIABILITY_DEMAND_LEG_ENABLED", "true").strip().lower()
+        in {"1", "true", "yes", "on"}
     )
     EXPANSION_VIABILITY_DEMOTION_STEPS: int = int(
         os.getenv("EXPANSION_VIABILITY_DEMOTION_STEPS", "6")

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -4484,7 +4484,7 @@ def _apply_market_viability_pass(
 ) -> list[dict[str, Any]]:
     """Demote candidates that are confidently bad on the CEO-directive legs.
 
-    Three independent legs, soft-demote on any (single demote, never compounded):
+    Four independent legs, soft-demote on any (single demote, never compounded):
 
       * Population leg (clause 1, "high population density") — fires when the
         per-search bottom-quartile gate fails AND the radiance growth signal
@@ -4499,17 +4499,31 @@ def _apply_market_viability_pass(
         not a forward-looking signal; rescuing it on growth would conflate
         clause 3 with future-looking signals already covered by the other
         legs.
+      * Demand leg (clause 2 of Faisal's directive, "strong potential for
+        sales", B3) — fires when ``feature_snapshot_json["realized_demand_30d"]``
+        is in the per-search bottom quartile AND the catchment carries at
+        least ``EXPANSION_VIABILITY_DEMAND_MIN_BRANCHES`` distinct
+        contributing branches (mirroring the snapshot writer's confidence
+        gate). No growth rescue, by the same precedent as the economics
+        leg: realized demand is a present-state signal, not a forward-state
+        one, and conflating it with radiance growth re-introduces the
+        false-positive class the leg exists to suppress. Disable in
+        isolation via ``EXPANSION_VIABILITY_DEMAND_LEG_ENABLED=false``;
+        the snapshot pipeline (and the ``realized_demand_30d`` /
+        ``realized_demand_branches`` annotation) remain fully populated.
 
-    The third leg's growth signal reads ``feature_snapshot_json["radiance_growth"]``
+    The growth-rescue signal reads ``feature_snapshot_json["radiance_growth"]``
     (NASA Black Marble VNP46A3). When that signal is confident and YoY growth
     meets the threshold, the candidate is rescued from the population and rent
-    legs (not from the economics leg).
+    legs (not from the economics or demand legs).
 
     Conservative: each measured leg requires its underlying signal to be
     CONFIDENT (rent scope not citywide; pop reach > 0; economics_score
-    populated). Positional reorder only, does not mutate final_score. Writes
+    populated; realized_demand_30d present with branches >= the configured
+    minimum). Positional reorder only, does not mutate final_score. Writes
     ``market_viability_flag`` to score_breakdown_json with the legs that fired
-    encoded as a stable ``_and_``-joined string in the ``reason`` field.
+    encoded as a stable ``_and_``-joined string in the ``reason`` field
+    (stable order: population, rent, economics, demand).
     """
     if not candidates:
         return candidates
@@ -4534,6 +4548,15 @@ def _apply_market_viability_pass(
         if radiance_yoy_threshold is not None
         else settings.EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD
     )
+    demand_percentile_threshold = float(getattr(
+        settings, "EXPANSION_VIABILITY_DEMAND_PERCENTILE", 0.25
+    ))
+    demand_min_branches = int(getattr(
+        settings, "EXPANSION_VIABILITY_DEMAND_MIN_BRANCHES", 3
+    ))
+    demand_leg_enabled = bool(getattr(
+        settings, "EXPANSION_VIABILITY_DEMAND_LEG_ENABLED", True
+    ))
 
     # ── CEO directive: hard floors (broader data + filter low-potential) ──
     # Two absolute drops applied BEFORE the 3-of-3 conjunction below. Keys
@@ -4682,14 +4705,52 @@ def _apply_market_viability_pass(
 
     economics_min = float(settings.EXPANSION_VIABILITY_ECONOMICS_MIN)
 
+    # ── Demand leg (B3) — per-search bottom-quartile cutoff over confident
+    # realized_demand_30d values. The snapshot writer omits the field
+    # entirely when branches < 3, so presence already implies confidence;
+    # we still re-check the branches gate per candidate so the threshold
+    # used here can be read independently of the writer's gate. When the
+    # kill switch is off, or fewer than 4 confident values exist, the
+    # threshold is None and the leg silently does not fire.
+    demand_values: list[float] = []
+    if demand_leg_enabled:
+        for c in out:
+            fs = c.get("feature_snapshot_json")
+            if not isinstance(fs, dict):
+                continue
+            raw = fs.get("realized_demand_30d")
+            if raw is None:
+                continue
+            v = _safe_float(raw, default=-1.0)
+            if v > 0:
+                demand_values.append(v)
+
+    demand_threshold: float | None
+    if not demand_leg_enabled or len(demand_values) < 4:
+        demand_threshold = None
+    else:
+        demand_pct_index = max(
+            1, min(99, int(round(demand_percentile_threshold * 100)))
+        )
+        try:
+            demand_cutoffs = statistics.quantiles(
+                demand_values, n=100, method="inclusive"
+            )
+            demand_threshold = float(demand_cutoffs[demand_pct_index - 1])
+        except Exception:
+            demand_threshold = None
+
     def _flag_inputs(
         c: dict[str, Any]
     ) -> tuple[
-        bool, bool, bool, float, str | None, float, float | None, dict[str, Any]
+        bool, bool, bool, bool,
+        float, str | None, float, float | None, dict[str, Any],
+        float | None, int | None,
     ]:
         # Returns:
-        #   (pop_demote, rent_demote, econ_demote,
-        #    rent_pct, rent_scope, pop_reach, economics_score, radiance_meta)
+        #   (pop_demote, rent_demote, econ_demote, demand_demote,
+        #    rent_pct, rent_scope, pop_reach, economics_score, radiance_meta,
+        #    demand_value, demand_branches)
         radiance_meta: dict[str, Any] = {
             "radiance_growth_pct": None,
             "radiance_confident": None,
@@ -4774,15 +4835,47 @@ def _apply_market_viability_pass(
                     pop_confident and pop_low and not growth_rescue
                 )
 
+        # ── Clause "strong potential for sales" (B3) — realized-demand leg.
+        # NO growth_rescue — sales potential and growth are distinct pillars
+        # in the directive; conflating them re-introduces the false-positive
+        # class this leg exists to suppress. Mirrors the economics-leg
+        # precedent in the docstring above.
+        demand_value_raw = fs.get("realized_demand_30d") if isinstance(fs, dict) else None
+        demand_branches_raw = fs.get("realized_demand_branches") if isinstance(fs, dict) else None
+        demand_value: float | None
+        if isinstance(demand_value_raw, (int, float)) and not isinstance(demand_value_raw, bool):
+            dv = float(demand_value_raw)
+            demand_value = dv if not (math.isnan(dv) or math.isinf(dv)) else None
+        else:
+            demand_value = None
+        demand_branches: int | None
+        if isinstance(demand_branches_raw, (int, float)) and not isinstance(demand_branches_raw, bool):
+            demand_branches = int(demand_branches_raw)
+        else:
+            demand_branches = None
+        demand_confident = (
+            demand_threshold is not None
+            and demand_branches is not None
+            and demand_branches >= demand_min_branches
+            and demand_value is not None
+        )
+        demand_low = (
+            demand_confident
+            and demand_value is not None
+            and demand_value < demand_threshold
+        )
+        demand_demote = bool(demand_confident and demand_low)
+
         return (
-            pop_demote, rent_demote, econ_demote,
+            pop_demote, rent_demote, econ_demote, demand_demote,
             rent_pct, rent_scope, pop_reach, economics_score, radiance_meta,
+            demand_value, demand_branches,
         )
 
     pre_eval = [_flag_inputs(c) for c in out]
     demote_indices = [
         i for i in range(n)
-        if pre_eval[i][0] or pre_eval[i][1] or pre_eval[i][2]
+        if pre_eval[i][0] or pre_eval[i][1] or pre_eval[i][2] or pre_eval[i][3]
     ]
 
     demoted = 0
@@ -4790,10 +4883,12 @@ def _apply_market_viability_pass(
         target = min(i + demotion_steps, n - 1)
         c = out[i]
         (
-            pop_demote, rent_demote, econ_demote,
+            pop_demote, rent_demote, econ_demote, demand_demote,
             rent_pct, rent_scope, pop_reach, economics_score, radiance_meta,
+            demand_value, demand_branches,
         ) = pre_eval[i]
-        # Stable-order annotation: clause 1, clause 2, clause 3.
+        # Stable-order annotation: clause 1 (pop), clause 2 (rent),
+        # clause 3 (economics), clause "sales potential" (demand).
         reasons: list[str] = []
         if pop_demote:
             reasons.append("population_below_quartile")
@@ -4801,6 +4896,8 @@ def _apply_market_viability_pass(
             reasons.append("rent_high")
         if econ_demote:
             reasons.append("economics_below_threshold")
+        if demand_demote:
+            reasons.append("demand_low")
         sb = c.get("score_breakdown_json")
         if not isinstance(sb, dict):
             sb = {}
@@ -4819,6 +4916,14 @@ def _apply_market_viability_pass(
             "population_demote": pop_demote,
             "rent_demote": rent_demote,
             "economics_demote": econ_demote,
+            "realized_demand_30d": (
+                float(demand_value) if demand_value is not None else None
+            ),
+            "realized_demand_branches": demand_branches,
+            "realized_demand_threshold": (
+                float(demand_threshold) if demand_threshold is not None else None
+            ),
+            "demand_demote": demand_demote,
             "reason": "_and_".join(reasons),
             "radiance_growth_pct": radiance_meta["radiance_growth_pct"],
             "radiance_confident": radiance_meta["radiance_confident"],
@@ -4834,14 +4939,19 @@ def _apply_market_viability_pass(
         pop_demoted = sum(1 for pe in pre_eval if pe[0])
         rent_demoted = sum(1 for pe in pre_eval if pe[1])
         econ_demoted = sum(1 for pe in pre_eval if pe[2])
+        demand_demoted = sum(1 for pe in pre_eval if pe[3])
         logger.info(
             "expansion_market_viability_pass: search_id=%s demoted=%d "
-            "pop_leg=%d rent_leg=%d econ_leg=%d "
+            "pop_leg=%d rent_leg=%d econ_leg=%d demand_leg=%d "
             "rent_pct_threshold=%.2f pop_percentile=%.2f pop_threshold=%.0f "
-            "economics_min=%.2f demotion_steps=%d cohort_n=%d",
+            "economics_min=%.2f demand_percentile=%.2f demand_threshold=%s "
+            "demotion_steps=%d cohort_n=%d demand_cohort_n=%d",
             search_id, demoted, pop_demoted, rent_demoted, econ_demoted,
+            demand_demoted,
             rent_pct_threshold, pop_percentile_threshold, pop_threshold,
-            economics_min, demotion_steps, len(pop_values),
+            economics_min, demand_percentile_threshold,
+            ("%.2f" % demand_threshold) if demand_threshold is not None else "None",
+            demotion_steps, len(pop_values), len(demand_values),
         )
     return out
 

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -2488,6 +2488,8 @@ def _make_viability_candidate(
     pop_reach: float | None = None,
     value_band: str | None = None,
     low_conf: bool = False,
+    realized_demand_30d: float | None = None,
+    realized_demand_branches: int | None = None,
 ) -> dict:
     sb: dict = {}
     if rent_pct is not None:
@@ -2503,6 +2505,10 @@ def _make_viability_candidate(
     fs: dict = {}
     if pop_reach is not None:
         fs["population_reach"] = pop_reach
+    if realized_demand_30d is not None:
+        fs["realized_demand_30d"] = realized_demand_30d
+    if realized_demand_branches is not None:
+        fs["realized_demand_branches"] = realized_demand_branches
     return {
         "id": id_,
         "parcel_id": id_,
@@ -2974,6 +2980,256 @@ def test_viability_growth_rescue_does_not_save_economics_leg(disable_market_viab
     assert flag["rent_demote"] is False, "growth should rescue rent leg"
     assert flag["economics_demote"] is True
     assert flag["reason"] == "economics_below_threshold"
+
+
+# ---------------------------------------------------------------------------
+# Realized-demand soft-demote leg (B3, "strong potential for sales"). Mirrors
+# the pop/rent/economics leg-isolation pattern. The leg fires on confident
+# bottom-quartile realized_demand_30d, gated by a minimum branch count, and
+# has no growth_rescue (mirrors the economics leg).
+# ---------------------------------------------------------------------------
+
+
+def _viability_cohort_with_demand_target(
+    *,
+    target_demand: float | None,
+    target_demand_branches: int | None = 5,
+    target_pop_reach: float = 80000.0,
+    target_rent_pct: float = 0.40,
+    target_rent_scope: str = "district_band_type",
+    target_economics: float | None = 80.0,
+) -> list[dict]:
+    """Background carries confident realized_demand_30d well above any p25.
+
+    Background demand spans 600..2200 (8 rows) so p25 lands near 750 with
+    ``method="inclusive"``. Background pop_reach also spans both sides of
+    its own p25 to keep the pop leg quiet on the target. Background rent
+    is low (0.40) so the rent leg stays quiet. Background economics is
+    unset so the econ leg cannot fire on background rows.
+    """
+    pops = [5000, 6000, 7000, 8000, 50000, 60000, 70000, 80000]
+    demands = [600.0, 800.0, 1000.0, 1200.0, 1500.0, 1800.0, 2000.0, 2200.0]
+    cohort = [
+        _make_viability_candidate(
+            id_=f"bg{i}",
+            final_score=80.0 - i,
+            rent_pct=0.40,
+            rent_scope="district_band_type",
+            pop_reach=p,
+            realized_demand_30d=d,
+            realized_demand_branches=5,
+        )
+        for i, (p, d) in enumerate(zip(pops, demands))
+    ]
+    target = _make_viability_candidate(
+        id_="target",
+        final_score=78.5,
+        rent_pct=target_rent_pct,
+        rent_scope=target_rent_scope,
+        pop_reach=target_pop_reach,
+        realized_demand_30d=target_demand,
+        realized_demand_branches=target_demand_branches,
+    )
+    if target_economics is not None:
+        target["economics_score"] = target_economics
+    cohort.insert(2, target)
+    return cohort
+
+
+def test_viability_demand_only_leg_fires(disable_market_viability_floors):
+    # Demand leg alone: rent low, pop above p25, economics healthy, no growth.
+    # target realized_demand_30d=400 sits in the bottom quartile of the
+    # cohort (p25 ≈ 750). target carries 5 branches (>= min 3).
+    # Expected: demote with reason="demand_low".
+    cohort = _viability_cohort_with_demand_target(
+        target_demand=400.0,
+        target_demand_branches=5,
+    )
+    starting_idx = next(i for i, c in enumerate(cohort) if c["id"] == "target")
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["population_demote"] is False
+    assert flag["rent_demote"] is False
+    assert flag["economics_demote"] is False
+    assert flag["demand_demote"] is True
+    assert flag["realized_demand_30d"] == 400.0
+    assert flag["realized_demand_branches"] == 5
+    assert flag["realized_demand_threshold"] is not None
+    assert flag["reason"] == "demand_low"
+    new_idx = next(i for i, c in enumerate(out) if c["id"] == "target")
+    # Default demotion is 6 steps, capped at the end of the list.
+    assert new_idx == min(
+        starting_idx + 6, len(out) - 1
+    ), "candidate should move down by EXPANSION_VIABILITY_DEMOTION_STEPS"
+
+
+def test_viability_demand_leg_skipped_when_branches_below_min(
+    disable_market_viability_floors,
+):
+    # Bottom-quartile realized_demand_30d but only 2 contributing branches
+    # → confidence gate fails → leg does NOT fire on the target. Position
+    # is not asserted: the cohort's bg0 / bg1 pop_reach (5k, 6k) sit below
+    # the pop-leg p25, so they shift around the target legitimately. The
+    # absence of market_viability_flag on the target alone proves the
+    # demand leg did not fire here.
+    cohort = _viability_cohort_with_demand_target(
+        target_demand=400.0,
+        target_demand_branches=2,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is None, "demand leg must not fire when branches < min"
+
+
+def test_viability_demand_leg_skipped_when_field_absent(
+    disable_market_viability_floors,
+):
+    # Both realized_demand_30d AND realized_demand_branches absent on the
+    # target (the flag-OFF / history_unavailable shape from the snapshot
+    # writer). Background still carries demand so the cohort cutoff is
+    # well-defined. The target's leg must NOT fire.
+    cohort = _viability_cohort_with_demand_target(
+        target_demand=None,
+        target_demand_branches=None,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is None, "demand leg must not fire when fields absent"
+
+
+def test_viability_demand_leg_no_growth_rescue(disable_market_viability_floors):
+    # Confidently low realized demand AND confidently positive radiance YoY
+    # at/above the default threshold. Mirrors
+    # test_viability_growth_rescue_does_not_save_economics_leg: the demand
+    # leg STILL fires because sales potential is a present-state signal,
+    # not a forward-state signal that growth can redeem.
+    cohort = _viability_cohort_with_demand_target(
+        target_demand=400.0,
+        target_demand_branches=5,
+    )
+    target_in = next(c for c in cohort if c["id"] == "target")
+    target_in["feature_snapshot_json"]["radiance_growth"] = {
+        "value_yoy_pct": 4.2,
+        "source_label": "blackmarble_district_yoy_simple",
+        "confident": True,
+        "pixel_count": 132,
+        "year_month": "2026-03",
+    }
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["demand_demote"] is True
+    assert "demand_low" in flag["reason"]
+    assert flag["radiance_confident"] is True
+    assert flag["radiance_growth_pct"] == 4.2
+
+
+def test_viability_demand_leg_skipped_when_cohort_too_small(
+    disable_market_viability_floors,
+):
+    # Fewer than 4 candidates have realized_demand_30d → demand_threshold
+    # is None and the leg is silent regardless of value. Use a cohort big
+    # enough to clear the outer pop-cohort guard (>=4 confident pop_reach
+    # values), but where only 2 rows carry realized_demand_30d.
+    pops = [5000, 6000, 7000, 8000, 50000, 60000, 70000, 80000]
+    cohort = [
+        _make_viability_candidate(
+            id_=f"bg{i}",
+            final_score=80.0 - i,
+            rent_pct=0.40,
+            rent_scope="district_band_type",
+            pop_reach=p,
+        )
+        for i, p in enumerate(pops)
+    ]
+    # Only 2 rows have realized_demand_30d; one of them is in the bottom of
+    # that 2-element set but the leg should still be silent.
+    cohort[0]["feature_snapshot_json"]["realized_demand_30d"] = 100.0
+    cohort[0]["feature_snapshot_json"]["realized_demand_branches"] = 5
+    cohort[1]["feature_snapshot_json"]["realized_demand_30d"] = 5000.0
+    cohort[1]["feature_snapshot_json"]["realized_demand_branches"] = 5
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    for c in out:
+        flag = c["score_breakdown_json"].get("market_viability_flag")
+        if flag is not None:
+            assert flag.get("demand_demote") is False
+            assert flag.get("realized_demand_threshold") is None
+
+
+def test_viability_demand_leg_skipped_when_kill_switch_off(
+    disable_market_viability_floors, monkeypatch,
+):
+    # EXPANSION_VIABILITY_DEMAND_LEG_ENABLED=False → leg silent even with
+    # otherwise-firing inputs. Patch every live ``settings`` reference the
+    # same way ``disable_market_viability_floors`` does, so this test is
+    # robust to test-order dependence on importlib.reload.
+    import sys
+
+    import app.core.config as config
+
+    seen_ids: set[int] = set()
+    for module in list(sys.modules.values()):
+        if module is None:
+            continue
+        candidate = getattr(module, "settings", None)
+        if candidate is None or id(candidate) in seen_ids:
+            continue
+        if not hasattr(candidate, "EXPANSION_VIABILITY_DEMAND_LEG_ENABLED"):
+            continue
+        seen_ids.add(id(candidate))
+        monkeypatch.setattr(
+            candidate, "EXPANSION_VIABILITY_DEMAND_LEG_ENABLED", False
+        )
+    if id(config.settings) not in seen_ids:
+        monkeypatch.setattr(
+            config.settings, "EXPANSION_VIABILITY_DEMAND_LEG_ENABLED", False
+        )
+
+    cohort = _viability_cohort_with_demand_target(
+        target_demand=400.0,
+        target_demand_branches=5,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is None, "kill switch must suppress the demand_demote decision"
+    # Snapshot fields remain on feature_snapshot_json — pipeline untouched.
+    fs = target["feature_snapshot_json"]
+    assert fs.get("realized_demand_30d") == 400.0
+    assert fs.get("realized_demand_branches") == 5
+
+
+def test_viability_all_four_legs_fire_with_compound_annotation(
+    disable_market_viability_floors,
+):
+    # Four-leg variant of test_viability_all_three_legs_fire_with_compound_annotation:
+    # pop below p25, rent high on confident scope, economics_score=60 < 65,
+    # realized_demand_30d=400 in the bottom quartile with 5 branches, no
+    # growth. Reason concatenates in stable order: pop, rent, econ, demand.
+    cohort = _viability_cohort_with_demand_target(
+        target_demand=400.0,
+        target_demand_branches=5,
+        target_pop_reach=4500.0,
+        target_rent_pct=0.85,
+        target_economics=60.0,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["population_demote"] is True
+    assert flag["rent_demote"] is True
+    assert flag["economics_demote"] is True
+    assert flag["demand_demote"] is True
+    assert flag["reason"] == (
+        "population_below_quartile_and_rent_high_and_economics_below_threshold"
+        "_and_demand_low"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the structural P2 gap in Faisal's directive clause "strong potential for sales":

1. **Flips** `EXPANSION_REALIZED_DEMAND_ENABLED` default from `false` → `true`. Production coverage check confirmed 100% of recent candidates carry ≥3 branches in their 1200 m catchment; median `realized_demand_30d` = 797 and p90 = 2,293 — well above the `_delivery_score` calibration reference of 200. The signal is now first-class, not opt-in.
2. **Adds** a fourth soft-demote leg `demand_demote` to `_apply_market_viability_pass`, mirroring the population leg's structure (per-search bottom-quartile cutoff, defensive missing-field semantics, single positional demote) and gated on `realized_demand_branches >= EXPANSION_VIABILITY_DEMAND_MIN_BRANCHES` (default 3). **No `growth_rescue`** — by the same precedent as the economics leg, present-state signals are not redeemed by forward-state signals. Conflating sales potential with radiance growth re-introduces the false-positive class this leg exists to suppress.
3. **Adds** kill switch `EXPANSION_VIABILITY_DEMAND_LEG_ENABLED` (default `true`) that surgically suppresses the demote decision without touching the realized-demand data pipeline (snapshots, memo phrasing, rerank emission remain fully populated).

This is a single-PR ship of what the original investigation framed as PR-A + PR-B, justified by the Bundle-C-style coverage finding and the kill switch. **Rolling back behavior post-merge does not require a code revert** — flip `EXPANSION_VIABILITY_DEMAND_LEG_ENABLED=false` (kill switch) or `EXPANSION_REALIZED_DEMAND_ENABLED=false` (full pipeline rollback to legacy behavior).

## Phase 1 verification summary

All investigation line numbers held on `main`; nothing drifted. Env-var names `EXPANSION_VIABILITY_DEMAND_PERCENTILE`, `EXPANSION_VIABILITY_DEMAND_MIN_BRANCHES`, `EXPANSION_VIABILITY_DEMAND_LEG_ENABLED` are collision-free across `app/`, `tests/`, `frontend/`.

Confirmed:
- `app/core/config.py:84-87` — `EXPANSION_REALIZED_DEMAND_ENABLED` (truthy-set pattern)
- `app/core/config.py:172-177` — viability settings (`float(os.getenv(...))` pattern)
- `app/services/expansion_advisor.py:4473-4846` — `_apply_market_viability_pass`
- `app/services/expansion_advisor.py:7930-7945` — snapshot writer with `branches >= 3` gate; `realized_demand_source` reports `history_unavailable` (flag off) vs `insufficient_history` (flag on but data missing)
- `tests/conftest.py:27-69` — `disable_market_viability_floors` fixture pattern reused for the kill-switch test

## Files changed

- `app/core/config.py`
  - `app/core/config.py:84-104` — flip `EXPANSION_REALIZED_DEMAND_ENABLED` default to `"true"` and update the comment with the coverage rationale.
  - `app/core/config.py:178-201` — three new settings adjacent to `EXPANSION_VIABILITY_POP_PERCENTILE`: `EXPANSION_VIABILITY_DEMAND_PERCENTILE` (0.25), `EXPANSION_VIABILITY_DEMAND_MIN_BRANCHES` (3), `EXPANSION_VIABILITY_DEMAND_LEG_ENABLED` (true).
- `app/services/expansion_advisor.py`
  - `app/services/expansion_advisor.py:4485-4527` — docstring updated to four-leg semantics, stable-order reason note, `demand` no-`growth_rescue` rationale.
  - `app/services/expansion_advisor.py:4543-4555` — settings reads via `getattr(settings, ..., default)` alongside the existing `radiance_yoy_threshold`.
  - `app/services/expansion_advisor.py:4699-4732` — per-search bottom-quartile demand cutoff (`statistics.quantiles` with `method="inclusive"`); silent when kill switch off, fewer than 4 confident values, or `quantiles` raises.
  - `app/services/expansion_advisor.py:4734-4750` — extended `_flag_inputs` return tuple to carry `demand_demote`, `demand_value`, `demand_branches`.
  - `app/services/expansion_advisor.py:4814-4843` — per-candidate evaluation: `demand_value`/`demand_branches` parsed defensively (NaN/Inf rejected, bool excluded); `demand_demote = confident AND demand_value < demand_threshold`; **no `growth_rescue`** branch.
  - `app/services/expansion_advisor.py:4858-4862` — `demote_indices` OR extended to include `demand_demote`.
  - `app/services/expansion_advisor.py:4869-4906` — stable-order `reasons` list now appends `"demand_low"` after `"economics_below_threshold"`; `market_viability_flag` dict gains `realized_demand_30d`, `realized_demand_branches`, `realized_demand_threshold`, `demand_demote`.
  - `app/services/expansion_advisor.py:4913-4929` — log line gains `demand_leg=%d`, `demand_percentile=%.2f`, `demand_threshold=%s`, `demand_cohort_n=%d`.
- `tests/test_expansion_advisor_service.py`
  - `tests/test_expansion_advisor_service.py:2484-2521` — `_make_viability_candidate` extended with optional `realized_demand_30d` / `realized_demand_branches` kwargs (kwargs-only, additive — every existing call is unaffected).
  - `tests/test_expansion_advisor_service.py:2982-3216` — seven new tests under a "Realized-demand soft-demote leg (B3)" header.

## Tests

`python -m pytest tests/test_expansion_advisor_service.py -v -k "viability"` — 24 passed, 89 deselected:

```
tests/test_expansion_advisor_service.py::test_viability_pass_fires_when_pop_below_p25 PASSED
tests/test_expansion_advisor_service.py::test_viability_pass_high_rent_high_pop_fires_rent_leg PASSED
tests/test_expansion_advisor_service.py::test_viability_pass_skips_low_confidence_rent_scope PASSED
tests/test_expansion_advisor_service.py::test_viability_pass_pop_missing_still_fires_rent_leg PASSED
tests/test_expansion_advisor_service.py::test_viability_pass_demotion_capped_at_end PASSED
tests/test_expansion_advisor_service.py::test_viability_pass_cohort_too_small PASSED
tests/test_expansion_advisor_service.py::test_viability_pass_p25_correctness PASSED
tests/test_expansion_advisor_service.py::test_viability_pass_stacks_with_value_band_pass PASSED
tests/test_expansion_advisor_service.py::test_market_viability_third_leg_rescue PASSED
tests/test_expansion_advisor_service.py::test_market_viability_third_leg_no_rescue_when_not_confident PASSED
tests/test_expansion_advisor_service.py::test_market_viability_third_leg_no_rescue_when_growth_below_threshold PASSED
tests/test_expansion_advisor_service.py::test_viability_pop_only_leg_fires PASSED
tests/test_expansion_advisor_service.py::test_viability_rent_only_leg_fires PASSED
tests/test_expansion_advisor_service.py::test_viability_economics_only_leg_fires PASSED
tests/test_expansion_advisor_service.py::test_viability_all_three_legs_fire_with_compound_annotation PASSED
tests/test_expansion_advisor_service.py::test_viability_growth_rescue_saves_pop_and_rent_legs_not_econ PASSED
tests/test_expansion_advisor_service.py::test_viability_growth_rescue_does_not_save_economics_leg PASSED
tests/test_expansion_advisor_service.py::test_viability_demand_only_leg_fires PASSED
tests/test_expansion_advisor_service.py::test_viability_demand_leg_skipped_when_branches_below_min PASSED
tests/test_expansion_advisor_service.py::test_viability_demand_leg_skipped_when_field_absent PASSED
tests/test_expansion_advisor_service.py::test_viability_demand_leg_no_growth_rescue PASSED
tests/test_expansion_advisor_service.py::test_viability_demand_leg_skipped_when_cohort_too_small PASSED
tests/test_expansion_advisor_service.py::test_viability_demand_leg_skipped_when_kill_switch_off PASSED
tests/test_expansion_advisor_service.py::test_viability_all_four_legs_fire_with_compound_annotation PASSED

====================== 24 passed, 89 deselected in 0.61s =======================
```

The seven new tests cover: leg fires alone with the correct `reason` and demotion distance; skipped when `branches < min`; skipped when fields are absent (the `history_unavailable` flag-OFF shape); fires regardless of confident positive radiance YoY (no-growth-rescue precedent); skipped when fewer than 4 confident demand values exist (`demand_threshold` is `None`); skipped when the kill switch is off (snapshot fields preserved on `feature_snapshot_json`); and the four-leg compound annotation `population_below_quartile_and_rent_high_and_economics_below_threshold_and_demand_low`.

## Frontend

No frontend changes in this PR. The frontend already handles `realized_demand_30d` permissively (`AdvisorySectionCards.tsx:144-148`, `lib/api/expansionAdvisor.ts:154-155`). Surfacing the new `demand_demote` flag in the UI is queued under the larger frontend pillar-tile work.

## Risk

Low. The leg is a positional reorder only (no `final_score` mutation), gated by an explicit confidence check, has a kill switch, and is enabled only when the cohort exceeds 4 confident values. The flag flip activates a snapshot path the writer already protects with `branches >= 3`. No migrations, no schema changes, no API contract changes.

## Run after merge

```sql
-- 1. Confirm the leg fires on real candidates and the annotation propagates.
--    Expected: ~25% of candidates with confident demand will show demand_demote=true.
SELECT
    COUNT(*) AS recent_candidates,
    COUNT(*) FILTER (
        WHERE (score_breakdown_json->'market_viability_flag'->>'demand_demote')::boolean
    ) AS demand_demote_count,
    COUNT(*) FILTER (
        WHERE score_breakdown_json->'market_viability_flag'->>'reason' LIKE '%demand_low%'
    ) AS reason_contains_demand_low,
    COUNT(*) FILTER (
        WHERE (score_breakdown_json->'market_viability_flag'->>'realized_demand_30d') IS NOT NULL
    ) AS demand_field_populated
FROM expansion_candidate
WHERE computed_at >= NOW() - INTERVAL '1 hour';

-- 2. Confirm the realized-demand pipeline is hot end-to-end after the flag flip.
--    Expected: the vast majority of candidates carry realized_demand_30d in feature_snapshot_json.
SELECT
    COUNT(*) AS recent_candidates,
    COUNT(*) FILTER (WHERE feature_snapshot_json ? 'realized_demand_30d') AS has_demand,
    COUNT(*) FILTER (
        WHERE feature_snapshot_json->>'realized_demand_source' = 'history_unavailable'
    ) AS source_history_unavailable,
    COUNT(*) FILTER (
        WHERE feature_snapshot_json->>'realized_demand_source' = 'insufficient_history'
    ) AS source_insufficient_history
FROM expansion_candidate
WHERE computed_at >= NOW() - INTERVAL '1 hour';

-- 3. Sanity-check the cohort cutoff distribution.
--    Expected: realized_demand_threshold is similar across recent searches and falls in
--    a sensible range given p25 ≈ 200-300 ratings/window for typical cohorts.
SELECT DISTINCT
    (score_breakdown_json->'market_viability_flag'->>'realized_demand_threshold')::numeric
        AS threshold,
    COUNT(*) AS candidates_at_this_threshold
FROM expansion_candidate
WHERE computed_at >= NOW() - INTERVAL '1 hour'
GROUP BY 1
ORDER BY 1;
```


---
_Generated by [Claude Code](https://claude.ai/code/session_0162Afv6c6TFnfS2o42bvUNT)_