### PR TITLE
feat(expansion_advisor): surface hard-floor drop counts in API response meta

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -143,6 +143,12 @@ class ExpansionAdvisorMeta(StrictResponseModel):
     pool_size: int | None = None
     limit_requested: int | None = None
     rows_returned: int | None = None
+    # Hard-floor pre-pass diagnostics: per-leg drop counts and the thresholds
+    # in effect, so operators can interpret unsaturated searches without
+    # consulting application logs. Populated when the directive's hard floors
+    # fired during `_apply_market_viability_pass`.
+    hard_floor_drops: dict[str, int] | None = None
+    hard_floor_thresholds: dict[str, float] | None = None
 
 
 class ExpansionAdvisorBrandProfileResponse(StrictResponseModel):
@@ -1084,6 +1090,16 @@ def create_expansion_search(
             "pool_size": (search_notes.get("coverage") or {}).get("candidates_evaluated"),
             "limit_requested": req.limit,
             "rows_returned": len(items),
+            # Hard-floor pre-pass diagnostics. None when the pre-pass dropped
+            # nothing (so the response stays unchanged for searches where no
+            # gate fired). Sourced from `notes.viability.hard_floors` written
+            # by `_apply_market_viability_pass`.
+            "hard_floor_drops": (
+                ((search_notes.get("viability") or {}).get("hard_floors") or {}).get("drops")
+            ),
+            "hard_floor_thresholds": (
+                ((search_notes.get("viability") or {}).get("hard_floors") or {}).get("thresholds")
+            ),
         },
     }
 

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -4481,6 +4481,7 @@ def _apply_market_viability_pass(
     population_hard_floor: int | None = None,
     commercial_hard_floor: int | None = None,
     construction_buffer_m: float | None = None,
+    diagnostics: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Demote candidates that are confidently bad on the CEO-directive legs.
 
@@ -4669,6 +4670,25 @@ def _apply_market_viability_pass(
                 "construction_buffer_m": cp_buffer_m,
             },
         )
+
+    # Surface the per-leg drop counts and the thresholds in effect to the
+    # caller so the API meta can explain unsaturated-limit responses without
+    # needing kubectl logs. Always populated when ``diagnostics`` is provided
+    # — even when nothing was dropped, so the response shape stays stable.
+    if diagnostics is not None:
+        diagnostics["hard_floors"] = {
+            "drops": {
+                "dropped_population": dropped_population,
+                "dropped_commercial": dropped_commercial,
+                "dropped_construction": dropped_construction,
+                "remaining": len(survivors),
+            },
+            "thresholds": {
+                "hard_floor_pop_threshold": pop_floor,
+                "hard_floor_brand_threshold": bp_floor,
+                "hard_floor_construction_buffer_m": cp_buffer_m,
+            },
+        }
 
     candidates = survivors
     if not candidates or len(candidates) < 4:
@@ -8611,7 +8631,12 @@ def run_expansion_search(
     # both rent and population. Soft positional pass; runs after value_band so
     # demotions stack when the same row is both above-market and high-rent +
     # low-pop, and before truncation/rerank so the LLM sees post-pass order.
-    candidates = _apply_market_viability_pass(candidates, search_id=search_id)
+    viability_diagnostics: dict[str, Any] = {}
+    candidates = _apply_market_viability_pass(
+        candidates,
+        search_id=search_id,
+        diagnostics=viability_diagnostics,
+    )
 
     candidates = candidates[:limit]
 
@@ -8904,6 +8929,12 @@ def run_expansion_search(
             ) if _districts_with_no_candidates else None,
         }
         search_notes: dict[str, Any] = {"coverage": coverage_meta}
