### PR TITLE
fix(expansion_advisor): lift silent 36-row cap on candidate_location retrieval

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -139,6 +139,10 @@ class ExpansionAdvisorMeta(StrictResponseModel):
     excluded_sources: list[str] = Field(default_factory=list)
     degraded: bool = False
     error_class: str | None = None
+    # Pool diagnostics: explain why limit may be unsaturated.
+    pool_size: int | None = None
+    limit_requested: int | None = None
+    rows_returned: int | None = None
 
 
 class ExpansionAdvisorBrandProfileResponse(StrictResponseModel):
@@ -1075,6 +1079,11 @@ def create_expansion_search(
             "version": "expansion_advisor_v7",
             "parcel_source": "listings_only",
             "excluded_sources": ["arcgis_parcels", "hungerstation_poi", "suhail", "inferred_parcels"],
+            # Pool diagnostics: surface why limit may not be saturated. Matches
+            # `notes.coverage.candidates_evaluated` from the service layer.
+            "pool_size": (search_notes.get("coverage") or {}).get("candidates_evaluated"),
+            "limit_requested": req.limit,
+            "rows_returned": len(items),
         },
     }
 

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -6230,6 +6230,23 @@ def run_expansion_search(
     is_city_wide = not target_district_norm
     use_stratified = is_city_wide or len(target_district_norm) >= 2
 
+    # ── Probe candidate_location availability up front ──
+    # The active retrieval path is candidate_location when ≥10 Tier-1
+    # cluster primaries exist. The per-district cap denominator must match
+    # the retrieval universe; the arcgis_raw district count (~148) is the
+    # wrong denominator when listings live in candidate_location (only ~26
+    # districts have qualifying listings under default search params).
+    _cl_count = 0
+    try:
+        _cl_count = int(db.execute(text(
+            "SELECT COUNT(*) FROM candidate_location "
+            "WHERE is_cluster_primary = TRUE AND source_tier = 1 AND geom IS NOT NULL"
+        )).scalar() or 0)
+    except Exception as exc:
+        logger.warning("candidate_location count query failed, falling back to legacy: %s", exc)
+
+    use_candidate_location = _cl_count >= 10
+
     # Compute per-district cap dynamically.
     # Goal: spread _CANDIDATE_POOL_LIMIT slots across districts.
     # We estimate the district count from external_feature to set the cap,
@@ -6252,6 +6269,20 @@ def run_expansion_search(
         logger.info(
             "expansion_search stratified multi-district mode: target_count=%d per_district_cap=%d search_id=%s",
             len(target_district_norm), per_district_cap, search_id,
+        )
+    elif is_city_wide and use_candidate_location:
+        # candidate_location path: the retrieval universe is Tier-1 cluster
+        # primaries (~83 districts; only ~26 with qualifying listings under
+        # default params). Deriving the cap from arcgis_raw's ~148 districts
+        # silently collapses the pool — e.g. 2000 // 148 ≈ 13, clamped by
+        # _PER_DISTRICT_MIN_CAP to 5, gave a 36-row cap on the production
+        # QSR/store-showroom/80–500m² combination whose structural ceiling
+        # is 58. At current inventory no district has more than ~14
+        # qualifying listings, so MAX_CAP is functionally unbounded.
+        per_district_cap = _PER_DISTRICT_MAX_CAP
+        logger.info(
+            "expansion_search city-wide candidate_location mode: cl_count=%d per_district_cap=%d search_id=%s",
+            _cl_count, per_district_cap, search_id,
         )
     elif is_city_wide:
         try:
@@ -6312,18 +6343,17 @@ def run_expansion_search(
         except Exception:
             pass
 
-    # ── Check if candidate_location table is available (preferred path) ──
-    _cl_count = 0
-    try:
-        _cl_count = int(db.execute(text(
-            "SELECT COUNT(*) FROM candidate_location "
-            "WHERE is_cluster_primary = TRUE AND source_tier = 1 AND geom IS NOT NULL"
-        )).scalar() or 0)
-    except Exception as exc:
-        logger.warning("candidate_location count query failed, falling back to legacy: %s", exc)
-
-    use_candidate_location = _cl_count >= 10
+    # candidate_location availability (_cl_count, use_candidate_location)
+    # was probed earlier so the per-district cap could match the active
+    # retrieval universe.
     use_commercial_units = False
+
+    logger.info(
+        "expansion_advisor.candidate_pool_cap search_id=%s is_city_wide=%s "
+        "use_candidate_location=%s per_district_cap=%d candidate_pool_limit=%d cl_count=%d",
+        search_id, is_city_wide, use_candidate_location,
+        per_district_cap, _CANDIDATE_POOL_LIMIT, _cl_count,
+    )
 
     if use_candidate_location:
         rows = _query_candidate_location_pool(

--- a/tests/test_expansion_per_district_cap.py
+++ b/tests/test_expansion_per_district_cap.py
@@ -69,12 +69,20 @@ class _CapProbeDB:
 
     Pre-cap probes (column_exists, information_schema lookups) return
     empty/false results so the function can progress to the cap block.
+    The candidate_location count probe (now run before the cap calc to
+    let the city-wide branch detect the active retrieval path) returns 0
+    so the legacy fallback path is taken — equivalent to the prior test
+    behaviour where _cl_count was never read at this point.
     The first post-cap execute() raises _StopAfterCap to short-circuit.
     """
 
     _PRE_CAP_SQL_MARKERS = (
         "information_schema.columns",
     )
+    _CANDIDATE_LOCATION_COUNT_MARKER = "FROM candidate_location"
+
+    def __init__(self, *, cl_count: int = 0):
+        self._cl_count = cl_count
 
     def begin_nested(self):
         return _Nested()
@@ -85,6 +93,11 @@ class _CapProbeDB:
             if marker in sql:
                 # Return "column not found" so _cached_column_exists → False.
                 return _Result([])
+        if (
+            self._CANDIDATE_LOCATION_COUNT_MARKER in sql
+            and "is_cluster_primary" in sql
+        ):
+            return _Result([self._cl_count])
         raise _StopAfterCap()
 
 
@@ -239,3 +252,97 @@ def test_city_wide_branch_unchanged(caplog: pytest.LogCaptureFixture) -> None:
 def test_headroom_multiplier_constant_value() -> None:
     # Locks the multiplier so future tweaks cause a visible test break.
     assert expansion_service._PER_DISTRICT_HEADROOM_MULTIPLIER == 3
+
+
+_CL_LOG_RE = re.compile(
+    r"expansion_search city-wide candidate_location mode: "
+    r"cl_count=(\d+) per_district_cap=(\d+) search_id="
+)
+
+
+def test_per_district_cap_uses_max_cap_for_candidate_location_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Confirms the city-wide candidate_location branch uses
+    _PER_DISTRICT_MAX_CAP unconditionally.
+
+    Regression for the silent 36-row cap that occurred when
+    per_district_cap was derived from arcgis_raw's ~148-district count
+    (2000 // 148 ≈ 13, clamped to MIN_CAP=5) instead of the
+    candidate_location universe. The structural ceiling for
+    restaurant-suitable Tier-1 primaries in Riyadh under default search
+    params is 58; raising the cap from 5 to MAX_CAP unblocks rows 37-58.
+    See app/services/expansion_advisor.py: city-wide candidate_location
+    branch in run_expansion_search.
+    """
+    clear_expansion_caches()
+    caplog.clear()
+    caplog.set_level(logging.INFO, logger="app.services.expansion_advisor")
+
+    # _cl_count >= 10 forces the candidate_location retrieval path.
+    with pytest.raises(_StopAfterCap):
+        run_expansion_search(
+            _CapProbeDB(cl_count=83),
+            search_id="search-test",
+            brand_name="Brand",
+            category="burger",
+            service_model="qsr",
+            min_area_m2=80,
+            max_area_m2=500,
+            target_area_m2=200,
+            limit=100,
+            target_districts=None,  # city-wide
+        )
+
+    cap_used: int | None = None
+    for record in caplog.records:
+        match = _CL_LOG_RE.search(record.getMessage())
+        if match:
+            assert int(match.group(1)) == 83
+            cap_used = int(match.group(2))
+            break
+
+    assert cap_used == expansion_service._PER_DISTRICT_MAX_CAP, (
+        "city-wide candidate_location path must use _PER_DISTRICT_MAX_CAP "
+        "(=200) so the structural pool ceiling — not an arcgis_raw-derived "
+        "denominator — bounds the result. Got cap=%r." % cap_used
+    )
+
+    # The arcgis_raw branch must NOT fire when candidate_location is used.
+    assert not any(
+        "stratified mode: district_count=" in r.getMessage()
+        for r in caplog.records
+    ), (
+        "arcgis_raw district-count branch must be skipped when "
+        "use_candidate_location=True"
+    )
+
+
+def test_city_wide_legacy_branch_runs_when_candidate_location_unavailable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When candidate_location has <10 Tier-1 primaries the city-wide
+    branch falls back to the arcgis_raw district-count formula
+    (unchanged from the pre-patch behaviour)."""
+    clear_expansion_caches()
+    caplog.clear()
+    caplog.set_level(logging.INFO, logger="app.services.expansion_advisor")
+
+    with pytest.raises(_StopAfterCap):
+        run_expansion_search(
+            _CapProbeDB(cl_count=0),  # legacy path
+            search_id="search-test",
+            brand_name="Brand",
+            category="burger",
+            service_model="qsr",
+            min_area_m2=80,
+            max_area_m2=500,
+            target_area_m2=200,
+            limit=50,
+            target_districts=None,
+        )
+
+    # The candidate_location info-log must NOT fire for the legacy path.
+    assert not any(
+        _CL_LOG_RE.search(r.getMessage()) for r in caplog.records
+    ), "legacy path must not log the candidate_location cap message"


### PR DESCRIPTION
## Summary

The city-wide `per_district_cap` was being derived from `COUNT(DISTINCT district_label)` against `public.riyadh_parcels_arcgis_raw` (~148 districts). With `_CANDIDATE_POOL_LIMIT = 2000` that collapsed to `floor(2000/148) = 13`, then the `_PER_DISTRICT_MIN_CAP = 5` floor stamped it at **5**. The candidate_location retrieval path applies that cap as `WHERE district_rank <= per_district_cap` (`app/services/expansion_advisor.py:5418`), capping QSR / store-showroom / 80–500 m² searches at **36 rows** — even though the structural ceiling for that combination is **58**.

The arcgis_raw denominator is the wrong universe when the candidate_location path is active: the listings universe is ~83 Tier-1 cluster-primary districts, of which only ~26 have qualifying inventory under default search params. No single district has more than ~14 qualifying listings today, so `_PER_DISTRICT_MAX_CAP = 200` is functionally unbounded at current inventory.

## Phase 1 verification

Re-grepped on the working tree against the stated reference points:

| Reference | Brief said | On `main` | Status |
|---|---|---|---|
| `run_expansion_search` | `:5775` | `:5775` | ✅ |
| `is_city_wide = not target_district_norm` | `:6230-6300` block | `:6230` | ✅ |
| `district_count_row` query against `riyadh_parcels_arcgis_raw` | inside the same block | `:6258-6262` | ✅ |
| `per_district_cap = max(MIN_CAP, min(MAX_CAP, _CANDIDATE_POOL_LIMIT // …))` | inside the same block | `:6263-6266` | ✅ |
| `per_district_cap` bound into `sql_params` | `:6256-6266` neighborhood | `:6291` | ✅ |
| `WHERE district_rank <= CAST(:per_district_cap AS integer)` | `:5418` | `:5418` | ✅ |
| `_cl_count` probe | `:6315-6340` | `:6315-6325` | ✅ |
| Constants `_CANDIDATE_POOL_LIMIT=2000`, `_PER_DISTRICT_MIN_CAP=5`, `_PER_DISTRICT_MAX_CAP=200`, `_PER_DISTRICT_HEADROOM_MULTIPLIER=3` | `:37-41` | `:37-41` | ✅ |

Branch order on `main` matches the brief: `_cl_count` was probed **after** `per_district_cap` was computed. This patch lifts the probe up to before the cap calc so the city-wide branch can pick the right denominator.

## Files changed

- **`app/services/expansion_advisor.py`** — Moved the `_cl_count` candidate_location probe up before the `per_district_cap` block. Added a new branch `elif is_city_wide and use_candidate_location: per_district_cap = _PER_DISTRICT_MAX_CAP`. The arcgis_raw fallback `elif is_city_wide:` block remains for the `_cl_count < 10` case (untouched). Added an info log at retrieval time naming the cap, branch, and pool limit. Removed the duplicate `_cl_count` probe at the original location and replaced with a brief lead-in comment.
- **`app/api/expansion_advisor.py`** — Added `pool_size`, `limit_requested`, `rows_returned` to `ExpansionAdvisorMeta` and populated them in the `POST /v1/expansion-advisor/searches` response from the existing `notes.coverage.candidates_evaluated` field. No changes to the legacy strict response model semantics — `extra="forbid"` remains, the new fields are explicit `int | None`.
- **`tests/test_expansion_per_district_cap.py`** — Updated `_CapProbeDB` to stub the new candidate_location count probe with a configurable `cl_count`. Added two regression tests:
  - `test_per_district_cap_uses_max_cap_for_candidate_location_path` — confirms `cl_count=83 ⇒ per_district_cap = _PER_DISTRICT_MAX_CAP` and the arcgis_raw branch never fires.
  - `test_city_wide_legacy_branch_runs_when_candidate_location_unavailable` — confirms `cl_count=0` skips the new branch (legacy fallback unchanged).

## Test output

```
$ pytest tests/test_expansion_per_district_cap.py -v
============================== 11 passed in 2.02s ==============================

$ pytest tests/test_expansion_advisor_service.py tests/test_expansion_advisor_radiance.py
======================== 113 passed, 7 skipped in 1.36s ========================
(skipped tests in radiance suite require a real PostGIS DB)

$ pytest tests/test_expansion_advisor_api.py
============================== 18 passed in 6.15s ==============================

$ pytest tests/test_expansion_advisor.py tests/test_expansion_advisor_regression.py tests/test_expansion_advisor_production_patch.py
============================== 245 passed in 1.34s ==============================

$ python -m py_compile app/services/expansion_advisor.py app/api/expansion_advisor.py
PY_COMPILE OK
```

## Test plan
- [x] Existing `tests/test_expansion_per_district_cap.py` regression tests still pass with the new branch order.
- [x] New regression test confirms `_PER_DISTRICT_MAX_CAP` is used for the city-wide candidate_location branch.
- [x] New regression test confirms the legacy arcgis_raw branch fires when `cl_count < 10`.
- [x] Multi-district targeted branch (`test_per_district_cap_matches_new_formula`) untouched.
- [x] Single-district branch (`test_single_district_uses_max_cap_default`) untouched.
- [x] B1.5 radiance suite still passes (skipped tests are DB-gated).
- [x] API tests pass — strict response-model schema accepts the new pool fields.
- [ ] Run after merge: confirm searches return up to 58 rows on QSR / store-showroom / 80-500 m² requests with `limit ≥ 58` (see SQL block below).

## Run after merge

```sql
-- 1. Confirm new searches return up to the structural ceiling.
-- Expected: searches with limit >= 58 return up to 58 rows;
-- searches with limit < 58 return limit rows.
SELECT
    s.id,
    s.request_json->>'limit'         AS limit_sent,
    s.request_json->>'service_model' AS service_model,
    (SELECT COUNT(*) FROM expansion_candidate ec WHERE ec.search_id = s.id) AS rows_returned
FROM expansion_search s
WHERE s.created_at >= NOW() - INTERVAL '1 hour'
ORDER BY s.created_at DESC
LIMIT 20;

-- 2. Confirm geographic distribution is reasonable post-fix.
-- Expected: Al Wurud (الورود) shows up to 14 candidates;
-- no single district dominates pathologically.
SELECT
    cu.neighborhood AS district,
    COUNT(*)        AS candidates_in_district
FROM expansion_candidate ec
JOIN commercial_unit cu ON cu.aqar_id = ec.parcel_id
WHERE ec.search_id = (
    SELECT id FROM expansion_search
    WHERE created_at >= NOW() - INTERVAL '1 hour'
      AND request_json->>'service_model' = 'qsr'
    ORDER BY created_at DESC LIMIT 1
)
GROUP BY cu.neighborhood
ORDER BY COUNT(*) DESC, cu.neighborhood;

-- 3. Confirm the new log line is firing.
-- (run from kubectl logs or whatever log access SCCC provides)
-- grep "candidate_pool_cap" /path/to/logs/expansion-advisor.log | head
-- grep "city-wide candidate_location mode"  /path/to/logs/expansion-advisor.log | head
```

## Directive context

Faisal's directive ("well-populated areas with strong potential for sales and business growth") was being silently undermined by this cap — even when the directive's gates and demote legs work correctly, they only operated on 36 of the 58 available candidates. Restoring the full pool is a precondition for accurate B1+B2 calibration of the radiance threshold and demote-on-decline.

## Risk

Low. Change is scoped to a single elif branch in `run_expansion_search`. The arcgis_raw fallback path, the multi-district headroom formula, and `_query_candidate_location_pool`'s SQL are untouched. No new env vars, no constant changes. The new meta fields are additive and nullable.

https://claude.ai/code/session_01SFFQbtgZP9Umtv6HhXvtHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFFQbtgZP9Umtv6HhXvtHW)_