### PR TITLE
Add radiance-growth soft-demote leg to market viability pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,16 @@ SUHAIL_API_KEY=
 GOOGLE_PLACES_API_KEY=
 FOURSQUARE_API_KEY=
 
+# ---- Expansion Advisor: market-viability radiance-growth demote leg ----
+# YoY radiance growth (%) below which the radiance-growth leg of
+# _apply_market_viability_pass soft-demotes a candidate. Operator is
+# strict `<`. Default 0.0 ships inert (calibration is a follow-up).
+EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD=0.0
+# Kill switch for the radiance-growth demote leg. Setting to `false`
+# leaves the snapshot field and advisory `radiance_growth_pass` gate
+# untouched — only the soft-demote behavior is suppressed.
+EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED=true
+
 AUTH_MODE=disabled     # disabled | api_key | oidc
 # API_KEY=changeme      # used when AUTH_MODE=api_key and API_KEYS_JSON unset
 # API_KEYS_JSON={"user-1":"key-1","user-2":"key-2"}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -224,6 +224,32 @@ class Settings:
     EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD: float = float(
         os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD", "0.0")
     )
+    # Demote threshold for the radiance-growth leg of
+    # _apply_market_viability_pass (CEO directive pillar 3 — "strong
+    # potential for business growth"). When ``radiance_growth.confident``
+    # is True and ``value_yoy_pct`` < this threshold, the candidate is
+    # soft-demoted by the same positional mechanism as the population /
+    # rent / economics / demand legs. Operator is strict ``<``. Ships at
+    # 0.0 (inert: with the post-B1.5 distribution, zero confident
+    # districts sit below 0% YoY) — calibration is a separate follow-up
+    # patch once the 1.46% modal cluster is characterized. Distinct from
+    # ``EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD`` above (which drives
+    # the rescue side, operator ``>=``); splitting the knobs prevents
+    # calibrating one from silently affecting the other.
+    EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD: float = float(
+        os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD", "0.0")
+    )
+    # Kill switch for the radiance-growth demote leg. Setting this to
+    # ``false`` suppresses the leg's demote decision while leaving the
+    # ``radiance_growth`` snapshot field (and the advisory
+    # ``radiance_growth_pass`` gate emission) fully intact — only the
+    # soft-demote behavior is suppressed. The ``GROWTH`` disambiguator
+    # is intentional: multiple Black Marble metrics may land later, and
+    # the env var is the operator-facing name.
+    EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED: bool = (
+        os.getenv("EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED", "true").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
     # Hard floors (CEO directive — broader data + filter low-potential
     # locations). Unlike the soft demotion legs above, these are absolute
     # drops applied before the 3-of-3 conjunction. A value of 0 disables

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -4485,7 +4485,7 @@ def _apply_market_viability_pass(
 ) -> list[dict[str, Any]]:
     """Demote candidates that are confidently bad on the CEO-directive legs.
 
-    Four independent legs, soft-demote on any (single demote, never compounded):
+    Five independent legs, soft-demote on any (single demote, never compounded):
 
       * Population leg (clause 1, "high population density") — fires when the
         per-search bottom-quartile gate fails AND the radiance growth signal
@@ -4512,6 +4512,21 @@ def _apply_market_viability_pass(
         isolation via ``EXPANSION_VIABILITY_DEMAND_LEG_ENABLED=false``;
         the snapshot pipeline (and the ``realized_demand_30d`` /
         ``realized_demand_branches`` annotation) remain fully populated.
+      * Radiance-growth leg (Pillar 3 of Faisal's directive, "strong
+        potential for business growth", B1+B2) — fires when
+        ``feature_snapshot_json["radiance_growth"].confident`` is True
+        AND ``value_yoy_pct`` < ``EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD``
+        (operator strict ``<``). NO growth rescue: a leg whose own signal
+        is forward-looking cannot self-rescue; mirrors the economics and
+        demand legs. Distinct from
+        ``EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD`` which drives the
+        rescue side (operator ``>=``) for the population and rent legs;
+        splitting the knobs prevents calibrating one from silently
+        affecting the other. Disable in isolation via
+        ``EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED=false``; the
+        advisory ``radiance_growth_pass`` gate emission remains intact —
+        only the soft-demote behavior is suppressed. Ships at threshold
+        ``0.0`` (inert by default).
 
     The growth-rescue signal reads ``feature_snapshot_json["radiance_growth"]``
     (NASA Black Marble VNP46A3). When that signal is confident and YoY growth
@@ -4524,7 +4539,7 @@ def _apply_market_viability_pass(
     minimum). Positional reorder only, does not mutate final_score. Writes
     ``market_viability_flag`` to score_breakdown_json with the legs that fired
     encoded as a stable ``_and_``-joined string in the ``reason`` field
-    (stable order: population, rent, economics, demand).
+    (stable order: population, rent, economics, demand, radiance_growth).
     """
     if not candidates:
         return candidates
@@ -4557,6 +4572,12 @@ def _apply_market_viability_pass(
     ))
     demand_leg_enabled = bool(getattr(
         settings, "EXPANSION_VIABILITY_DEMAND_LEG_ENABLED", True
+    ))
+    radiance_yoy_demote_threshold = float(getattr(
+        settings, "EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD", 0.0
+    ))
+    radiance_growth_leg_enabled = bool(getattr(
+        settings, "EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED", True
     ))
 
     # ── CEO directive: hard floors (broader data + filter low-potential) ──
