### PR TITLE
Gate listing confidence grades by road/parking evidence bands

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -3125,6 +3125,8 @@ def _confidence_grade(
     delivery_observed: bool = True,
     data_completeness_score: int | float = 0,
     is_listing: bool = False,
+    road_evidence_band: str | None = None,
+    parking_evidence_band: str | None = None,
 ) -> str:
     """Map a 0-100 confidence score to an A/B/C/D grade.
 
@@ -3144,16 +3146,35 @@ def _confidence_grade(
     if rent_source != "conservative_default":
         adjusted += 3.0
 
+    def _band_missing(band: str | None) -> bool:
+        if band is None:
+            return True
+        return band.strip().lower() in {"none", "none_found", "unknown"}
+
     if is_listing:
-        # Listings: score is grounded in unit-level ground truth.
-        # Trust the score directly without parcel-context demotions.
+        # Listings: trust the score for the score-derived band, but let the
+        # road and parking evidence bands gate the ceiling. When both bands
+        # are missing we cap at B (not C) so the headline grade stays in
+        # range of the score signal while preventing UI contradictions like
+        # "Data: A" rendered next to "Road access evidence: None found /
+        # Parking evidence: None found"; capping below B would amount to a
+        # cohort re-grade, which the score itself does not justify.
+        missing_bands = sum(
+            1
+            for band in (road_evidence_band, parking_evidence_band)
+            if _band_missing(band)
+        )
         if adjusted >= 85.0:
-            return "A"
-        if adjusted >= 70.0:
-            return "B"
-        if adjusted >= 50.0:
-            return "C"
-        return "D"
+            grade = "A"
+        elif adjusted >= 70.0:
+            grade = "B"
+        elif adjusted >= 50.0:
+            grade = "C"
+        else:
+            grade = "D"
+        if missing_bands >= 2 and grade == "A":
+            grade = "B"
+        return grade
 
     # Parcel path: legacy logic, unchanged.
     critical_missing = 0
@@ -8724,6 +8745,8 @@ def run_expansion_search(
             delivery_observed=provider_listing_count > 0,
             data_completeness_score=feature_snapshot_json.get("data_completeness_score", 0),
             is_listing=_is_listing,
+            road_evidence_band=feature_snapshot_json.get("context_sources", {}).get("road_evidence_band"),
+            parking_evidence_band=feature_snapshot_json.get("context_sources", {}).get("parking_evidence_band"),
         )
         demand_thesis = _build_demand_thesis(
             demand_score=demand_score,

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -1417,9 +1417,9 @@ VOICE EXAMPLES (target tone — match this directness and depth):
 Example C — strong recommend, score 84, rank 1, district-tier comparable:
 {
   "headline_recommendation": "Recommend — asking rent sits at the 28th percentile vs district comparables and the corner frontage gives the brand visibility from two arteries.",
-  "ranking_explanation": "The investment case here is rent: SAR 432,000/yr lands at the 28th percentile vs 14 district comparables, a roughly SAR 110,000/yr discount to the median that compounds materially over a five-year lease. Site quality reinforces the economics — a 24 m corner on a primary artery with an access/visibility score of 82/100 — and a population reach of 41,000 inside the walking catchment supports the dine-in model. The trade-off is depth of competition: three named chains operate within 500 m, so the brand will need a defensible category position rather than a generic offer.",
+  "ranking_explanation": "The investment case here is rent: SAR 432,000/yr lands at the 28th percentile vs 14 district comparables — roughly 20% below the SAR 542,000 median, a cushion that compounds materially over a five-year lease. Site quality reinforces the economics — a 24 m corner on a primary artery with an access/visibility score of 82/100 — and a population reach of 41,000 inside the walking catchment supports the dine-in model. The trade-off is depth of competition: three named chains operate within 500 m, so the brand will need a defensible category position rather than a generic offer.",
   "key_evidence": [
-    {"signal": "annual rent", "value": "SAR 432,000/yr", "implication": "the spread to the district median justifies the entry — roughly SAR 110k/yr saved vs peer listings", "polarity": "positive"},
+    {"signal": "annual rent", "value": "SAR 432,000/yr", "implication": "asking sits roughly 20% below the district median — the entry basis is genuinely below peer listings, not just below list", "polarity": "positive"},
     {"signal": "rent percentile vs comparables", "value": "28th percentile (vs 14 district comparables)", "implication": "deal pricing is genuinely below market, not just below list", "polarity": "positive"},
     {"signal": "frontage", "value": "24 m corner", "implication": "signage works in both traffic directions on a primary artery", "polarity": "positive"},
     {"signal": "access/visibility score", "value": "82/100", "implication": "site quality reinforces the rent advantage rather than offsetting it", "polarity": "positive"},
@@ -1431,7 +1431,7 @@ Example C — strong recommend, score 84, rank 1, district-tier comparable:
     {"risk": "Parking provision could not be verified from current data — typical for Aqar listings, not a site defect.", "mitigation": "Walk the block at peak hours during diligence; lease two adjacent street stalls from the neighbour if curbside turnover is constrained."},
     {"risk": "Listing has been live for 102 days, longer than is typical for prime corner units in this district.", "mitigation": "Open negotiation 8–12% below asking and ask the landlord to absorb fit-out contribution."}
   ],
-  "comparison": "This site beats Peer Chain A on rent by roughly SAR 90k/yr and matches Peer Chain B on visibility, while pulling ahead of rank 2 in this search on rent percentile (28th vs 47th) and access/visibility (82/100 vs 71/100). Rank 2 has a marginally larger footprint but no comparable corner exposure.",
+  "comparison": "This site undercuts Peer Chain A on rent by roughly 17% and matches Peer Chain B on visibility, while pulling ahead of rank 2 in this search on rent percentile (28th vs 47th) and access/visibility (82/100 vs 71/100). Rank 2 has a marginally larger footprint but no comparable corner exposure.",
   "bottom_line": "This is the deal in the shortlist — sign it before the listing turns."
 }
 
@@ -1481,9 +1481,9 @@ Inline note on missing rank-2 alternatives: when next_candidate_summary is absen
 Example F — strong recommend with the four typed advisory sections fully populated (district-tier comparable, rank-2 present):
 {
   "headline_recommendation": "Recommend — asking rent sits at the 28th percentile vs district comparables and the corner frontage gives the brand visibility from two arteries.",
-  "ranking_explanation": "The investment case here is rent: SAR 432,000/yr lands at the 28th percentile vs 14 district comparables, a roughly SAR 110,000/yr discount to the median. Site quality reinforces the economics — a 24 m corner on a primary artery with an access/visibility score of 82/100 — and a population reach of 41,000 inside the walking catchment supports the dine-in model. The trade-off is depth of competition: three named chains operate within 500 m, so the brand will need a defensible category position rather than a generic offer.",
+  "ranking_explanation": "The investment case here is rent: SAR 432,000/yr lands at the 28th percentile vs 14 district comparables — roughly 20% below the SAR 542,000 median. Site quality reinforces the economics — a 24 m corner on a primary artery with an access/visibility score of 82/100 — and a population reach of 41,000 inside the walking catchment supports the dine-in model. The trade-off is depth of competition: three named chains operate within 500 m, so the brand will need a defensible category position rather than a generic offer.",
   "key_evidence": [
-    {"signal": "annual rent", "value": "SAR 432,000/yr", "implication": "the spread to the district median justifies the entry — roughly SAR 110k/yr saved vs peer listings", "polarity": "positive"},
+    {"signal": "annual rent", "value": "SAR 432,000/yr", "implication": "asking sits roughly 20% below the district median — the entry basis is genuinely below peer listings, not just below list", "polarity": "positive"},
     {"signal": "rent percentile vs comparables", "value": "28th percentile (vs 14 district comparables)", "implication": "deal pricing is genuinely below market, not just below list", "polarity": "positive"},
     {"signal": "frontage", "value": "24 m corner", "implication": "signage works in both traffic directions on a primary artery", "polarity": "positive"},
     {"signal": "access/visibility score", "value": "82/100", "implication": "site quality reinforces the rent advantage rather than offsetting it", "polarity": "positive"},
@@ -1494,7 +1494,7 @@ Example F — strong recommend with the four typed advisory sections fully popul
     {"risk": "Three established chains operate within 500 m, including two with strong delivery presence — undifferentiated entry will compete on price.", "mitigation": "Lead with a single-SKU hero menu and a sharper delivery price point in the first 90 days."},
     {"risk": "Listing has been live for 64 days, longer than is typical for prime corner units in this district.", "mitigation": "Open negotiation 8–12% below asking and ask the landlord to absorb fit-out contribution."}
   ],
-  "comparison": "This site beats Peer Chain A on rent by roughly SAR 90k/yr and matches Peer Chain B on visibility, while pulling ahead of rank 2 in this search on rent percentile (28th vs 47th) and access/visibility (82/100 vs 71/100). Rank 2 has a marginally larger footprint but no comparable corner exposure.",
+  "comparison": "This site undercuts Peer Chain A on rent by roughly 17% and matches Peer Chain B on visibility, while pulling ahead of rank 2 in this search on rent percentile (28th vs 47th) and access/visibility (82/100 vs 71/100). Rank 2 has a marginally larger footprint but no comparable corner exposure.",
   "bottom_line": "This is the deal in the shortlist — sign it before the listing turns.",
   "property_overview": {
     "summary": "180 m² corner unit on a primary artery, 24 m frontage, listed 64 days ago.",
@@ -1507,8 +1507,8 @@ Example F — strong recommend with the four typed advisory sections fully popul
     "vacancy_status": "vacant"
   },
   "financial_framing": {
-    "summary": "SAR 432,000/yr at the 28th percentile vs 14 district comparables — SAR 110k under median.",
-    "thesis": "Rent is the spine of the case at this site. SAR 432,000/yr is decisively below the SAR 542,000 district median across 14 peer listings — a SAR 110,000/yr cushion that compounds across a five-year lease and absorbs the operator's first-year ramp risk. The 28th percentile reading is district-scoped, not a wider city band, so the comparison sits inside the same demand catchment the operator will trade in. The thesis is straightforward: enter at this basis, run operational margin, and the deal does not need a heroic revenue assumption to clear.",
+    "summary": "SAR 432,000/yr at the 28th percentile vs 14 district comparables — roughly 20% below the SAR 542,000 median.",
+    "thesis": "Rent is the spine of the case at this site. SAR 432,000/yr sits roughly 20% below the SAR 542,000 district median across 14 peer listings — a cushion that compounds across a five-year lease and absorbs the operator's first-year ramp risk. The 28th percentile reading is district-scoped, not a wider city band, so the comparison sits inside the same demand catchment the operator will trade in. The thesis is straightforward: enter at this basis, run operational margin, and the deal does not need a heroic revenue assumption to clear.",
     "annual_rent_sar": 432000,
     "comparable_median_annual_rent_sar": 542000,
     "rent_percentile_vs_comparables": 0.28,
@@ -1527,7 +1527,7 @@ Example F — strong recommend with the four typed advisory sections fully popul
   },
   "competitive_landscape": {
     "summary": "3 named chains within 500 m; rank 2 in this search clears at the 47th rent percentile.",
-    "saturation_thesis": "Three named chains operate within 500 m — Peer Chain A, Peer Chain B, and Peer Chain C — confirming the category trades and raising the bar on differentiation. Rank 2 in this search sits at the 47th rent percentile vs comparables and an access/visibility score of 71/100, materially weaker than this site on both axes; the operator is paying SAR 110k less for a stronger street position. The competitive read supports entry, but only with a defensible category position rather than a generic offer.",
+    "saturation_thesis": "Three named chains operate within 500 m — Peer Chain A, Peer Chain B, and Peer Chain C — confirming the category trades and raising the bar on differentiation. Rank 2 in this search sits at the 47th rent percentile vs comparables and an access/visibility score of 71/100, materially weaker than this site on both axes; the operator is paying roughly 20% below the district median for a stronger street position. The competitive read supports entry, but only with a defensible category position rather than a generic offer.",
     "top_chains": [
       {"display_name_en": "Peer Chain A", "display_name_ar": null, "branch_count": 2, "nearest_distance_m": 180},
       {"display_name_en": "Peer Chain B", "display_name_ar": null, "branch_count": 1, "nearest_distance_m": 320},

--- a/tests/services/test_expansion_advisor_confidence.py
+++ b/tests/services/test_expansion_advisor_confidence.py
@@ -1,0 +1,66 @@
+"""Unit tests for ``_confidence_grade``.
+
+Cover the listings branch where the road and parking evidence bands now
+gate the maximum grade — both bands missing caps at B, regardless of how
+strong the underlying score is — and verify that the parcels branch
+ignores the new params (its existing critical-missing logic already
+covers the same ground).
+"""
+
+from app.services.expansion_advisor import _confidence_grade
+
+
+def _listings_grade(score: float, road: str | None, parking: str | None) -> str:
+    return _confidence_grade(
+        confidence_score=score,
+        district=None,
+        provider_platform_count=None,
+        multi_platform_presence_score=0.0,
+        rent_source="conservative_default",
+        is_listing=True,
+        road_evidence_band=road,
+        parking_evidence_band=parking,
+    )
+
+
+def test_listings_score_100_both_primary_returns_A():
+    assert _listings_grade(100.0, "primary", "primary") == "A"
+
+
+def test_listings_score_100_one_band_missing_still_returns_A():
+    assert _listings_grade(100.0, "none_found", "primary") == "A"
+
+
+def test_listings_score_100_both_none_found_caps_at_B():
+    assert _listings_grade(100.0, "none_found", "none_found") == "B"
+
+
+def test_listings_score_100_both_bands_none_caps_at_B():
+    assert _listings_grade(100.0, None, None) == "B"
+
+
+def test_listings_score_60_both_none_found_floor_wins_at_C():
+    assert _listings_grade(60.0, "none_found", "none_found") == "C"
+
+
+def test_parcels_branch_ignores_new_params():
+    base_kwargs = dict(
+        confidence_score=100.0,
+        district=None,
+        provider_platform_count=None,
+        multi_platform_presence_score=0.0,
+        rent_source="conservative_default",
+        road_context_available=True,
+        parking_context_available=True,
+        zoning_available=True,
+        delivery_observed=True,
+        data_completeness_score=100,
+        is_listing=False,
+    )
+    baseline = _confidence_grade(**base_kwargs)
+    with_bands = _confidence_grade(
+        **base_kwargs,
+        road_evidence_band="none_found",
+        parking_evidence_band="none_found",
+    )
+    assert baseline == with_bands

--- a/tests/test_expansion_advisor.py
+++ b/tests/test_expansion_advisor.py
@@ -594,7 +594,11 @@ def test_confidence_score_parcel_legacy_base():
 
 
 def test_confidence_grade_listing_a():
-    """Listing with high score grades A without needing parcel context."""
+    """Listing with high score grades A without needing parcel context.
+
+    Evidence bands are present (``primary``) so the listings ceiling cap
+    based on missing road/parking bands does not apply.
+    """
     grade = _confidence_grade(
         confidence_score=85.0,
         district="Al Olaya",
@@ -607,6 +611,8 @@ def test_confidence_grade_listing_a():
         delivery_observed=False,
         data_completeness_score=0,
         is_listing=True,
+        road_evidence_band="primary",
+        parking_evidence_band="primary",
     )
     assert grade == "A"
 


### PR DESCRIPTION
## Summary
Adds road and parking evidence band parameters to the listing confidence grading logic, capping the maximum grade at B when both evidence bands are missing. This prevents UI contradictions where a high confidence grade is displayed alongside "None found" evidence indicators.

## Key Changes
- **`_confidence_grade()` function**: Added `road_evidence_band` and `parking_evidence_band` parameters that only apply to listings (parcels branch ignores them)
  - When both bands are missing/unknown, caps the grade at B regardless of the underlying confidence score
  - When at least one band is present, the score-derived grade is returned unchanged
  - Preserves the existing score signal while preventing misleading grade/evidence mismatches

- **Data flow**: Updated the call site in `_build_expansion_advisor_context()` to extract and pass the evidence bands from `feature_snapshot_json["context_sources"]`

- **Test coverage**: Added comprehensive unit tests covering:
  - Grade A returned when both bands are primary
  - Grade A returned when only one band is missing
  - Grade capped at B when both bands are missing/none_found
  - Parcels branch unaffected by the new parameters

- **Documentation updates**: Refined example text in `llm_decision_memo.py` for clarity (percentage-based rent comparisons instead of absolute values)

## Implementation Details
- The `_band_missing()` helper normalizes band values to handle None, "none", "none_found", and "unknown" consistently
- The cap applies only when `missing_bands >= 2 and grade == "A"`, allowing lower grades to pass through unchanged
- Parcels path retains its existing critical-missing logic and is unaffected by the new parameters

https://claude.ai/code/session_01CDCfyo2WGvPrLefFoaR44i