### PR TITLE
Add rent_per_capita demote leg to market viability pass

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -207,6 +207,20 @@ class Settings:
     EXPANSION_VIABILITY_DEMOTION_STEPS: int = int(
         os.getenv("EXPANSION_VIABILITY_DEMOTION_STEPS", "6")
     )
+    # rent_per_capita demote leg: catches the "low-pop + high-rent" anti-pattern
+    # via a cohort percentile on estimated_annual_rent_sar / population_reach.
+    # Mirrors EXPANSION_VIABILITY_POP_PERCENTILE (per-search cohort cutoff,
+    # positional reorder, no final_score mutation). Top-quartile of cohort
+    # gets demoted at the default 0.75.
+    EXPANSION_VIABILITY_RPC_PERCENTILE: float = float(
+        os.getenv("EXPANSION_VIABILITY_RPC_PERCENTILE", "0.75")
+    )
+    # Below this cohort size, the rpc leg is skipped entirely (avoids noisy
+    # percentile cutoffs on tiny samples). No demotions and no flag writes
+    # below this floor.
+    EXPANSION_VIABILITY_RPC_MIN_COHORT: int = int(
+        os.getenv("EXPANSION_VIABILITY_RPC_MIN_COHORT", "10")
+    )
     # Threshold for the economics-quality leg of _apply_market_viability_pass
     # (CEO directive clause 3 — "strong potential for profitability"). Candidates
     # with economics_score < this threshold are soft-demoted by the same

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -8,6 +8,7 @@ import statistics
 import time
 import os
 import uuid
+from bisect import bisect_right
 from datetime import datetime, timedelta
 from typing import Any, Mapping
 
