### PR TITLE
Elevate listing quality signals in expansion advisor ranking

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -2411,24 +2411,24 @@ def _listing_quality_score(
     For parcels (or any candidate without a commercial_unit row),
     returns a neutral 50.
 
-    Components (Phase 3b weight tuple when _MOMENTUM_ENABLED is True):
-      - Freshness from effective_age_days (25.50%): how recently the listing
+    Components (post-2026-05-07 sub-weights when _MOMENTUM_ENABLED is True):
+      - Freshness from effective_age_days (30.00%): how recently the listing
         was created or updated on Aqar (bands at 14/30/60/120/240/365 —
         frozen for Phase 3a).
-      - Aqar suitability (34.00%): the classifier's assessment — LLM verdict
+      - Aqar suitability (20.00%): the classifier's assessment — LLM verdict
         when available, structural restaurant_score fallback otherwise
-      - Image / fit-out signal (17.00%): LLM-derived listing quality when
+      - Image / fit-out signal (10.00%): LLM-derived listing quality when
         available, binary image presence fallback otherwise
-      - Furnished (8.50%): faster open, lower risk, lower fitout
-      - District momentum (15.00%): percentile-ranked 30-day activity in
+      - Furnished (5.00%): faster open, lower risk, lower fitout
+      - District momentum (35.00%): percentile-ranked 30-day activity in
         the district (blended creates + updates on commercial_unit).
         Districts below the sample floor resolve to a neutral 50.0.
       - Drive-thru bonus: small additive (+5) when present
 
-    The four pre-3b sub-weights (0.30/0.40/0.20/0.10) are rescaled
-    multiplicatively by 0.85 so their ratios are preserved exactly while
-    making room for the 15% momentum allocation. When _MOMENTUM_ENABLED
-    is False the pre-3b tuple is used and district_momentum_score is
+    The 2026-05-07 rebalance lifted freshness (0.2550 → 0.30) and momentum
+    (0.1500 → 0.35) and rescaled the remaining sub-weights by
+    0.35 / 0.595 = 0.5882353. When _MOMENTUM_ENABLED is False the pre-3b
+    tuple (0.30/0.40/0.20/0.10) is used and district_momentum_score is
     ignored.
 
     Momentum values are always on the same 0-100 scale as the other
@@ -2486,21 +2486,31 @@ def _listing_quality_score(
     furnished_signal = 100.0 if is_furnished else 50.0
 
     if _MOMENTUM_ENABLED:
-        # Multiplicative rebalance of the pre-3b sub-weights by 0.85 to
-        # make room for the 0.15 momentum slot. Ratios are preserved
-        # exactly (0.2550 : 0.3400 : 0.1700 : 0.0850 == 0.30 : 0.40 :
-        # 0.20 : 0.10). Unknown momentum → neutral 50.0 per the tri-state
-        # convention used by freshness and suitability above.
+        # Sub-weight rebalance — 2026-05-07 (CEO directive elevation).
+        # Audit (branch claude/audit-advisor-ranking-4prR3) found momentum
+        # contributing only ~1.65% and freshness only ~2.81% of final_score,
+        # below the noise threshold for any real rank movement. Lifted
+        # freshness 0.2550→0.30 and momentum 0.1500→0.35; the remaining
+        # sub-weights (suitability, image, furnished) were rescaled by
+        # 0.35 / 0.595 = 0.5882353 so the tuple still sums to 1.0:
+        #   suitability       0.3400 → 0.20
+        #   image_signal      0.1700 → 0.10
+        #   furnished_signal  0.0850 → 0.05
+        # Combined with the listing_quality top-level lift in
+        # _score_breakdown (0.11 → 0.22), momentum's share of final_score
+        # rises from ~1.65% to ~7.7% and freshness from ~2.81% to ~6.6%.
+        # Unknown momentum → neutral 50.0 per the tri-state convention
+        # used by freshness and suitability above.
         if district_momentum_score is None:
             momentum_signal = 50.0
         else:
             momentum_signal = _clamp(float(district_momentum_score))
         composite = (
-            freshness * 0.2550
-            + suitability * 0.3400
-            + image_signal * 0.1700
-            + furnished_signal * 0.0850
-            + momentum_signal * 0.1500
+            freshness * 0.30
+            + suitability * 0.20
+            + image_signal * 0.10
+            + furnished_signal * 0.05
+            + momentum_signal * 0.35
         )
     else:
         # Pre-3b weight tuple. Used by the kill-switch revert path;
@@ -2787,37 +2797,61 @@ def _score_breakdown(
 ) -> dict[str, Any]:
     """Listings-first weight distribution.
 
-    55% of weight is on listing-specific components:
-      - occupancy_economics (30%): rent burden, fitout, area, cannibalization
-      - listing_quality (11%): freshness, suitability, furnished, image
-      - landlord_signal (8%):  LLM read of landlord intent / listing copy
-      - access_visibility (10%): measured street width
-    41% on district context:
-      - brand_fit (11%): district preference + format fit
-      - competition_whitespace (10%)
-      - demand_potential (10%)
-      - delivery_demand (5%)
-      - confidence (5%): data trust signal
+    Post-2026-05-07 weights (CEO directive elevation; see comment block
+    on ``component_weights`` below):
+      - occupancy_economics (26.2924%): rent burden, fitout, area, cannibalization
+      - listing_quality (22%): freshness, momentum, suitability, furnished, image
+      - landlord_signal (7.0112%):  LLM read of landlord intent / listing copy
+      - access_visibility (8.7640%): measured street width
+      - brand_fit (9.6404%): district preference + format fit
+      - competition_whitespace (8.7640%)
+      - demand_potential (8.7640%)
+      - delivery_demand (4.3820%)
+      - confidence (4.3820%): data trust signal
 
-    Patch 13 promoted ``landlord_signal`` to its own first-class 8% component,
-    taking 4 points each from ``brand_fit`` and ``listing_quality`` so total
-    weights still sum to 100. Combined with the Patch 13 sub-component
-    rebalance inside ``_listing_quality_score``, the LLM-influenced share of
-    ``final_score`` rises from roughly 9% to roughly 18%.
+    Patch 13 promoted ``landlord_signal`` to its own first-class component,
+    taking points from ``brand_fit`` and ``listing_quality``. The
+    2026-05-07 rebalance then lifted ``listing_quality`` from 11 to 22 to
+    materially elevate the recency and district-momentum signals; every
+    other component was rescaled by 78/89 = 0.8764045 so weights still
+    sum to 100.
     """
+    # Top-level weight rebalance — 2026-05-07 (CEO directive elevation).
+    # Audit (branch claude/audit-advisor-ranking-4prR3) found that even
+    # after raising the momentum/freshness sub-weights inside
+    # _listing_quality_score, listing_quality at 11% of final_score kept
+    # both directives below the noise threshold. Lifted listing_quality
+    # 11 → 22; the remaining components were rescaled proportionally by
+    # (100 - 22) / (100 - 11) = 78 / 89 = 0.8764045, with the rounding
+    # residual absorbed into the largest remaining weight
+    # (occupancy_economics):
+    #   occupancy_economics    30 → 26.2924  (residual +0.0003 absorbed)
+    #   brand_fit              11 →  9.6404
+    #   landlord_signal         8 →  7.0112
+    #   competition_whitespace 10 →  8.7640
+    #   demand_potential       10 →  8.7640
+    #   access_visibility      10 →  8.7640
+    #   delivery_demand         5 →  4.3820
+    #   confidence              5 →  4.3820
+    # Net effect: momentum lifts to ~7.7% and freshness to ~6.6% of
+    # final_score (up from ~1.65% and ~2.81%). All other listing_quality
+    # sub-components also lift proportionally — listing-quality writ
+    # large (recency, momentum, suitability, image, furnished) is the
+    # CEO-aligned axis.
     component_weights = {
-        "occupancy_economics": 30,
-        "listing_quality": 11,
-        "brand_fit": 11,
-        "landlord_signal": 8,
-        "competition_whitespace": 10,
-        "demand_potential": 10,
-        "access_visibility": 10,
-        "delivery_demand": 5,
-        "confidence": 5,
+        "occupancy_economics": 26.2924,
+        "listing_quality": 22.0,
+        "brand_fit": 9.6404,
+        "landlord_signal": 7.0112,
+        "competition_whitespace": 8.7640,
+        "demand_potential": 8.7640,
+        "access_visibility": 8.7640,
+        "delivery_demand": 4.3820,
+        "confidence": 4.3820,
     }
     # Invariant: weights must sum to 100 so final_score stays on a 0-100 scale.
-    assert sum(component_weights.values()) == 100, (
+    # Tolerance accommodates IEEE-754 rounding of 4-decimal float weights.
+    assert abs(sum(component_weights.values()) - 100) < 1e-3, (
         f"_score_breakdown component weights must sum to 100, "
         f"got {sum(component_weights.values())}"
     )
@@ -2834,15 +2868,15 @@ def _score_breakdown(
         "confidence": round(_safe_float(confidence_score), 2),
     }
     weighted_components = {
-        "occupancy_economics": round(_safe_float(economics_score) * 0.30, 2),
-        "listing_quality": round(_safe_float(listing_quality_score) * 0.11, 2),
-        "brand_fit": round(_safe_float(brand_fit_score) * 0.11, 2),
-        "landlord_signal": round(landlord_input * 0.08, 2),
-        "competition_whitespace": round(_safe_float(whitespace_score) * 0.10, 2),
-        "demand_potential": round(_safe_float(demand_score) * 0.10, 2),
-        "access_visibility": round(_safe_float(access_visibility_score) * 0.10, 2),
-        "delivery_demand": round(_safe_float(provider_intelligence_composite) * 0.05, 2),
-        "confidence": round(_safe_float(confidence_score) * 0.05, 2),
+        "occupancy_economics": round(_safe_float(economics_score) * 0.262924, 2),
+        "listing_quality": round(_safe_float(listing_quality_score) * 0.22, 2),
+        "brand_fit": round(_safe_float(brand_fit_score) * 0.096404, 2),
+        "landlord_signal": round(landlord_input * 0.070112, 2),
+        "competition_whitespace": round(_safe_float(whitespace_score) * 0.087640, 2),
+        "demand_potential": round(_safe_float(demand_score) * 0.087640, 2),
+        "access_visibility": round(_safe_float(access_visibility_score) * 0.087640, 2),
+        "delivery_demand": round(_safe_float(provider_intelligence_composite) * 0.043820, 2),
+        "confidence": round(_safe_float(confidence_score) * 0.043820, 2),
     }
     final_score = round(sum(weighted_components.values()), 2)
     display = {

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -375,18 +375,21 @@ def generate_decision_memo(
 # to the legacy ``generate_decision_memo`` output byte-for-byte.
 
 # Deterministic scorer weights — kept in sync with the 9-component weights
-# in ``app.services.expansion_advisor``. Editing these here does NOT change
-# scoring; these are used only to compute memo-display contributions.
+# in ``app.services.expansion_advisor`` (see _score_breakdown). Editing
+# these here does NOT change scoring; these are used only to compute
+# memo-display contributions. 2026-05-07 rebalance: listing_quality lifted
+# 0.11 → 0.22 to elevate CEO-directive recency and momentum signals; every
+# other component rescaled by 78/89 = 0.8764045.
 COMPONENT_WEIGHTS: dict[str, float] = {
-    "occupancy_economics": 0.30,
-    "listing_quality": 0.11,
-    "brand_fit": 0.11,
-    "competition_whitespace": 0.10,
-    "demand_potential": 0.10,
-    "access_visibility": 0.10,
-    "landlord_signal": 0.08,
-    "delivery_demand": 0.05,
-    "confidence": 0.05,
+    "occupancy_economics": 0.262924,
+    "listing_quality": 0.22,
+    "brand_fit": 0.096404,
+    "competition_whitespace": 0.087640,
+    "demand_potential": 0.087640,
+    "access_visibility": 0.087640,
+    "landlord_signal": 0.070112,
+    "delivery_demand": 0.043820,
+    "confidence": 0.043820,
 }
 
 # Feature-snapshot fields that actually drive a decision. Used to truncate

--- a/tests/test_expansion_advisor_regression.py
+++ b/tests/test_expansion_advisor_regression.py
@@ -113,7 +113,9 @@ def test_score_breakdown_weights_sum_to_100():
         confidence_score=50.0,
         listing_quality_score=50.0,
     )
-    assert sum(bd["weights"].values()) == 100
+    # 2026-05-07 rebalance moved weights to 4-decimal floats; tolerance
+    # accommodates IEEE-754 rounding.
+    assert abs(sum(bd["weights"].values()) - 100) < 1e-3
 
 
 def test_score_breakdown_weighted_points_never_exceed_100():
@@ -1056,7 +1058,7 @@ def test_listing_quality_parcel_returns_neutral_50():
 
 
 def test_listing_quality_fresh_full_data_high_score():
-    """A fresh listing with full data should score close to 100."""
+    """A fresh listing with full data should score well above neutral."""
     score = _listing_quality_score(
         is_listing=True,
         effective_age_days=3,
@@ -1065,11 +1067,14 @@ def test_listing_quality_fresh_full_data_high_score():
         has_image=True,
         has_drive_thru=True,
     )
-    # Phase 3b: momentum defaults to neutral 50.0 when not passed.
-    # freshness=100, suitability=180→clamped 100, image=100, furnished=100,
-    # momentum=50. Composite ≈ 100*0.2550 + 100*0.3400 + 100*0.1700 +
-    # 100*0.0850 + 50*0.15 + 5 (drive-thru) = 25.5+34+17+8.5+7.5+5 = 97.5.
-    assert score > 90.0
+    # Post-2026-05-07 sub-weights (0.30/0.20/0.10/0.05/0.35) — momentum
+    # defaults to neutral 50.0 when not passed. freshness=100,
+    # suitability=180→clamped 100, image=100, furnished=100, momentum=50.
+    # Composite = 100*0.30 + 100*0.20 + 100*0.10 + 100*0.05 + 50*0.35 +
+    # 5 (drive-thru) = 30+20+10+5+17.5+5 = 87.5. The lower ceiling here
+    # (vs the prior 97.5) is the intended cost of letting unknown
+    # momentum pull the composite toward 50.
+    assert score > 80.0
 
 
 def test_listing_quality_stale_no_image_low_score():
@@ -1081,9 +1086,10 @@ def test_listing_quality_stale_no_image_low_score():
         unit_restaurant_score=None,
         has_image=False,
     )
-    # Phase 3b: momentum defaults to neutral 50.0 when not passed.
-    # composite = 15*0.2550 + 50*0.3400 + 30*0.1700 + 50*0.0850 + 50*0.15
-    #           = 3.825 + 17.00 + 5.10 + 4.25 + 7.50 = 37.675 < 50.
+    # Post-2026-05-07 sub-weights (0.30/0.20/0.10/0.05/0.35) — momentum
+    # defaults to neutral 50.0 when not passed.
+    # composite = 15*0.30 + 50*0.20 + 30*0.10 + 50*0.05 + 50*0.35
+    #           = 4.5 + 10.0 + 3.0 + 2.5 + 17.5 = 37.5 < 50.
     assert score < 50.0
 
 
@@ -1161,7 +1167,7 @@ def test_effective_age_all_null_returns_unknown_neutral():
     assert source == "unknown"
 
     # Fixed-neutral inputs to isolate the freshness contribution.
-    # Phase 3b: sub-weights are (0.2550, 0.3400, 0.1700, 0.0850, 0.15).
+    # Post-2026-05-07 sub-weights (0.30, 0.20, 0.10, 0.05, 0.35).
     # district_momentum_score=None → momentum resolves to neutral 50.0.
     common = dict(
         is_listing=True,
@@ -1174,14 +1180,14 @@ def test_effective_age_all_null_returns_unknown_neutral():
         district_momentum_score=None,
     )
     # suitability=50, image_signal=30, furnished_signal=50, momentum=50.
-    # Composite = freshness*0.2550 + 50*0.3400 + 30*0.1700 + 50*0.0850
-    #           + 50*0.15 = freshness*0.2550 + 33.85.
+    # Composite = freshness*0.30 + 50*0.20 + 30*0.10 + 50*0.05 + 50*0.35
+    #           = freshness*0.30 + 33.0.
     expected_with_freshness_50 = (
-        50.0 * 0.2550
-        + 50.0 * 0.3400
-        + 30.0 * 0.1700
-        + 50.0 * 0.0850
-        + 50.0 * 0.15
+        50.0 * 0.30
+        + 50.0 * 0.20
+        + 30.0 * 0.10
+        + 50.0 * 0.05
+        + 50.0 * 0.35
     )
     observed = _listing_quality_score(effective_age_days=None, **common)
     assert abs(observed - expected_with_freshness_50) < 1e-9
@@ -1211,11 +1217,11 @@ def test_effective_age_future_updated_at_clamps_to_zero():
         has_drive_thru=False,
         district_momentum_score=None,
     )
-    # Phase 3b weights (0.2550, 0.3400, 0.1700, 0.0850, 0.15). freshness
-    # = 100 (days <= 14 band), suitability=50, image_signal=30,
+    # Post-2026-05-07 sub-weights (0.30, 0.20, 0.10, 0.05, 0.35).
+    # freshness = 100 (days <= 14 band), suitability=50, image_signal=30,
     # furnished=50, momentum=50 (None → neutral). Composite =
-    # 100*0.2550 + 50*0.3400 + 30*0.1700 + 50*0.0850 + 50*0.15 = 59.35.
-    assert abs(score - 59.35) < 1e-9
+    # 100*0.30 + 50*0.20 + 30*0.10 + 50*0.05 + 50*0.35 = 63.0.
+    assert abs(score - 63.0) < 1e-9
 
 
 def test_effective_age_future_only_returns_unknown():
@@ -1247,9 +1253,9 @@ def test_effective_age_future_only_returns_unknown():
 )
 def test_effective_age_band_boundaries(age_days, expected_freshness):
     """Lock the frozen Phase 3a band cutoffs at 14/30/60/120/240/365 days
-    against silent drift. Phase 3b sub-weights (0.2550, 0.3400, 0.1700,
-    0.0850, 0.15); fixed inputs make suitability=50, image_signal=30,
-    furnished=50, momentum=50 (None)."""
+    against silent drift. Post-2026-05-07 sub-weights
+    (0.30, 0.20, 0.10, 0.05, 0.35); fixed inputs make suitability=50,
+    image_signal=30, furnished=50, momentum=50 (None)."""
     score = _listing_quality_score(
         is_listing=True,
         effective_age_days=age_days,
@@ -1260,11 +1266,11 @@ def test_effective_age_band_boundaries(age_days, expected_freshness):
         district_momentum_score=None,
     )
     expected_composite = (
-        expected_freshness * 0.2550
-        + 50.0 * 0.3400
-        + 30.0 * 0.1700
-        + 50.0 * 0.0850
-        + 50.0 * 0.15
+        expected_freshness * 0.30
+        + 50.0 * 0.20
+        + 30.0 * 0.10
+        + 50.0 * 0.05
+        + 50.0 * 0.35
     )
     assert abs(score - expected_composite) < 1e-9
 
@@ -1323,32 +1329,32 @@ def _fake_db_raising(exc: Exception):
 
 
 def test_listing_quality_score_momentum_high_raises_composite():
-    """Momentum sub-weight is 0.15. A 100 vs 0 momentum swing must raise
-    the composite by exactly (100 - 0) * 0.15 = 15.0 points, with all
-    other sub-signals held at their neutral values and the drive-thru
-    bonus disabled."""
+    """Momentum sub-weight is 0.35 post-2026-05-07. A 100 vs 0 momentum
+    swing must raise the composite by exactly (100 - 0) * 0.35 = 35.0
+    points, with all other sub-signals held at their neutral values and
+    the drive-thru bonus disabled."""
     common = _lq_neutral_kwargs(effective_age_days=30)
     high = _listing_quality_score(district_momentum_score=100.0, **common)
     low = _listing_quality_score(district_momentum_score=0.0, **common)
-    assert abs((high - low) - 15.0) < 1e-9
+    assert abs((high - low) - 35.0) < 1e-9
 
 
 def test_listing_quality_score_momentum_none_neutral():
     """district_momentum_score=None resolves to neutral 50.0. With
     fully-neutral other inputs (freshness=50, suitability=50,
-    image_signal=30, furnished=50) and Phase 3b sub-weights, composite
-    = 50*0.2550 + 50*0.3400 + 30*0.1700 + 50*0.0850 + 50*0.15 = 46.60."""
+    image_signal=30, furnished=50) and post-2026-05-07 sub-weights,
+    composite = 50*0.30 + 50*0.20 + 30*0.10 + 50*0.05 + 50*0.35 = 48.0."""
     common = _lq_neutral_kwargs(effective_age_days=None)
     observed = _listing_quality_score(district_momentum_score=None, **common)
     expected = (
-        50.0 * 0.2550
-        + 50.0 * 0.3400
-        + 30.0 * 0.1700
-        + 50.0 * 0.0850
-        + 50.0 * 0.15
+        50.0 * 0.30
+        + 50.0 * 0.20
+        + 30.0 * 0.10
+        + 50.0 * 0.05
+        + 50.0 * 0.35
     )
     assert abs(observed - expected) < 1e-9
-    assert abs(observed - 46.60) < 1e-9
+    assert abs(observed - 48.0) < 1e-9
 
 
 def test_listing_quality_score_momentum_below_floor_neutral():
@@ -1367,10 +1373,10 @@ def test_listing_quality_score_momentum_below_floor_neutral():
 
 
 def test_listing_quality_score_sub_weights_sum_to_one():
-    """Regression guard against silent sub-weight drift. Post-3b weights
-    must sum to 1.0 exactly under math.isclose."""
+    """Regression guard against silent sub-weight drift. Post-2026-05-07
+    sub-weights must sum to 1.0 exactly under math.isclose."""
     import math
-    assert math.isclose(0.2550 + 0.3400 + 0.1700 + 0.0850 + 0.15, 1.0)
+    assert math.isclose(0.30 + 0.20 + 0.10 + 0.05 + 0.35, 1.0)
 
 
 def test_district_momentum_score_composite_math():
@@ -1880,10 +1886,11 @@ def test_economics_score_damps_rent_burden_on_city_fallback():
 # ---------------------------------------------------------------------------
 
 def test_score_breakdown_economics_weight_is_30():
-    """occupancy_economics should still be weighted at 30%.
+    """Top-level weights post-2026-05-07 rebalance.
 
-    Patch 13 moved 4 points of listing_quality weight into a new
-    landlord_signal component, so listing_quality is now 11% not 15%.
+    listing_quality lifted 11 → 22 to elevate CEO-directive recency and
+    momentum signals; every other component rescaled by 78/89 = 0.8764045
+    so the total still sums to 100.
     """
     bd = _score_breakdown(
         demand_score=50.0,
@@ -1895,18 +1902,19 @@ def test_score_breakdown_economics_weight_is_30():
         confidence_score=50.0,
         listing_quality_score=50.0,
     )
-    assert bd["weights"]["occupancy_economics"] == 30
-    assert bd["weights"]["listing_quality"] == 11
-    assert bd["weights"]["landlord_signal"] == 8
-    # Weight total invariant: everything must sum to 100.
-    assert sum(bd["weights"].values()) == 100
+    assert abs(bd["weights"]["occupancy_economics"] - 26.2924) < 1e-6
+    assert bd["weights"]["listing_quality"] == 22.0
+    assert abs(bd["weights"]["landlord_signal"] - 7.0112) < 1e-6
+    # Weight total invariant: everything must sum to 100 (within FP tolerance).
+    assert abs(sum(bd["weights"].values()) - 100) < 1e-3
 
 
 def test_score_breakdown_listing_quality_contributes():
     """A high listing_quality should raise final_score vs a low one.
 
-    Patch 13 rebalance: listing_quality now carries 11% weight (down
-    from 15%) because 4 points moved to the new landlord_signal slot.
+    2026-05-07 rebalance: listing_quality now carries 22% weight (up
+    from 11%) so CEO-directive recency and momentum signals materially
+    move ranking.
     """
     high = _score_breakdown(
         demand_score=60.0,
@@ -1929,9 +1937,9 @@ def test_score_breakdown_listing_quality_contributes():
         listing_quality_score=20.0,
     )
     assert high["final_score"] > low["final_score"]
-    # With 11% weight, the difference should be (95-20)*0.11 = 8.25 points
+    # With 22% weight, the difference should be (95-20)*0.22 = 16.5 points.
     diff = high["final_score"] - low["final_score"]
-    assert abs(diff - 8.25) < 0.1
+    assert abs(diff - 16.5) < 0.1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_expansion_advisor_regression.py
+++ b/tests/test_expansion_advisor_regression.py
@@ -1557,7 +1557,8 @@ def test_listing_quality_scoring_callsite_two_district_delta():
     """Integration guard at the _listing_quality_score call-site contract.
     Two synthetic candidates share all inputs except their district's
     momentum score (80 vs absent → neutral 50). The composite must
-    differ by exactly (80 - 50) * 0.15 = 4.50 points."""
+    differ by exactly (80 - 50) * 0.35 = 10.50 points (post-2026-05-07
+    momentum sub-weight 0.35)."""
     momentum_dict = {
         "high_district": {"momentum_score": 80.0},
         # "low_district" intentionally absent → .get returns None → neutral.
@@ -1578,7 +1579,7 @@ def test_listing_quality_scoring_callsite_two_district_delta():
         district_momentum_score=low_val, **common
     )
 
-    assert abs((high_score - low_score) - 4.5) < 1e-9
+    assert abs((high_score - low_score) - 10.5) < 1e-9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -1768,23 +1768,26 @@ def test_score_breakdown_has_display_structure():
     assert "weight_percent" in dp
     assert "weighted_points" in dp
     assert dp["raw_input_score"] == 80.0
-    assert dp["weight_percent"] == 10  # Patch 06: demand_potential weight is now 10
-    assert dp["weighted_points"] == round(80.0 * 0.10, 2)
+    # 2026-05-07 rebalance: 10 -> 8.7640 (rescaled by 78/89).
+    assert abs(dp["weight_percent"] - 8.7640) < 1e-6
+    assert dp["weighted_points"] == round(80.0 * 0.087640, 2)
 
-    # Verify listing_quality entry (Patch 13: 15 -> 11, 4 pts shifted to landlord_signal)
+    # Verify listing_quality entry (2026-05-07: 11 -> 22 to elevate
+    # CEO-directive recency and momentum signals).
     lq = breakdown["display"]["listing_quality"]
     assert lq["raw_input_score"] == 60.0
-    assert lq["weight_percent"] == 11
-    assert lq["weighted_points"] == round(60.0 * 0.11, 2)
+    assert lq["weight_percent"] == 22.0
+    assert lq["weighted_points"] == round(60.0 * 0.22, 2)
 
-    # Patch 13: landlord_signal is a new first-class 8% component.
+    # Patch 13: landlord_signal is a new first-class component.
+    # 2026-05-07 rebalance: 8 -> 7.0112 (rescaled by 78/89).
     # When the optional landlord_signal_score arg is omitted it falls back
     # to a neutral 50.0 so rows missing the LLM signal aren't penalized.
     assert "landlord_signal" in breakdown["display"]
     ls = breakdown["display"]["landlord_signal"]
     assert ls["raw_input_score"] == 50.0
-    assert ls["weight_percent"] == 8
-    assert ls["weighted_points"] == round(50.0 * 0.08, 2)
+    assert abs(ls["weight_percent"] - 7.0112) < 1e-6
+    assert ls["weighted_points"] == round(50.0 * 0.070112, 2)
 
     # Verify weighted_points != weight_percent (they are NOT the same thing)
     for name, entry in breakdown["display"].items():

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -421,8 +421,10 @@ class TestBuildMemoContextContributionsMath:
         for comp, weight in COMPONENT_WEIGHTS.items():
             expected = round(weight * scores[comp], 3)
             assert contributions[comp] == expected, f"{comp}: got {contributions[comp]}, want {expected}"
-        # Spot-check the headline number the prompt expects to see
-        assert contributions["occupancy_economics"] == 27.0
+        # Spot-check the headline number the prompt expects to see.
+        # 2026-05-07 rebalance: occupancy_economics weight 0.30 → 0.262924,
+        # so contribution at score=90 = round(90 * 0.262924, 3) = 23.663.
+        assert contributions["occupancy_economics"] == 23.663
         # Weights sub-dict carried through for the LLM
         assert ctx.score_breakdown["weights"] == dict(COMPONENT_WEIGHTS)
 


### PR DESCRIPTION
## Summary

This change implements a CEO-directive rebalancing of the expansion advisor ranking algorithm to materially elevate the impact of listing recency and district momentum signals on final scores. The rebalance addresses an audit finding that these signals were contributing below the noise threshold despite their strategic importance.

## Key Changes

**Sub-weight rebalance in `_listing_quality_score`:**
- Increased freshness weight: 25.50% → 30.00%
- Increased momentum weight: 15.00% → 35.00%
- Decreased suitability weight: 34.00% → 20.00%
- Decreased image signal weight: 17.00% → 10.00%
- Decreased furnished weight: 8.50% → 5.00%
- Remaining sub-weights rescaled by factor 0.5882353 to preserve ratios while making room for momentum elevation

**Top-level weight rebalance in `_score_breakdown`:**
- Doubled listing_quality weight: 11% → 22% (from 100-point scale)
- Rescaled all other components by factor 78/89 = 0.8764045 to maintain 100-point total:
  - occupancy_economics: 30 → 26.2924
  - brand_fit: 11 → 9.6404
  - landlord_signal: 8 → 7.0112
  - competition_whitespace: 10 → 8.7640
  - demand_potential: 10 → 8.7640
  - access_visibility: 10 → 8.7640
  - delivery_demand: 5 → 4.3820
  - confidence: 5 → 4.3820

**Net impact on final_score:**
- Momentum contribution rises from ~1.65% to ~7.7%
- Freshness contribution rises from ~2.81% to ~6.6%
- All listing-quality sub-components (recency, momentum, suitability, image, furnished) lift proportionally

## Implementation Details

- Updated weight assertions to use floating-point tolerance (`abs(sum - 100) < 1e-3`) to accommodate IEEE-754 rounding of 4-decimal weights
- Updated all test expectations to reflect new sub-weights and top-level weights
- Maintained backward compatibility with `_MOMENTUM_ENABLED` kill-switch (pre-3b weights still available)
- Updated documentation in `llm_decision_memo.py` to keep component weights in sync with scoring logic
- All weight calculations preserve the 0-100 scale for final_score through proportional rescaling

https://claude.ai/code/session_019wuks7fx2bEd9vS4zujScT