### PR TITLE
Flatten expansion results list; move tier indicators to cards

### DIFF
--- a/frontend/src/features/expansion-advisor/ExpansionCandidateCard.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionCandidateCard.tsx
@@ -177,6 +177,14 @@ export default function ExpansionCandidateCard({
               {t("expansionAdvisor.premierBadge")}
             </span>
           )}
+          {isExploratory && (
+            <span
+              className="ea-badge ea-badge--exploratory ea-candidate__exploratory-pill"
+              title={t("expansionAdvisor.exploratoryBadgeTooltip")}
+            >
+              {t("expansionAdvisor.exploratoryBadge")}
+            </span>
+          )}
           <ScorePill value={getDisplayScore(candidate)} />
           {/* value_band chip — derived "strong location at a fair price"
             * signal. Three states render:

--- a/frontend/src/features/expansion-advisor/ExpansionResultsPanel.test.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionResultsPanel.test.tsx
@@ -47,12 +47,12 @@ const EXPLORATORY_OVERRIDES: Partial<ExpansionCandidate> = {
   gate_status_json: { overall_pass: false },
 };
 
-describe("ExpansionResultsPanel — tier section headers", () => {
-  it("renders no section headers when every candidate is Standard", () => {
+describe("ExpansionResultsPanel — flat rank-ordered render", () => {
+  it("never renders tier section headers (no grouping in the panel)", () => {
     const items = [
-      baseCandidate({ id: "c1", rank_position: 1 }),
+      baseCandidate({ id: "c1", rank_position: 1, ...PREMIER_OVERRIDES }),
       baseCandidate({ id: "c2", rank_position: 2 }),
-      baseCandidate({ id: "c3", rank_position: 3 }),
+      baseCandidate({ id: "c3", rank_position: 3, ...EXPLORATORY_OVERRIDES }),
     ];
     const html = render(items);
     expect(html).not.toContain("ea-candidate-list__section-header");
@@ -60,43 +60,28 @@ describe("ExpansionResultsPanel — tier section headers", () => {
     expect(html).not.toContain("Also consider");
   });
 
-  it("renders the Premier header only when a Premier candidate exists", () => {
-    const items = [
-      baseCandidate({ id: "c1", rank_position: 1, ...PREMIER_OVERRIDES }),
-      baseCandidate({ id: "c2", rank_position: 2 }),
-    ];
-    const html = render(items);
-    expect(html).toContain("Premier — best of the best");
-    expect(html).not.toContain("Also consider");
-  });
-
-  it("renders the Exploratory header only when an Exploratory candidate exists", () => {
+  it("renders candidates in the exact order supplied by the backend", () => {
+    // Mixed tiers in backend rank order: standard, standard, premier,
+    // standard, exploratory. The panel must preserve this order — a
+    // Premier card at rank 3 sits at DOM position 3, not lifted to the top.
     const items = [
       baseCandidate({ id: "c1", rank_position: 1 }),
-      baseCandidate({ id: "c2", rank_position: 2, ...EXPLORATORY_OVERRIDES }),
-    ];
-    const html = render(items);
-    expect(html).not.toContain("Premier — best of the best");
-    expect(html).toContain("Also consider");
-  });
-
-  it("renders both headers when both tiers are populated", () => {
-    const items = [
-      baseCandidate({ id: "c1", rank_position: 1, ...PREMIER_OVERRIDES }),
       baseCandidate({ id: "c2", rank_position: 2 }),
-      baseCandidate({ id: "c3", rank_position: 3, ...EXPLORATORY_OVERRIDES }),
+      baseCandidate({ id: "c3", rank_position: 3, ...PREMIER_OVERRIDES }),
+      baseCandidate({ id: "c4", rank_position: 4 }),
+      baseCandidate({ id: "c5", rank_position: 5, ...EXPLORATORY_OVERRIDES }),
     ];
     const html = render(items);
-    expect(html).toContain("Premier — best of the best");
-    expect(html).toContain("Also consider");
-    // Premier section must appear before Exploratory section in the DOM.
-    const premierIdx = html.indexOf("Premier — best of the best");
-    const exploratoryIdx = html.indexOf("Also consider");
-    expect(premierIdx).toBeGreaterThan(-1);
-    expect(exploratoryIdx).toBeGreaterThan(premierIdx);
+    const positions = ["c1", "c2", "c3", "c4", "c5"].map((id) =>
+      html.indexOf(`data-candidate-id="${id}"`),
+    );
+    positions.forEach((p) => expect(p).toBeGreaterThan(-1));
+    for (let i = 1; i < positions.length; i += 1) {
+      expect(positions[i]).toBeGreaterThan(positions[i - 1]);
+    }
   });
 
-  it("renders the Premier pill on Premier cards", () => {
+  it("renders the Premier chip on Premier cards (in-card, not under a header)", () => {
     const items = [baseCandidate({ id: "c1", rank_position: 1, ...PREMIER_OVERRIDES })];
     const html = render(items);
     expect(html).toContain("ea-candidate--premier");
@@ -104,12 +89,19 @@ describe("ExpansionResultsPanel — tier section headers", () => {
     expect(html).toContain(">Premier<");
   });
 
-  it("applies the exploratory class (muted) on Exploratory cards", () => {
+  it("renders the Exploratory chip on Exploratory cards", () => {
     const items = [baseCandidate({ id: "c1", rank_position: 1, ...EXPLORATORY_OVERRIDES })];
     const html = render(items);
     expect(html).toContain("ea-candidate--exploratory");
-    // No "Exploratory" label on the card itself — the section header carries it.
-    expect(html).not.toContain(">Exploratory<");
+    expect(html).toContain("ea-candidate__exploratory-pill");
+    expect(html).toContain(">Exploratory<");
+  });
+
+  it("renders no tier chip on Standard cards", () => {
+    const items = [baseCandidate({ id: "c1", rank_position: 1 })];
+    const html = render(items);
+    expect(html).not.toContain("ea-candidate__premier-pill");
+    expect(html).not.toContain("ea-candidate__exploratory-pill");
   });
 
   it("handles an empty shortlist", () => {
@@ -118,7 +110,7 @@ describe("ExpansionResultsPanel — tier section headers", () => {
     expect(html).toContain("ea-candidate-list");
   });
 
-  it("preserves global rank numbers across tier groups (not reset per tier)", () => {
+  it("preserves global rank numbers across mixed tiers", () => {
     const items = [
       baseCandidate({ id: "c1", rank_position: 1, ...PREMIER_OVERRIDES }),
       baseCandidate({ id: "c2", rank_position: 2 }),

--- a/frontend/src/features/expansion-advisor/ExpansionResultsPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionResultsPanel.tsx
@@ -1,8 +1,7 @@
-import { useTranslation } from "react-i18next";
 import type { ExpansionCandidate } from "../../lib/api/expansionAdvisor";
 import ExpansionCandidateCard from "./ExpansionCandidateCard";
 import type { MemoDrawerSection } from "./ExpansionMemoPanel";
-import { groupCandidatesByTier, type CandidateTier } from "./tiers";
+import { classifyCandidateTier } from "./tiers";
 
 type Props = {
   items: ExpansionCandidate[];
@@ -21,65 +20,27 @@ type Props = {
 };
 
 export default function ExpansionResultsPanel(props: Props) {
-  const { t } = useTranslation();
-  const grouped = groupCandidatesByTier(props.items);
-
-  const renderCard = (item: ExpansionCandidate, tier: CandidateTier) => (
-    <ExpansionCandidateCard
-      key={item.id}
-      candidate={item}
-      selected={props.selectedCandidateId === item.id}
-      shortlisted={props.shortlistIds.includes(item.id)}
-      compared={props.compareIds.includes(item.id)}
-      isLead={item.id === props.leadCandidateId}
-      localSortActive={props.localSortActive}
-      tier={tier}
-      onSelect={() => props.onSelectCandidate(item)}
-      onCompareToggle={() => props.onToggleCompare(item.id)}
-      onOpenMemo={props.onOpenMemo ? (options) => props.onOpenMemo!(item.id, options) : undefined}
-      onShowOnMap={props.onShowOnMap ? () => props.onShowOnMap!(item) : undefined}
-    />
-  );
-
-  // When every candidate is Standard (the common case for small shortlists
-  // and for brand profiles where no candidate qualifies as Premier or
-  // Exploratory), render the flat list with no section headers — the UI
-  // looks identical to pre-patch behavior.
-  const hasPremier = grouped.premier.length > 0;
-  const hasExploratory = grouped.exploratory.length > 0;
-  const needsSectionHeaders = hasPremier || hasExploratory;
-
-  if (!needsSectionHeaders) {
-    return (
-      <div className="ea-candidate-list">
-        {grouped.standard.map((item) => renderCard(item, "standard"))}
-      </div>
-    );
-  }
-
+  // Render a single flat list in the order the backend returned the
+  // candidates (post score-delta sort). Tier is a per-card signal carried
+  // by ExpansionCandidateCard's own chip; the list itself does no grouping.
   return (
     <div className="ea-candidate-list">
-      {hasPremier && (
-        <div className="ea-candidate-list__section ea-candidate-list__section--premier">
-          <h3 className="ea-candidate-list__section-header ea-candidate-list__section-header--premier">
-            {t("expansionAdvisor.tierPremierHeader")}
-          </h3>
-          {grouped.premier.map((item) => renderCard(item, "premier"))}
-        </div>
-      )}
-      {grouped.standard.length > 0 && (
-        <div className="ea-candidate-list__section ea-candidate-list__section--standard">
-          {grouped.standard.map((item) => renderCard(item, "standard"))}
-        </div>
-      )}
-      {hasExploratory && (
-        <div className="ea-candidate-list__section ea-candidate-list__section--exploratory">
-          <h3 className="ea-candidate-list__section-header ea-candidate-list__section-header--exploratory">
-            {t("expansionAdvisor.tierExploratoryHeader")}
-          </h3>
-          {grouped.exploratory.map((item) => renderCard(item, "exploratory"))}
-        </div>
-      )}
+      {props.items.map((item) => (
+        <ExpansionCandidateCard
+          key={item.id}
+          candidate={item}
+          selected={props.selectedCandidateId === item.id}
+          shortlisted={props.shortlistIds.includes(item.id)}
+          compared={props.compareIds.includes(item.id)}
+          isLead={item.id === props.leadCandidateId}
+          localSortActive={props.localSortActive}
+          tier={classifyCandidateTier(item)}
+          onSelect={() => props.onSelectCandidate(item)}
+          onCompareToggle={() => props.onToggleCompare(item.id)}
+          onOpenMemo={props.onOpenMemo ? (options) => props.onOpenMemo!(item.id, options) : undefined}
+          onShowOnMap={props.onShowOnMap ? () => props.onShowOnMap!(item) : undefined}
+        />
+      ))}
     </div>
   );
 }

--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -256,6 +256,17 @@
   opacity: 1;
 }
 
+.ea-badge--exploratory {
+  background: #e0e7ff;
+  color: #3730a3;
+}
+
+.ea-candidate__exploratory-pill {
+  font-size: 11px;
+  padding: 1px 8px;
+  letter-spacing: 0.02em;
+}
+
 /* ─ Candidate card ─ */
 .ea-candidate {
   display: grid;

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -888,6 +888,8 @@
     "updatedBadgeTooltip": "تم تحديث العقار على عقار خلال آخر 7 أيام",
     "premierBadge": "متميّز",
     "premierBadgeTooltip": "ثقة عالية، يجتاز جميع المعايير، وحاصل على أعلى الدرجات",
+    "exploratoryBadge": "استكشافي",
+    "exploratoryBadgeTooltip": "ثقة أقل أو فشل في أحد المعايير — راجع بعناية قبل الإضافة إلى القائمة المختصرة",
     "tierPremierHeader": "متميّز — الأفضل بين الأفضل",
     "tierExploratoryHeader": "خيارات إضافية للنظر",
     "viewOnAqar": "عرض في عقار",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -961,6 +961,8 @@
     "updatedBadgeTooltip": "Listing refreshed by the owner on Aqar within the last 7 days",
     "premierBadge": "Premier",
     "premierBadgeTooltip": "High confidence, clears all gates, and scores in the top tier",
+    "exploratoryBadge": "Exploratory",
+    "exploratoryBadgeTooltip": "Lower confidence or a failed gate — review carefully before shortlisting",
     "tierPremierHeader": "Premier — best of the best",
     "tierExploratoryHeader": "Also consider",
     "viewOnAqar": "View on Aqar",


### PR DESCRIPTION
## Summary
Refactored the expansion results panel to render candidates in a single flat list ordered by backend rank, rather than grouping them into tier-based sections. Tier classification is now a per-card visual signal (badge/chip) rather than a structural grouping mechanism.

## Key Changes
- **Removed tier-based grouping**: Eliminated `groupCandidatesByTier()` call and section headers (Premier, Exploratory). Candidates now render in the exact order returned by the backend.
- **Added Exploratory badge**: Implemented a new in-card chip for Exploratory candidates (matching the existing Premier badge pattern) with localized text and tooltip.
- **Simplified component logic**: Removed conditional rendering of section headers and the `renderCard` helper function. The component now uses a straightforward `map()` over all items.
- **Updated tier classification**: Changed from passing grouped tier data to calling `classifyCandidateTier(item)` per card, making tier a computed property rather than a structural grouping.
- **Removed i18n dependencies**: Eliminated the `useTranslation()` hook from the panel (section headers no longer needed); tier labels now live on individual cards.
- **Updated tests**: Refactored test suite to verify flat rank-ordered rendering, per-card tier chips, and that section headers are never rendered.
- **Added CSS**: New styles for `.ea-badge--exploratory` and `.ea-candidate__exploratory-pill` to match Premier badge styling.
- **Localization**: Added `exploratoryBadge` and `exploratoryBadgeTooltip` keys to English and Arabic translation files.

## Implementation Details
- The `classifyCandidateTier()` function (from `tiers.ts`) is now called inline for each candidate to determine its tier classification.
- Tier information is purely visual via CSS classes and badge chips; the DOM structure is flat with no grouping containers.
- Global rank positions are preserved across all tiers in the flat list, maintaining the backend's score-delta sort order.

https://claude.ai/code/session_01XANYriCQm5v8uZeUxxrjWK