@@ -4763,12 +4784,13 @@ def _apply_market_viability_pass(
     def _flag_inputs(
         c: dict[str, Any]
     ) -> tuple[
-        bool, bool, bool, bool,
+        bool, bool, bool, bool, bool,
         float, str | None, float, float | None, dict[str, Any],
         float | None, int | None,
     ]:
         # Returns:
         #   (pop_demote, rent_demote, econ_demote, demand_demote,
+        #    radiance_growth_demote,
         #    rent_pct, rent_scope, pop_reach, economics_score, radiance_meta,
         #    demand_value, demand_branches)
         radiance_meta: dict[str, Any] = {
@@ -4886,8 +4908,23 @@ def _apply_market_viability_pass(
         )
         demand_demote = bool(demand_confident and demand_low)
 
+        # ── Pillar 3 (radiance growth) — NASA Black Marble VNP46A3 YoY
+        # demote leg. Fires when ``radiance_growth.confident`` is True AND
+        # ``value_yoy_pct`` < the demote threshold (operator strict ``<``).
+        # NO growth-rescue (mirrors the economics and demand legs): a leg
+        # whose own signal is forward-looking cannot self-rescue. Defensive
+        # silent-pass when the kill switch is off, the block is missing,
+        # the signal is not confident, or the value is None.
+        radiance_growth_demote = False
+        if radiance_growth_leg_enabled and isinstance(rad, dict):
+            if rad_confident and rad_yoy_pct is not None:
+                radiance_growth_demote = bool(
+                    rad_yoy_pct < radiance_yoy_demote_threshold
+                )
+
         return (
             pop_demote, rent_demote, econ_demote, demand_demote,
+            radiance_growth_demote,
             rent_pct, rent_scope, pop_reach, economics_score, radiance_meta,
             demand_value, demand_branches,
         )
@@ -4895,7 +4932,10 @@ def _apply_market_viability_pass(
     pre_eval = [_flag_inputs(c) for c in out]
     demote_indices = [
         i for i in range(n)
-        if pre_eval[i][0] or pre_eval[i][1] or pre_eval[i][2] or pre_eval[i][3]
+        if (
+            pre_eval[i][0] or pre_eval[i][1] or pre_eval[i][2]
+            or pre_eval[i][3] or pre_eval[i][4]
+        )
     ]
 
     demoted = 0
@@ -4904,11 +4944,13 @@ def _apply_market_viability_pass(
         c = out[i]
         (
             pop_demote, rent_demote, econ_demote, demand_demote,
+            radiance_growth_demote,
             rent_pct, rent_scope, pop_reach, economics_score, radiance_meta,
             demand_value, demand_branches,
         ) = pre_eval[i]
         # Stable-order annotation: clause 1 (pop), clause 2 (rent),
-        # clause 3 (economics), clause "sales potential" (demand).
+        # clause 3 (economics), clause "sales potential" (demand),
+        # clause "growth potential" (radiance growth).
         reasons: list[str] = []
         if pop_demote:
             reasons.append("population_below_quartile")
@@ -4918,6 +4960,8 @@ def _apply_market_viability_pass(
             reasons.append("economics_below_threshold")
         if demand_demote:
             reasons.append("demand_low")
+        if radiance_growth_demote:
+            reasons.append("radiance_growth_low")
         sb = c.get("score_breakdown_json")
         if not isinstance(sb, dict):
             sb = {}
@@ -4944,6 +4988,8 @@ def _apply_market_viability_pass(
                 float(demand_threshold) if demand_threshold is not None else None
             ),
             "demand_demote": demand_demote,
+            "radiance_growth_demote": radiance_growth_demote,
+            "radiance_yoy_demote_threshold": float(radiance_yoy_demote_threshold),
             "reason": "_and_".join(reasons),
             "radiance_growth_pct": radiance_meta["radiance_growth_pct"],
             "radiance_confident": radiance_meta["radiance_confident"],
@@ -4955,24 +5001,62 @@ def _apply_market_viability_pass(
             out.insert(target, c)
         demoted += 1
 
+    pop_demoted = sum(1 for pe in pre_eval if pe[0])
+    rent_demoted = sum(1 for pe in pre_eval if pe[1])
+    econ_demoted = sum(1 for pe in pre_eval if pe[2])
+    demand_demoted = sum(1 for pe in pre_eval if pe[3])
+    radiance_demoted = sum(1 for pe in pre_eval if pe[4])
     if demoted:
-        pop_demoted = sum(1 for pe in pre_eval if pe[0])
-        rent_demoted = sum(1 for pe in pre_eval if pe[1])
-        econ_demoted = sum(1 for pe in pre_eval if pe[2])
-        demand_demoted = sum(1 for pe in pre_eval if pe[3])
         logger.info(
             "expansion_market_viability_pass: search_id=%s demoted=%d "
             "pop_leg=%d rent_leg=%d econ_leg=%d demand_leg=%d "
+            "radiance_growth_leg=%d "
             "rent_pct_threshold=%.2f pop_percentile=%.2f pop_threshold=%.0f "
             "economics_min=%.2f demand_percentile=%.2f demand_threshold=%s "
+            "radiance_yoy_demote_threshold=%.2f "
             "demotion_steps=%d cohort_n=%d demand_cohort_n=%d",
             search_id, demoted, pop_demoted, rent_demoted, econ_demoted,
-            demand_demoted,
+            demand_demoted, radiance_demoted,
             rent_pct_threshold, pop_percentile_threshold, pop_threshold,
             economics_min, demand_percentile_threshold,
             ("%.2f" % demand_threshold) if demand_threshold is not None else "None",
+            radiance_yoy_demote_threshold,
             demotion_steps, len(pop_values), len(demand_values),
         )
+
+    # Per-leg diagnostics: parallel block to ``hard_floors`` (written
+    # earlier in this function before the soft-demote loop). Placed AFTER
+    # the pre_eval loop so the per-leg counters are populated. Always
+    # written when ``diagnostics`` is provided so the response shape stays
+    # stable even when no leg fired.
+    if diagnostics is not None:
+        diagnostics["demote_legs"] = {
+            "drops": {
+                "dropped_population": pop_demoted,
+                "dropped_rent": rent_demoted,
+                "dropped_economics": econ_demoted,
+                "dropped_demand": demand_demoted,
+                "dropped_radiance_growth": radiance_demoted,
+            },
+            "thresholds": {
+                "rent_pct_threshold": float(rent_pct_threshold),
+                "pop_percentile": float(pop_percentile_threshold),
+                "pop_threshold": (
+                    float(pop_threshold) if pop_threshold is not None else None
+                ),
+                "economics_min": float(economics_min),
+                "demand_percentile": float(demand_percentile_threshold),
+                "demand_threshold": (
+                    float(demand_threshold) if demand_threshold is not None else None
+                ),
+                "demand_min_branches": int(demand_min_branches),
+                "radiance_yoy_demote_threshold": float(radiance_yoy_demote_threshold),
+            },
+            "leg_enabled": {
+                "demand": demand_leg_enabled,
+                "radiance_growth": radiance_growth_leg_enabled,
+            },
+        }
     return out
 
 

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -3233,6 +3233,299 @@ def test_viability_all_four_legs_fire_with_compound_annotation(
 
 
 # ---------------------------------------------------------------------------
+# Radiance-growth soft-demote leg (B1+B2, "strong potential for business
+# growth"). Mirrors the demand-leg isolation pattern. The leg fires on
+# confident YoY radiance growth strictly below threshold, with NO growth
+# rescue (mirrors the economics and demand legs).
+# ---------------------------------------------------------------------------
+
+
+def _viability_cohort_with_radiance_growth_target(
+    *,
+    target_yoy_pct: float | None,
+    target_confident: bool = True,
+    target_pop_reach: float = 80000.0,
+    target_rent_pct: float = 0.40,
+    target_rent_scope: str = "district_band_type",
+    target_economics: float | None = 80.0,
+    include_radiance_block: bool = True,
+) -> list[dict]:
+    """Background carries no radiance_growth so the leg cannot fire on bg rows.
+
+    Background pop/rent/demand/economics are set so only the radiance leg
+    (or the explicitly-tested leg) can fire on the target.
+    """
+    pops = [5000, 6000, 7000, 8000, 50000, 60000, 70000, 80000]
+    demands = [600.0, 800.0, 1000.0, 1200.0, 1500.0, 1800.0, 2000.0, 2200.0]
+    cohort = [
+        _make_viability_candidate(
+            id_=f"bg{i}",
+            final_score=80.0 - i,
+            rent_pct=0.40,
+            rent_scope="district_band_type",
+            pop_reach=p,
+            realized_demand_30d=d,
+            realized_demand_branches=5,
+        )
+        for i, (p, d) in enumerate(zip(pops, demands))
+    ]
+    target = _make_viability_candidate(
+        id_="target",
+        final_score=78.5,
+        rent_pct=target_rent_pct,
+        rent_scope=target_rent_scope,
+        pop_reach=target_pop_reach,
+        realized_demand_30d=1500.0,
+        realized_demand_branches=5,
+    )
+    if target_economics is not None:
+        target["economics_score"] = target_economics
+    if include_radiance_block:
+        target["feature_snapshot_json"]["radiance_growth"] = {
+            "value_yoy_pct": target_yoy_pct,
+            "source_label": "blackmarble_district_yoy_rolling6",
+            "confident": target_confident,
+            "pixel_count": 132 if target_confident else 5,
+            "year_month": "2026-03",
+        }
+    cohort.insert(2, target)
+    return cohort
+
+
+def test_viability_radiance_growth_only_leg_fires(disable_market_viability_floors):
+    # Radiance leg alone: pop above p25, rent low, economics healthy, demand
+    # mid-cohort. Confident negative YoY (-2.0%) at the default 0.0 demote
+    # threshold ⇒ leg fires alone with reason="radiance_growth_low".
+    cohort = _viability_cohort_with_radiance_growth_target(
+        target_yoy_pct=-2.0,
+        target_confident=True,
+    )
+    starting_idx = next(i for i, c in enumerate(cohort) if c["id"] == "target")
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["population_demote"] is False
+    assert flag["rent_demote"] is False
+    assert flag["economics_demote"] is False
+    assert flag["demand_demote"] is False
+    assert flag["radiance_growth_demote"] is True
+    assert flag["radiance_growth_pct"] == -2.0
+    assert flag["radiance_confident"] is True
+    assert flag["radiance_yoy_demote_threshold"] == 0.0
+    assert flag["reason"] == "radiance_growth_low"
+    new_idx = next(i for i, c in enumerate(out) if c["id"] == "target")
+    assert new_idx == min(
+        starting_idx + 6, len(out) - 1
+    ), "candidate should move down by EXPANSION_VIABILITY_DEMOTION_STEPS"
+
+
+def test_viability_radiance_growth_leg_skipped_when_not_confident(
+    disable_market_viability_floors,
+):
+    # Confident=False → confidence gate fails → leg silent regardless of
+    # value. Mirrors the demand-leg branches-below-min precedent: low-
+    # confidence signals are not allowed to drive demote decisions.
+    cohort = _viability_cohort_with_radiance_growth_target(
+        target_yoy_pct=-5.0,
+        target_confident=False,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is None, "radiance leg must not fire when not confident"
+
+
+def test_viability_radiance_growth_leg_skipped_when_field_absent(
+    disable_market_viability_floors,
+):
+    # No radiance_growth key in feature_snapshot_json (history_unavailable
+    # shape from the snapshot writer). The target's leg must NOT fire.
+    cohort = _viability_cohort_with_radiance_growth_target(
+        target_yoy_pct=None,
+        include_radiance_block=False,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is None, "radiance leg must not fire when field absent"
+
+
+def test_viability_radiance_growth_leg_no_growth_rescue(
+    disable_market_viability_floors,
+):
+    # Confident negative YoY drives the radiance leg, AND the same row
+    # carries the same negative YoY (which can't self-rescue anyway —
+    # rescue requires yoy >= radiance_yoy_threshold, default 0.0). Mirrors
+    # the economics/demand precedent: the leg whose own forward-looking
+    # signal triggered the demote cannot self-rescue.
+    cohort = _viability_cohort_with_radiance_growth_target(
+        target_yoy_pct=-3.0,
+        target_confident=True,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["radiance_growth_demote"] is True
+    assert "radiance_growth_low" in flag["reason"]
+    assert flag["radiance_confident"] is True
+
+
+def test_viability_radiance_growth_leg_skipped_when_kill_switch_off(
+    disable_market_viability_floors, monkeypatch,
+):
+    # EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED=False → leg silent
+    # even when conditions otherwise met. Patch every live ``settings``
+    # reference (mirrors the demand-leg kill-switch test).
+    import sys
+
+    import app.core.config as config
+
+    seen_ids: set[int] = set()
+    for module in list(sys.modules.values()):
+        if module is None:
+            continue
+        candidate = getattr(module, "settings", None)
+        if candidate is None or id(candidate) in seen_ids:
+            continue
+        if not hasattr(
+            candidate, "EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED"
+        ):
+            continue
+        seen_ids.add(id(candidate))
+        monkeypatch.setattr(
+            candidate, "EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED", False
+        )
+    if id(config.settings) not in seen_ids:
+        monkeypatch.setattr(
+            config.settings,
+            "EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED",
+            False,
+        )
+
+    cohort = _viability_cohort_with_radiance_growth_target(
+        target_yoy_pct=-2.0,
+        target_confident=True,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is None, "kill switch must suppress the radiance_growth_demote decision"
+    # Snapshot field remains on feature_snapshot_json — pipeline untouched.
+    fs = target["feature_snapshot_json"]
+    assert fs.get("radiance_growth", {}).get("value_yoy_pct") == -2.0
+    assert fs.get("radiance_growth", {}).get("confident") is True
+
+
+def test_viability_radiance_growth_leg_threshold_boundary(
+    disable_market_viability_floors,
+):
+    # Operator is strict ``<``: at value_yoy_pct == threshold exactly, the
+    # leg must NOT fire. With default threshold=0.0 and yoy=0.0, the leg
+    # is silent and the candidate carries no flag (no other leg fires).
+    cohort = _viability_cohort_with_radiance_growth_target(
+        target_yoy_pct=0.0,
+        target_confident=True,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is None, (
+        "radiance leg must not fire when yoy == threshold (operator is strict <)"
+    )
+
+
+def test_viability_all_five_legs_fire_with_compound_annotation(
+    disable_market_viability_floors,
+):
+    # Five-leg variant of test_viability_all_four_legs_fire_with_compound_annotation:
+    # pop below p25, rent high on confident scope, economics_score=60 < 65,
+    # realized_demand_30d=400 in the bottom quartile with 5 branches,
+    # confident negative radiance YoY (-1.5%) below the 0.0 demote threshold.
+    # Reason concatenates in stable order: pop, rent, econ, demand, radiance.
+    cohort = _viability_cohort_with_demand_target(
+        target_demand=400.0,
+        target_demand_branches=5,
+        target_pop_reach=4500.0,
+        target_rent_pct=0.85,
+        target_economics=60.0,
+    )
+    target_in = next(c for c in cohort if c["id"] == "target")
+    target_in["feature_snapshot_json"]["radiance_growth"] = {
+        "value_yoy_pct": -1.5,
+        "source_label": "blackmarble_district_yoy_rolling6",
+        "confident": True,
+        "pixel_count": 132,
+        "year_month": "2026-03",
+    }
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["population_demote"] is True
+    assert flag["rent_demote"] is True
+    assert flag["economics_demote"] is True
+    assert flag["demand_demote"] is True
+    assert flag["radiance_growth_demote"] is True
+    assert flag["reason"] == (
+        "population_below_quartile_and_rent_high_and_economics_below_threshold"
+        "_and_demand_low_and_radiance_growth_low"
+    )
+
+
+def test_viability_diagnostics_demote_legs_block_written(
+    disable_market_viability_floors,
+):
+    # When ``diagnostics`` is passed and at least one leg fires, the
+    # ``demote_legs`` block is populated with all five drop counters and
+    # all expected threshold keys. Mirrors the existing
+    # test_viability_pass_diagnostics_records_hard_floor_drops_per_leg
+    # but for the soft-demote pass.
+    cohort = _viability_cohort_with_radiance_growth_target(
+        target_yoy_pct=-2.0,
+        target_confident=True,
+    )
+    diagnostics: dict = {}
+    _apply_market_viability_pass(
+        list(cohort), search_id="t", diagnostics=diagnostics
+    )
+    assert "demote_legs" in diagnostics
+    drops = diagnostics["demote_legs"]["drops"]
+    expected_drop_keys = {
+        "dropped_population",
+        "dropped_rent",
+        "dropped_economics",
+        "dropped_demand",
+        "dropped_radiance_growth",
+    }
+    assert set(drops.keys()) == expected_drop_keys
+    for key in expected_drop_keys:
+        assert isinstance(drops[key], int)
+        assert drops[key] >= 0
+    # The radiance leg must have caught at least the target.
+    assert drops["dropped_radiance_growth"] >= 1
+
+    thresholds = diagnostics["demote_legs"]["thresholds"]
+    expected_threshold_keys = {
+        "rent_pct_threshold",
+        "pop_percentile",
+        "pop_threshold",
+        "economics_min",
+        "demand_percentile",
+        "demand_threshold",
+        "demand_min_branches",
+        "radiance_yoy_demote_threshold",
+    }
+    assert set(thresholds.keys()) == expected_threshold_keys
+    assert thresholds["radiance_yoy_demote_threshold"] == 0.0
+
+    leg_enabled = diagnostics["demote_legs"]["leg_enabled"]
+    assert leg_enabled["demand"] is True
+    assert leg_enabled["radiance_growth"] is True
+
+
+# ---------------------------------------------------------------------------
 # Hard-floor diagnostics: surface per-leg drop counts to the caller so the
 # API meta can explain unsaturated-limit responses.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements the radiance-growth demote leg (Pillar 3 of the CEO directive: "strong potential for business growth") as a fifth independent soft-demote mechanism in the market viability pass. This leg demotes candidates with confident negative year-over-year radiance growth below a configurable threshold.

## Key Changes

- **New demote leg**: Added radiance-growth leg to `_apply_market_viability_pass()` that fires when:
  - `feature_snapshot_json["radiance_growth"].confident` is `True`
  - `value_yoy_pct` is strictly less than `EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD` (default: 0.0)
  - Uses strict `<` operator (no demote at threshold boundary)

- **Configuration**: Added two new settings in `config.py`:
  - `EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD`: Demote threshold for YoY growth (ships at 0.0, inert by default)
  - `EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED`: Kill switch to suppress demote behavior while preserving snapshot field and advisory gate emission

- **No growth rescue**: Unlike the population and rent legs, the radiance-growth leg cannot self-rescue (mirrors economics and demand legs). This prevents a leg whose own forward-looking signal triggered the demote from rescuing itself.

- **Diagnostics**: Extended `demote_legs` diagnostics block to include:
  - Per-leg drop counters for all five legs (population, rent, economics, demand, radiance_growth)
  - All threshold values including `radiance_yoy_demote_threshold`
  - Leg enabled status for demand and radiance_growth

- **Reason annotation**: Updated stable-order reason string to include `"radiance_growth_low"` as the fifth component (order: population, rent, economics, demand, radiance_growth)

- **Environment variables**: Added configuration options to `.env.example` for operator-facing tuning

## Implementation Details

- Distinct from `EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD` (which drives rescue for population/rent legs with `>=` operator); splitting the knobs prevents calibrating one from silently affecting the other
- Defensive silent-pass when kill switch is off, block is missing, signal is not confident, or value is None
- Comprehensive test coverage including: basic leg firing, confidence gating, field absence handling, no-rescue behavior, kill switch, threshold boundary conditions, and five-leg compound annotation

https://claude.ai/code/session_01XwqUt31TMKsTWssP1SQdAR