@@ -4784,6 +4785,78 @@ def _apply_market_viability_pass(
         except Exception:
             demand_threshold = None
 
+    # ── rent_per_capita demote leg (CEO "low-pop + high-rent" anti-pattern) ──
+    # Evaluated BEFORE the existing legs. Cohort percentile on
+    # estimated_annual_rent_sar / population_reach, mirroring the
+    # pop_demote percentile pattern (statistics.quantiles, inclusive).
+    # Below ``EXPANSION_VIABILITY_RPC_MIN_COHORT`` valid candidates the leg
+    # is skipped entirely (no demotions, no flag writes). Independent of
+    # the rent_burden / population_reach legs above: this catches the
+    # joint pattern (~30K pop with ~200K SAR rent) that those independent
+    # legs only catch when both happen to fire on the same candidate.
+    rpc_percentile_threshold = float(getattr(
+        settings, "EXPANSION_VIABILITY_RPC_PERCENTILE", 0.75
+    ))
+    rpc_min_cohort = int(getattr(
+        settings, "EXPANSION_VIABILITY_RPC_MIN_COHORT", 10
+    ))
+    rpc_per_candidate_id: dict[int, float | None] = {}
+    for c in out:
+        fs = c.get("feature_snapshot_json")
+        rpc: float | None = None
+        if isinstance(fs, dict):
+            rent_raw = fs.get("estimated_annual_rent_sar")
+            pop_raw = fs.get("population_reach")
+            if rent_raw is not None and pop_raw is not None:
+                rent_v = _safe_float(rent_raw, default=-1.0)
+                pop_v = _safe_float(pop_raw, default=-1.0)
+                if rent_v > 0 and pop_v > 0:
+                    rpc = rent_v / pop_v
+        rpc_per_candidate_id[id(c)] = rpc
+
+    valid_rpc = sorted(v for v in rpc_per_candidate_id.values() if v is not None)
+    rpc_active = len(valid_rpc) >= rpc_min_cohort
+    rpc_threshold: float | None = None
+    if rpc_active:
+        rpc_pct_index = max(1, min(99, int(round(rpc_percentile_threshold * 100))))
+        try:
+            rpc_cutoffs = statistics.quantiles(
+                valid_rpc, n=100, method="inclusive"
+            )
+            rpc_threshold = float(rpc_cutoffs[rpc_pct_index - 1])
+        except Exception:
+            rpc_threshold = None
+            rpc_active = False
+
+    rpc_telemetry_by_id: dict[int, dict[str, Any]] = {}
+    rpc_demote_by_id: dict[int, bool] = {}
+    if rpc_active and rpc_threshold is not None:
+        cohort_size = len(valid_rpc)
+        for c in out:
+            cid = id(c)
+            rpc = rpc_per_candidate_id[cid]
+            if rpc is None:
+                rpc_telemetry_by_id[cid] = {
+                    "rent_per_capita_sar": None,
+                    "rent_per_capita_pct": None,
+                    "rent_per_capita_demote": None,
+                }
+                rpc_demote_by_id[cid] = False
+            else:
+                rank = bisect_right(valid_rpc, rpc)
+                pct = rank / cohort_size if cohort_size else 0.0
+                # At-most-once demote: ``rpc`` runs first, so the
+                # already-demoted check is a defensive no-op (the existing
+                # demote loop applies a single positional swap per
+                # candidate regardless of how many legs fire).
+                do_demote = rpc >= rpc_threshold
+                rpc_telemetry_by_id[cid] = {
+                    "rent_per_capita_sar": round(rpc, 4),
+                    "rent_per_capita_pct": float(pct),
+                    "rent_per_capita_demote": bool(do_demote),
+                }
+                rpc_demote_by_id[cid] = do_demote
+
     def _flag_inputs(
         c: dict[str, Any]
     ) -> tuple[
@@ -4936,7 +5009,8 @@ def _apply_market_viability_pass(
     demote_indices = [
         i for i in range(n)
         if (
-            pre_eval[i][0] or pre_eval[i][1] or pre_eval[i][2]
+            rpc_demote_by_id.get(id(out[i]), False)
+            or pre_eval[i][0] or pre_eval[i][1] or pre_eval[i][2]
             or pre_eval[i][3] or pre_eval[i][4]
         )
     ]
@@ -4951,10 +5025,13 @@ def _apply_market_viability_pass(
             rent_pct, rent_scope, pop_reach, economics_score, radiance_meta,
             demand_value, demand_branches,
         ) = pre_eval[i]
-        # Stable-order annotation: clause 1 (pop), clause 2 (rent),
-        # clause 3 (economics), clause "sales potential" (demand),
-        # clause "growth potential" (radiance growth).
+        rpc_demote = rpc_demote_by_id.get(id(c), False)
+        # Stable-order annotation: rpc (rent_per_capita), clause 1 (pop),
+        # clause 2 (rent), clause 3 (economics), clause "sales potential"
+        # (demand), clause "growth potential" (radiance growth).
         reasons: list[str] = []
+        if rpc_demote:
+            reasons.append("rent_per_capita_high")
         if pop_demote:
             reasons.append("population_below_quartile")
         if rent_demote:
@@ -4969,7 +5046,7 @@ def _apply_market_viability_pass(
         if not isinstance(sb, dict):
             sb = {}
             c["score_breakdown_json"] = sb
-        sb["market_viability_flag"] = {
+        flag_dict: dict[str, Any] = {
             "demoted": True,
             "demotion_steps": int(demotion_steps),
             "rent_percentile": float(rent_pct),
@@ -4999,16 +5076,48 @@ def _apply_market_viability_pass(
             "radiance_pixel_count": radiance_meta["radiance_pixel_count"],
             "radiance_year_month": radiance_meta["radiance_year_month"],
         }
+        if rpc_active:
+            flag_dict.update(rpc_telemetry_by_id.get(id(c), {
+                "rent_per_capita_sar": None,
+                "rent_per_capita_pct": None,
+                "rent_per_capita_demote": None,
+            }))
+        sb["market_viability_flag"] = flag_dict
         if target > i:
             out.pop(i)
             out.insert(target, c)
         demoted += 1
+
+    # Write rpc telemetry to candidates the rpc leg evaluated but the
+    # demote loop did not touch (i.e. no leg fired for them). The demote
+    # loop above already included the rpc keys for every demoted candidate
+    # via flag_dict. When the rpc leg is inactive (cohort below the
+    # min-cohort floor), no flag writes happen — per the leg's contract.
+    if rpc_active:
+        demoted_ids: set[int] = {id(out[i]) for i in demote_indices}
+        for c in out:
+            cid = id(c)
+            if cid in demoted_ids:
+                continue
+            telemetry = rpc_telemetry_by_id.get(cid)
+            if telemetry is None:
+                continue
+            sb = c.get("score_breakdown_json")
+            if not isinstance(sb, dict):
+                sb = {}
+                c["score_breakdown_json"] = sb
+            mvf = sb.get("market_viability_flag")
+            if not isinstance(mvf, dict):
+                mvf = {}
+                sb["market_viability_flag"] = mvf
+            mvf.update(telemetry)
 
     pop_demoted = sum(1 for pe in pre_eval if pe[0])
     rent_demoted = sum(1 for pe in pre_eval if pe[1])
     econ_demoted = sum(1 for pe in pre_eval if pe[2])
     demand_demoted = sum(1 for pe in pre_eval if pe[3])
     radiance_demoted = sum(1 for pe in pre_eval if pe[4])
+    rpc_demoted = sum(1 for v in rpc_demote_by_id.values() if v)
     if demoted:
         logger.info(
             "expansion_market_viability_pass: search_id=%s demoted=%d "
@@ -5040,6 +5149,7 @@ def _apply_market_viability_pass(
                 "dropped_economics": econ_demoted,
                 "dropped_demand": demand_demoted,
                 "dropped_radiance_growth": radiance_demoted,
+                "dropped_rent_per_capita": rpc_demoted,
             },
             "thresholds": {
                 "rent_pct_threshold": float(rent_pct_threshold),
@@ -5054,10 +5164,17 @@ def _apply_market_viability_pass(
                 ),
                 "demand_min_branches": int(demand_min_branches),
                 "radiance_yoy_demote_threshold": float(radiance_yoy_demote_threshold),
+                "rpc_percentile": float(rpc_percentile_threshold),
+                "rpc_threshold": (
+                    float(rpc_threshold) if rpc_threshold is not None else None
+                ),
+                "rpc_min_cohort": int(rpc_min_cohort),
+                "rpc_cohort_n": len(valid_rpc),
             },
             "leg_enabled": {
                 "demand": demand_leg_enabled,
                 "radiance_growth": radiance_growth_leg_enabled,
+                "rent_per_capita": rpc_active,
             },
         }
     return out

--- a/tests/test_expansion_advisor_api.py
+++ b/tests/test_expansion_advisor_api.py
@@ -950,6 +950,7 @@ def _full_demote_legs_block():
             "dropped_economics": 0,
             "dropped_demand": 3,
             "dropped_radiance_growth": 1,
+            "dropped_rent_per_capita": 2,
         },
         "thresholds": {
             "rent_pct_threshold": 0.85,
@@ -960,10 +961,15 @@ def _full_demote_legs_block():
             "demand_threshold": None,
             "demand_min_branches": 5,
             "radiance_yoy_demote_threshold": 2.0,
+            "rpc_percentile": 0.75,
+            "rpc_threshold": 1500.0,
+            "rpc_min_cohort": 10,
+            "rpc_cohort_n": 12,
         },
         "leg_enabled": {
             "demand": True,
             "radiance_growth": True,
+            "rent_per_capita": True,
         },
     }
 
@@ -979,6 +985,7 @@ def test_meta_includes_demote_leg_drops(monkeypatch):
         "dropped_economics",
         "dropped_demand",
         "dropped_radiance_growth",
+        "dropped_rent_per_capita",
     }
     for value in drops.values():
         assert isinstance(value, int)
@@ -999,6 +1006,10 @@ def test_meta_includes_demote_leg_thresholds(monkeypatch):
         "demand_threshold",
         "demand_min_branches",
         "radiance_yoy_demote_threshold",
+        "rpc_percentile",
+        "rpc_threshold",
+        "rpc_min_cohort",
+        "rpc_cohort_n",
     }
     assert isinstance(thresholds["rent_pct_threshold"], float)
     assert isinstance(thresholds["pop_percentile"], float)
@@ -1008,6 +1019,10 @@ def test_meta_includes_demote_leg_thresholds(monkeypatch):
     assert thresholds["demand_threshold"] is None
     assert isinstance(thresholds["demand_min_branches"], int)
     assert isinstance(thresholds["radiance_yoy_demote_threshold"], float)
+    assert isinstance(thresholds["rpc_percentile"], float)
+    assert isinstance(thresholds["rpc_threshold"], float)
+    assert isinstance(thresholds["rpc_min_cohort"], int)
+    assert isinstance(thresholds["rpc_cohort_n"], int)
 
 
 def test_meta_includes_demote_leg_enabled(monkeypatch):
@@ -1017,8 +1032,10 @@ def test_meta_includes_demote_leg_enabled(monkeypatch):
     leg_enabled = body["meta"]["demote_leg_enabled"]
     assert "demand" in leg_enabled
     assert "radiance_growth" in leg_enabled
+    assert "rent_per_capita" in leg_enabled
     assert isinstance(leg_enabled["demand"], bool)
     assert isinstance(leg_enabled["radiance_growth"], bool)
+    assert isinstance(leg_enabled["rent_per_capita"], bool)
 
 
 def test_meta_demote_leg_fields_default_none_when_block_absent(monkeypatch):

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -3500,6 +3500,7 @@ def test_viability_diagnostics_demote_legs_block_written(
         "dropped_economics",
         "dropped_demand",
         "dropped_radiance_growth",
+        "dropped_rent_per_capita",
     }
     assert set(drops.keys()) == expected_drop_keys
     for key in expected_drop_keys:
@@ -3518,6 +3519,10 @@ def test_viability_diagnostics_demote_legs_block_written(
         "demand_threshold",
         "demand_min_branches",
         "radiance_yoy_demote_threshold",
+        "rpc_percentile",
+        "rpc_threshold",
+        "rpc_min_cohort",
+        "rpc_cohort_n",
     }
     assert set(thresholds.keys()) == expected_threshold_keys
     assert thresholds["radiance_yoy_demote_threshold"] == 2.0
@@ -3525,6 +3530,153 @@ def test_viability_diagnostics_demote_legs_block_written(
     leg_enabled = diagnostics["demote_legs"]["leg_enabled"]
     assert leg_enabled["demand"] is True
     assert leg_enabled["radiance_growth"] is True
+    # rpc leg is inactive in this cohort (no estimated_annual_rent_sar
+    # supplied by the helper) so leg_enabled["rent_per_capita"] is False.
+    assert leg_enabled["rent_per_capita"] is False
+
+
+# ---------------------------------------------------------------------------
+# rent_per_capita demote leg — catches the CEO "low-pop + high-rent"
+# anti-pattern via cohort percentile on rent / population_reach.
+# ---------------------------------------------------------------------------
+
+
+def _rpc_candidate(
+    *, id_: str, final_score: float, rent_sar: float | None,
+    pop_reach: float | None,
+) -> dict:
+    fs: dict = {}
+    if rent_sar is not None:
+        fs["estimated_annual_rent_sar"] = rent_sar
+    if pop_reach is not None:
+        fs["population_reach"] = pop_reach
+    return {
+        "id": id_,
+        "parcel_id": id_,
+        "final_score": final_score,
+        "score_breakdown_json": {},
+        "feature_snapshot_json": fs,
+    }
+
+
+def test_viability_rpc_leg_demotes_top_quartile(disable_market_viability_floors):
+    # Cohort of 12 candidates: rpc values 1, 2, ..., 11 SAR/person plus an
+    # outlier "target" with rpc = 1000 (200K rent / 200 pop). Default
+    # percentile is 0.75; the target sits at the top of the cohort and
+    # must be demoted by the rpc leg, with telemetry written.
+    cohort = [
+        _rpc_candidate(
+            id_=f"c{i}", final_score=80.0 - i,
+            rent_sar=float(i * 1000), pop_reach=1000.0,
+        )
+        for i in range(1, 12)
+    ]
+    target = _rpc_candidate(
+        id_="target", final_score=78.5,
+        rent_sar=200_000.0, pop_reach=200.0,  # rpc = 1000
+    )
+    cohort.insert(2, target)
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target_out = next(c for c in out if c["id"] == "target")
+    flag = target_out["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None
+    assert flag["rent_per_capita_demote"] is True
+    assert flag["rent_per_capita_sar"] == 1000.0
+    assert flag["rent_per_capita_pct"] == 1.0
+    assert flag["demoted"] is True
+    assert "rent_per_capita_high" in flag["reason"].split("_and_")
+    # Position must have moved down.
+    assert next(i for i, c in enumerate(out) if c["id"] == "target") > 2
+
+
+def test_viability_rpc_leg_skipped_below_min_cohort(
+    disable_market_viability_floors,
+):
+    # Only 6 candidates have valid rpc inputs (< default min cohort 10);
+    # rpc leg is silent, no flag writes, no demotions.
+    cohort = [
+        _rpc_candidate(
+            id_=f"c{i}", final_score=80.0 - i,
+            rent_sar=float(i * 1000), pop_reach=1000.0,
+        )
+        for i in range(1, 7)
+    ]
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    for c in out:
+        assert "market_viability_flag" not in c["score_breakdown_json"]
+
+
+def test_viability_rpc_leg_writes_null_for_missing_inputs(
+    disable_market_viability_floors,
+):
+    # Cohort exceeds min_cohort with valid rpc, but one candidate is
+    # missing population_reach. That candidate gets null telemetry; the
+    # leg is otherwise active.
+    cohort = [
+        _rpc_candidate(
+            id_=f"c{i}", final_score=80.0 - i,
+            rent_sar=float(i * 1000), pop_reach=1000.0,
+        )
+        for i in range(1, 12)
+    ]
+    missing = _rpc_candidate(
+        id_="missing", final_score=78.5,
+        rent_sar=144_000.0, pop_reach=None,
+    )
+    cohort.insert(2, missing)
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    miss_out = next(c for c in out if c["id"] == "missing")
+    flag = miss_out["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None
+    assert flag["rent_per_capita_sar"] is None
+    assert flag["rent_per_capita_pct"] is None
+    assert flag["rent_per_capita_demote"] is None
+
+
+def test_viability_rpc_leg_handles_zero_population_safely(
+    disable_market_viability_floors,
+):
+    # population_reach == 0 must not raise; treated as missing (null
+    # telemetry) and no demotion.
+    cohort = [
+        _rpc_candidate(
+            id_=f"c{i}", final_score=80.0 - i,
+            rent_sar=float(i * 1000), pop_reach=1000.0,
+        )
+        for i in range(1, 12)
+    ]
+    zero_pop = _rpc_candidate(
+        id_="zero", final_score=78.5,
+        rent_sar=200_000.0, pop_reach=0.0,
+    )
+    cohort.insert(2, zero_pop)
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    zero_out = next(c for c in out if c["id"] == "zero")
+    flag = zero_out["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None
+    assert flag["rent_per_capita_sar"] is None
+    assert flag["rent_per_capita_demote"] is None
+
+
+def test_viability_rpc_leg_writes_telemetry_on_non_demoted(
+    disable_market_viability_floors,
+):
+    # Below-threshold candidates still get the three rpc keys written
+    # (telemetry, not just demote events).
+    cohort = [
+        _rpc_candidate(
+            id_=f"c{i}", final_score=80.0 - i,
+            rent_sar=float(i * 1000), pop_reach=1000.0,
+        )
+        for i in range(1, 12)
+    ]
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    low = next(c for c in out if c["id"] == "c1")  # rpc = 1.0, lowest
+    flag = low["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None
+    assert flag["rent_per_capita_sar"] == 1.0
+    assert flag["rent_per_capita_demote"] is False
+    assert 0.0 < flag["rent_per_capita_pct"] <= 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements a new "rent_per_capita" demotion leg in the market viability pass to catch the CEO anti-pattern of low-population parcels with disproportionately high rent. This leg evaluates candidates based on a cohort percentile of `estimated_annual_rent_sar / population_reach` and demotes those in the top quartile.

## Key Changes

- **New demotion leg**: Added rent_per_capita (rpc) leg that runs before existing demote legs, using cohort percentile analysis (default 75th percentile) on rent-per-capita ratio
- **Cohort floor**: Leg is skipped entirely when cohort has fewer than 10 valid candidates (configurable via `EXPANSION_VIABILITY_RPC_MIN_COHORT`), preventing noisy percentile calculations on small samples
- **Telemetry**: Writes three new fields to `market_viability_flag`:
  - `rent_per_capita_sar`: calculated rent per capita value (null if inputs missing)
  - `rent_per_capita_pct`: percentile rank within cohort (0.0-1.0)
  - `rent_per_capita_demote`: boolean indicating if candidate was demoted by this leg
- **Safe handling**: Gracefully handles missing or invalid inputs (null rent, null population, zero population) by writing null telemetry without demotion
- **Configuration**: Added two new settings:
  - `EXPANSION_VIABILITY_RPC_PERCENTILE` (default 0.75)
  - `EXPANSION_VIABILITY_RPC_MIN_COHORT` (default 10)
- **Diagnostics**: Updated viability diagnostics to include rpc leg metrics in drops, thresholds, and leg_enabled blocks

## Implementation Details

- Uses `bisect_right` to efficiently calculate percentile rank for each candidate
- Mirrors the existing population percentile leg pattern (statistics.quantiles with inclusive method)
- Demotion is applied at-most-once per candidate (rpc leg runs first, existing demote loop applies single positional swap)
- Non-demoted candidates still receive rpc telemetry when leg is active (for observability)
- Comprehensive test coverage including edge cases: below-threshold cohort, missing inputs, zero population, and non-demoted telemetry

https://claude.ai/code/session_01EQuSzzTgRKCngE7qVELoUH