### PR TITLE
Calibrate radiance YoY demote threshold from 0.0% to 2.0%

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,8 +43,11 @@ FOURSQUARE_API_KEY=
 # ---- Expansion Advisor: market-viability radiance-growth demote leg ----
 # YoY radiance growth (%) below which the radiance-growth leg of
 # _apply_market_viability_pass soft-demotes a candidate. Operator is
-# strict `<`. Default 0.0 ships inert (calibration is a follow-up).
-EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD=0.0
+# strict `<`. Calibrated default 2.0 sits inside the empirical
+# 1.5–3.0% gap in the candidate-side distribution and demotes ~45%
+# of confident candidates per Faisal's Pillar 3 directive (below 2%
+# YoY is not "strong growth" given ~5% typical citywide growth).
+EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD=2.0
 # Kill switch for the radiance-growth demote leg. Setting to `false`
 # leaves the snapshot field and advisory `radiance_growth_pass` gate
 # untouched — only the soft-demote behavior is suppressed.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -229,15 +229,20 @@ class Settings:
     # potential for business growth"). When ``radiance_growth.confident``
     # is True and ``value_yoy_pct`` < this threshold, the candidate is
     # soft-demoted by the same positional mechanism as the population /
-    # rent / economics / demand legs. Operator is strict ``<``. Ships at
-    # 0.0 (inert: with the post-B1.5 distribution, zero confident
-    # districts sit below 0% YoY) — calibration is a separate follow-up
-    # patch once the 1.46% modal cluster is characterized. Distinct from
+    # rent / economics / demand legs. Operator is strict ``<``.
+    # Calibrated 2026-05-06 against the candidate-side distribution from
+    # the last 24h of production searches (515 confident rolling-6
+    # candidates). Distribution is bimodal with an empty gap between
+    # 1.5% and 3.0% YoY; 2.0 sits inside that gap and demotes 234 of
+    # 515 confident candidates (~45%) — concentrated in two single
+    # districts (~0.01% and ~1.46% YoY). Above-typical citywide growth
+    # is ~5%, so below 2% is not "strong growth" per Faisal's directive
+    # (Pillar 3). Distinct from
     # ``EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD`` above (which drives
     # the rescue side, operator ``>=``); splitting the knobs prevents
     # calibrating one from silently affecting the other.
     EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD: float = float(
-        os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD", "0.0")
+        os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD", "2.0")
     )
     # Kill switch for the radiance-growth demote leg. Setting this to
     # ``false`` suppresses the leg's demote decision while leaving the

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -4525,8 +4525,11 @@ def _apply_market_viability_pass(
         affecting the other. Disable in isolation via
         ``EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED=false``; the
         advisory ``radiance_growth_pass`` gate emission remains intact —
-        only the soft-demote behavior is suppressed. Ships at threshold
-        ``0.0`` (inert by default).
+        only the soft-demote behavior is suppressed. Ships at the
+        calibrated default ``2.0`` (2026-05-06 calibration: sits in the
+        empirical 1.5–3.0% YoY gap and demotes ~45% of confident
+        candidates, matching Faisal's "below 2% is not strong growth"
+        directive against ~5% typical citywide growth).
 
     The growth-rescue signal reads ``feature_snapshot_json["radiance_growth"]``
     (NASA Black Marble VNP46A3). When that signal is confident and YoY growth
@@ -4574,7 +4577,7 @@ def _apply_market_viability_pass(
         settings, "EXPANSION_VIABILITY_DEMAND_LEG_ENABLED", True
     ))
     radiance_yoy_demote_threshold = float(getattr(
-        settings, "EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD", 0.0
+        settings, "EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD", 2.0
     ))
     radiance_growth_leg_enabled = bool(getattr(
         settings, "EXPANSION_VIABILITY_RADIANCE_GROWTH_LEG_ENABLED", True

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -3294,8 +3294,8 @@ def _viability_cohort_with_radiance_growth_target(
 
 def test_viability_radiance_growth_only_leg_fires(disable_market_viability_floors):
     # Radiance leg alone: pop above p25, rent low, economics healthy, demand
-    # mid-cohort. Confident negative YoY (-2.0%) at the default 0.0 demote
-    # threshold ⇒ leg fires alone with reason="radiance_growth_low".
+    # mid-cohort. Confident negative YoY (-2.0%) below the calibrated 2.0
+    # demote threshold ⇒ leg fires alone with reason="radiance_growth_low".
     cohort = _viability_cohort_with_radiance_growth_target(
         target_yoy_pct=-2.0,
         target_confident=True,
@@ -3312,7 +3312,7 @@ def test_viability_radiance_growth_only_leg_fires(disable_market_viability_floor
     assert flag["radiance_growth_demote"] is True
     assert flag["radiance_growth_pct"] == -2.0
     assert flag["radiance_confident"] is True
-    assert flag["radiance_yoy_demote_threshold"] == 0.0
+    assert flag["radiance_yoy_demote_threshold"] == 2.0
     assert flag["reason"] == "radiance_growth_low"
     new_idx = next(i for i, c in enumerate(out) if c["id"] == "target")
     assert new_idx == min(
@@ -3422,10 +3422,12 @@ def test_viability_radiance_growth_leg_threshold_boundary(
     disable_market_viability_floors,
 ):
     # Operator is strict ``<``: at value_yoy_pct == threshold exactly, the
-    # leg must NOT fire. With default threshold=0.0 and yoy=0.0, the leg
-    # is silent and the candidate carries no flag (no other leg fires).
+    # leg must NOT fire. Tests against whatever the env default is so
+    # threshold recalibrations don't break this assertion.
+    from app.core.config import settings
+    threshold = float(settings.EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD)
     cohort = _viability_cohort_with_radiance_growth_target(
-        target_yoy_pct=0.0,
+        target_yoy_pct=threshold,
         target_confident=True,
     )
     out = _apply_market_viability_pass(list(cohort), search_id="t")
@@ -3442,7 +3444,7 @@ def test_viability_all_five_legs_fire_with_compound_annotation(
     # Five-leg variant of test_viability_all_four_legs_fire_with_compound_annotation:
     # pop below p25, rent high on confident scope, economics_score=60 < 65,
     # realized_demand_30d=400 in the bottom quartile with 5 branches,
-    # confident negative radiance YoY (-1.5%) below the 0.0 demote threshold.
+    # confident negative radiance YoY (-1.5%) below the 2.0 demote threshold.
     # Reason concatenates in stable order: pop, rent, econ, demand, radiance.
     cohort = _viability_cohort_with_demand_target(
         target_demand=400.0,
@@ -3518,7 +3520,7 @@ def test_viability_diagnostics_demote_legs_block_written(
         "radiance_yoy_demote_threshold",
     }
     assert set(thresholds.keys()) == expected_threshold_keys
-    assert thresholds["radiance_yoy_demote_threshold"] == 0.0
+    assert thresholds["radiance_yoy_demote_threshold"] == 2.0
 
     leg_enabled = diagnostics["demote_legs"]["leg_enabled"]
     assert leg_enabled["demand"] is True


### PR DESCRIPTION
## Summary
Recalibrates the `EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD` from an inert default of 0.0% to 2.0% based on empirical analysis of production candidate distributions. This threshold controls when the radiance-growth leg soft-demotes expansion candidates based on year-over-year growth confidence.

## Key Changes
- **Config default**: Updated `EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD` from `0.0` to `2.0` in `app/core/config.py`
  - Added detailed calibration rationale: 2.0% sits in the empirical 1.5–3.0% gap in the candidate-side distribution
  - Demotes ~45% of confident candidates, aligning with Faisal's Pillar 3 directive that below 2% YoY is not "strong growth" (vs. ~5% typical citywide growth)
  - Calibrated 2026-05-06 against 515 confident rolling-6 candidates from 24h production data

- **Service layer**: Updated default fallback in `app/services/expansion_advisor.py` to match the new threshold
  - Enhanced documentation explaining the calibration basis and behavioral impact

- **Environment config**: Updated `.env.example` with new default and calibration explanation

- **Tests**: Updated test expectations to reflect the new 2.0% threshold
  - `test_viability_radiance_growth_only_leg_fires`: Updated assertion and comment
  - `test_viability_radiance_growth_leg_threshold_boundary`: Made threshold-agnostic by reading from settings to prevent future recalibration breakage
  - `test_viability_all_five_legs_fire_with_compound_annotation`: Updated comment
  - `test_viability_diagnostics_demote_legs_block_written`: Updated assertion

## Implementation Details
The threshold change is backward-compatible via environment variable override. The strict `<` operator means candidates with YoY growth ≥ 2.0% are unaffected; only those below 2.0% with confident radiance signals will be soft-demoted. The boundary test was refactored to dynamically read the threshold from settings, making it resilient to future calibration changes.

https://claude.ai/code/session_01VKT7ycW3tWYRocnUQyo2HC