### PR TITLE
fix(diagnostics): cast population_reach via numeric→int in rpc_validation query 6

### DIFF
--- a/scripts/diagnostics/rpc_validation.sql
+++ b/scripts/diagnostics/rpc_validation.sql
@@ -83,7 +83,7 @@ LIMIT 50;
 SELECT
   id,
   feature_snapshot_json->>'district_display'                         AS district,
-  (feature_snapshot_json->>'population_reach')::int                  AS pop_reach,
+  ROUND((feature_snapshot_json->>'population_reach')::numeric)::int  AS pop_reach,
   (feature_snapshot_json->>'estimated_annual_rent_sar')::float       AS annual_rent_sar,
   ROUND((score_breakdown_json->'market_viability_flag'->>'rent_per_capita_sar')::numeric, 2) AS rpc_sar,
   ROUND((score_breakdown_json->'market_viability_flag'->>'rent_per_capita_pct')::numeric, 4) AS rpc_pct,


### PR DESCRIPTION
## What's wrong

Query 6 of `scripts/diagnostics/rpc_validation.sql` errors with:

```
ERROR: invalid input syntax for type integer: "51019.4"
```

`feature_snapshot_json->>'population_reach'` can be a float (the bulk enrichment emits density-summed reach as a float, not an integer count), but query 6 casts it directly with `::int`.

## Fix (single one-line change)

Round through `numeric` before casting to `int` so the cast is float-tolerant:

```diff
-  (feature_snapshot_json->>'population_reach')::int                  AS pop_reach,
+  ROUND((feature_snapshot_json->>'population_reach')::numeric)::int  AS pop_reach,
```

Only query 6 references `population_reach::int`. The other `population_reach` references in the file are already float-tolerant:
- Line 16: `::float` (RPC numerator/denominator)
- Line 20: `IS NOT NULL` predicate

Query 4 is intentionally untouched — that's pending separate investigation into flag semantics (see Track A report; not in this PR).

## Validation

- Re-run `\i scripts/diagnostics/rpc_validation.sql` from psql; query 6 should now return rows with `pop_reach` as a rounded integer instead of erroring.
- Other queries in the file are unchanged and should produce identical output.

## Note on diff size

The actual fix is a single line in `scripts/diagnostics/rpc_validation.sql`. The PR diff against `main` may include prerequisite commits from the upstream investigate branch (which carries the as-yet-unmerged diagnostics file itself). Once those land on `main`, this PR's effective diff collapses to one line.

## Risk

Trivial. No business logic, no schema, no app code. Diagnostic-only SQL.

---
_Generated by [Claude Code](https://claude.ai/code/session_018t3wbazgHEvQCYQPqcmhiv)_