+        # Surface the hard-floor pre-pass diagnostics — per-leg drop counts
+        # and the thresholds in effect — so the API meta can explain why the
+        # requested limit may not be saturated. Operators otherwise have no
+        # signal beyond pool_size/rows_returned.
+        if viability_diagnostics:
+            search_notes["viability"] = viability_diagnostics
         db.execute(
             text(
                 "UPDATE expansion_search "

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -3233,6 +3233,116 @@ def test_viability_all_four_legs_fire_with_compound_annotation(
 
 
 # ---------------------------------------------------------------------------
+# Hard-floor diagnostics: surface per-leg drop counts to the caller so the
+# API meta can explain unsaturated-limit responses.
+# ---------------------------------------------------------------------------
+
+
+def test_viability_pass_diagnostics_records_hard_floor_drops_per_leg(monkeypatch):
+    """Regression: when the directive's hard-floor pre-pass drops candidates,
+    the optional ``diagnostics`` dict captures per-leg drop counts and the
+    thresholds in effect. Without this, operators receive
+    ``pool_size: N, rows_returned: M`` with no signal as to which gate
+    filtered which candidates — they would have to consult kubectl logs to
+    interpret the gap.
+    """
+    # Production thresholds, set explicitly so the test is independent of
+    # whatever defaults are configured at the moment.
+    import app.services.expansion_advisor as svc
+
+    monkeypatch.setattr(svc.settings, "EXPANSION_VIABILITY_POPULATION_HARD_FLOOR", 20000)
+    monkeypatch.setattr(svc.settings, "EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR", 1)
+    monkeypatch.setattr(svc.settings, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M", 75.0)
+
+    # Synthetic cohort spanning all four hard-floor outcomes:
+    #   * one survivor that clears every floor
+    #   * one drop on population (below 20k)
+    #   * one drop on commercial floor (zero unique brands)
+    #   * one drop on construction proximity (polygon within buffer)
+    cohort = [
+        {
+            "id": "ok",
+            "parcel_id": "ok",
+            "final_score": 80.0,
+            "score_breakdown_json": {},
+            "feature_snapshot_json": {
+                "population_reach": 50000.0,
+                "brand_presence": {"unique_brands": 5},
+                "construction_proximity": {"polygon_count": 0},
+            },
+        },
+        {
+            "id": "drop_pop",
+            "parcel_id": "drop_pop",
+            "final_score": 79.0,
+            "score_breakdown_json": {},
+            "feature_snapshot_json": {
+                "population_reach": 5000.0,
+                "brand_presence": {"unique_brands": 5},
+                "construction_proximity": {"polygon_count": 0},
+            },
+        },
+        {
+            "id": "drop_brand",
+            "parcel_id": "drop_brand",
+            "final_score": 78.0,
+            "score_breakdown_json": {},
+            "feature_snapshot_json": {
+                "population_reach": 50000.0,
+                "brand_presence": {"unique_brands": 0},
+                "construction_proximity": {"polygon_count": 0},
+            },
+        },
+        {
+            "id": "drop_constr",
+            "parcel_id": "drop_constr",
+            "final_score": 77.0,
+            "score_breakdown_json": {},
+            "feature_snapshot_json": {
+                "population_reach": 50000.0,
+                "brand_presence": {"unique_brands": 5},
+                "construction_proximity": {"polygon_count": 3},
+            },
+        },
+    ]
+
+    diagnostics: dict = {}
+    out = _apply_market_viability_pass(
+        list(cohort), search_id="t", diagnostics=diagnostics
+    )
+
+    survivor_ids = {c["id"] for c in out}
+    assert survivor_ids == {"ok"}
+
+    assert "hard_floors" in diagnostics
+    drops = diagnostics["hard_floors"]["drops"]
+    assert drops == {
+        "dropped_population": 1,
+        "dropped_commercial": 1,
+        "dropped_construction": 1,
+        "remaining": 1,
+    }
+
+    thresholds = diagnostics["hard_floors"]["thresholds"]
+    assert thresholds == {
+        "hard_floor_pop_threshold": 20000,
+        "hard_floor_brand_threshold": 1,
+        "hard_floor_construction_buffer_m": 75.0,
+    }
+
+
+def test_viability_pass_diagnostics_unchanged_when_caller_omits_kwarg(
+    disable_market_viability_floors,
+):
+    """Backwards-compat: existing callers that don't pass ``diagnostics`` must
+    see no behavior change. Return type stays a list of candidates only."""
+    cohort = _viability_cohort(target_pop_reach=4500.0, target_rent_pct=0.85)
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    assert isinstance(out, list)
+    assert all(isinstance(c, dict) for c in out)
+
+
+# ---------------------------------------------------------------------------
 # Bug A & Bug B regression coverage.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Operators currently receive `pool_size: 62, limit_requested: 100, rows_returned: 40` and have no signal as to why the result is unsaturated. The 22-row gap between pool and result is the directive's hard-floor pre-pass firing as designed — `population_floor=20000`, `brand_presence=1`, `construction=75m`. This patch surfaces the per-leg drop counts and the thresholds in effect, so operators can interpret unsaturated searches without having to consult application logs. Pure plumbing of values that already exist; no behavior change, no threshold tuning, no new computation.

## Phase 1 verification (against the live working tree)

- Hard-floor pre-pass: `app/services/expansion_advisor.py:4582-4673` — counts (`dropped_population`, `dropped_commercial`, `dropped_construction`) initialized at `4583-4585`; `logger.info("market_viability_hard_floors", …)` at `4659-4671`.
- `_apply_market_viability_pass` defined at `app/services/expansion_advisor.py:4473`. Pre-patch, the return type was `list[dict[str, Any]]` only — no diagnostics in the return shape.
- Call site: `app/services/expansion_advisor.py:8614` (inside `run_expansion_search`).
- `search_notes` is constructed at `app/services/expansion_advisor.py:8878` (initialized empty) and populated at `8906` with `{"coverage": coverage_meta}`. Because `search_notes` does not yet exist in scope at the call site (`8614`), Shape A (mutating an already-existing notes dict) does not apply directly. This patch uses an optional `diagnostics: dict | None` kwarg — the function mutates it when provided. The local diagnostics dict is then attached to `search_notes` later when the notes dict is assembled. This keeps the return signature unchanged and avoids touching the 25+ existing callers/tests of `_apply_market_viability_pass`.
- `ExpansionAdvisorMeta` defined at `app/api/expansion_advisor.py:136-145`; meta-construction site at `app/api/expansion_advisor.py:1063-1087` with `pool_size` sourced from `(search_notes.get("coverage") or {}).get("candidates_evaluated")` at `1084`.

## Files changed

- `app/services/expansion_advisor.py`
  - `_apply_market_viability_pass` signature gains `diagnostics: dict[str, Any] | None = None` (line `4485`).
  - After the existing `logger.info` emission, a stable `diagnostics["hard_floors"] = {"drops": {...}, "thresholds": {...}}` is written when the kwarg is provided (lines `4673-4690`).
  - The call site at `8614` allocates `viability_diagnostics: dict[str, Any] = {}` and passes it through.
  - At `search_notes` construction (`8906-8911`), the populated diagnostics are attached under `search_notes["viability"]`.
- `app/api/expansion_advisor.py`
  - `ExpansionAdvisorMeta` gains `hard_floor_drops: dict[str, int] | None` and `hard_floor_thresholds: dict[str, float] | None` (lines `146-151`).
  - Meta dict at the response-construction site (lines `1095-1102`) reads them from `search_notes["viability"]["hard_floors"]`.
- `tests/test_expansion_advisor_service.py`
  - New `test_viability_pass_diagnostics_records_hard_floor_drops_per_leg`: synthetic four-candidate cohort exercising population, brand, and construction-proximity drops; asserts the `diagnostics` dict captures per-leg counts and the production thresholds (20000 / 1 / 75.0).
  - New `test_viability_pass_diagnostics_unchanged_when_caller_omits_kwarg`: backwards-compat — return type stays a candidate list when `diagnostics` is omitted.

## Test results (Phase 3)

```
$ pytest tests/test_expansion_advisor_service.py -v
============================= 115 passed in 1.21s ==============================

$ pytest tests/test_expansion_advisor_api.py -v
======================== 18 passed, 4 warnings in 7.39s ========================

$ pytest tests/test_expansion_per_district_cap.py -v
============================== 11 passed in 0.89s ==============================

$ python -m py_compile app/services/expansion_advisor.py app/api/expansion_advisor.py
OK
```

The two new tests pass; no existing tests required changes (the `diagnostics` kwarg is optional and the return type is unchanged).

## Constraints honored

- No threshold changes — population floor stays 20k, brand floor stays 1, construction buffer stays 75m.
- `logger.info("market_viability_hard_floors", …)` emission is preserved alongside the new meta surface.
- No new env vars; the thresholds being surfaced are existing config values.
- No frontend changes — fields are available to the frontend whenever it chooses to render them.
- Single PR with service-side capture, API model fields, meta plumbing, and tests shipping together.

## Run after merge

```sql
-- 1. Confirm the new meta fields are populated for recent searches.
--    Search the notes column for the new viability.hard_floors structure.
SELECT
    s.id,
    s.created_at,
    s.request_json->>'limit'                                                AS limit_sent,
    (SELECT COUNT(*) FROM expansion_candidate ec
     WHERE ec.search_id = s.id)                                             AS rows_returned,
    s.notes->'coverage'->>'candidates_evaluated'                            AS pool_size,
    s.notes->'viability'->'hard_floors'->'drops'->>'dropped_population'     AS dropped_pop,
    s.notes->'viability'->'hard_floors'->'drops'->>'dropped_commercial'     AS dropped_brand,
    s.notes->'viability'->'hard_floors'->'drops'->>'dropped_construction'   AS dropped_constr,
    s.notes->'viability'->'hard_floors'->'drops'->>'remaining'              AS remaining
FROM expansion_search s
WHERE s.created_at >= NOW() - INTERVAL '1 hour'
ORDER BY s.created_at DESC
LIMIT 5;

-- Expected: searches where the hard floors fired have dropped_pop /
-- dropped_brand / dropped_constr populated. The four counts should
-- sum-and-relate so that:
--   pool_size - (dropped_pop + dropped_brand + dropped_constr) = remaining ≈ rows_returned
-- (Off-by-a-few is fine because score_dedup may also fire.)
-- Searches where no hard floors fired will have NULL under viability.

-- 2. Sanity: thresholds should match config defaults until env vars change.
SELECT
    s.id,
    s.notes->'viability'->'hard_floors'->'thresholds'->>'hard_floor_pop_threshold'           AS pop_t,
    s.notes->'viability'->'hard_floors'->'thresholds'->>'hard_floor_brand_threshold'         AS brand_t,
    s.notes->'viability'->'hard_floors'->'thresholds'->>'hard_floor_construction_buffer_m'   AS constr_buf
FROM expansion_search s
WHERE s.created_at >= NOW() - INTERVAL '1 hour'
  AND s.notes ? 'viability'
ORDER BY s.created_at DESC
LIMIT 1;

-- Expected: pop_t=20000, brand_t=1, constr_buf=75.
```

https://claude.ai/code/session_018D1fcqaQ4DiAgdfMNFqHoT

---
_Generated by [Claude Code](https://claude.ai/code/session_018D1fcqaQ4DiAgdfMNFqHoT)_