### PR TITLE
Filter expansion candidates by commercial unit active status

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -9398,6 +9398,14 @@ def get_candidates(db: Session, search_id: str, district_lookup: dict[str, dict[
                 (decision_memo_json IS NOT NULL OR decision_memo IS NOT NULL) AS decision_memo_present
             FROM expansion_candidate
             WHERE search_id = :search_id
+              AND (
+                source_type != 'commercial_unit'
+                OR EXISTS (
+                  SELECT 1 FROM commercial_unit cu
+                  WHERE cu.aqar_id = expansion_candidate.parcel_id
+                    AND cu.status = 'active'
+                )
+              )
             ORDER BY rank_position ASC NULLS LAST, compare_rank ASC NULLS LAST, final_score DESC, computed_at DESC
             """
         ),
@@ -9699,6 +9707,14 @@ def compare_candidates(db: Session, search_id: str, candidate_ids: list[str]) ->
             FROM expansion_candidate
             WHERE search_id = :search_id
               AND id = ANY(:candidate_ids)
+              AND (
+                source_type != 'commercial_unit'
+                OR EXISTS (
+                  SELECT 1 FROM commercial_unit cu
+                  WHERE cu.aqar_id = expansion_candidate.parcel_id
+                    AND cu.status = 'active'
+                )
+              )
             """
         ),
         {"search_id": search_id, "candidate_ids": candidate_ids},
@@ -9923,6 +9939,14 @@ def get_candidate_memo(db: Session, candidate_id: str) -> dict[str, Any] | None:
             FROM expansion_candidate c
             JOIN expansion_search s ON s.id = c.search_id
             WHERE c.id = :candidate_id
+              AND (
+                c.source_type != 'commercial_unit'
+                OR EXISTS (
+                  SELECT 1 FROM commercial_unit cu
+                  WHERE cu.aqar_id = c.parcel_id
+                    AND cu.status = 'active'
+                )
+              )
             """
         ),
         {"candidate_id": candidate_id},

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -76,7 +76,10 @@ class FakeDB:
         if "WITH listing_district AS" in sql:
             return _Result([])
         # commercial_unit queries → return candidate rows
-        if "FROM commercial_unit" in sql:
+        # Scope to top-level reads — the serve queries (compare/memo)
+        # also reference commercial_unit inside an EXISTS guard subquery,
+        # which we want routed to the expansion_candidate branches below.
+        if "FROM commercial_unit" in sql and "FROM expansion_candidate" not in sql:
             return _Result(self.candidate_rows)
         if "INSERT INTO expansion_candidate" in sql:
             self.inserted.append(params)


### PR DESCRIPTION
## Summary
Added filtering logic to exclude inactive commercial unit candidates from expansion candidate queries across three key functions in the expansion advisor service.

## Key Changes
- **get_candidates()**: Added WHERE clause condition to filter out commercial unit source types unless they have an active status in the commercial_unit table
- **compare_candidates()**: Applied the same filtering logic when retrieving candidates for comparison
- **get_candidate_memo()**: Extended filtering to the memo retrieval query to maintain consistency

## Implementation Details
The filtering uses a conditional OR logic pattern:
- Excludes candidates where `source_type = 'commercial_unit'` AND the corresponding commercial unit record is not active
- Allows all non-commercial unit candidates to pass through
- Allows commercial unit candidates only if they have an active status record in the `commercial_unit` table (matched by `aqar_id` to `parcel_id`)

This ensures that only candidates with active commercial units are returned across all candidate retrieval operations, preventing stale or inactive commercial unit data from appearing in search results and comparisons.

https://claude.ai/code/session_01MnSv5qCvmTNcFeckxxktEi