### PR TITLE
Recalibrate radiance growth thresholds post-analysis

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -233,10 +233,17 @@ class Settings:
     )
     # Minimum YoY radiance growth pct (0-100 scale) for the third leg (NASA
     # Black Marble VNP46A3) to rescue a candidate from market-viability
-    # flagging. Default 0 means any positive growth rescues; raise to e.g.
-    # 5.0 to require meaningful growth before granting a rescue.
+    # flagging. Operator is ``>=``. Rescue threshold for "confident,
+    # meaningfully growing" districts: only YoY at or above this floor
+    # mutes the pop/rent demote legs. Recalibrated 2026-05-10 against the
+    # rolling-6 candidate distribution (radiance_yoy_distribution.sql §7a):
+    # of 1,960 confident candidates over the last 30 days, ~1,000 (~51%)
+    # sit at >=2.0% YoY — the upper half of the confident-signal cohort,
+    # which is the "meaningfully growing" tier we want to rescue. Holding
+    # this at 0.0 rescued ~93% of confident candidates and made the
+    # rescue meaningless.
     EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD: float = float(
-        os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD", "0.0")
+        os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD", "2.0")
     )
     # Demote threshold for the radiance-growth leg of
     # _apply_market_viability_pass (CEO directive pillar 3 — "strong
@@ -244,19 +251,19 @@ class Settings:
     # is True and ``value_yoy_pct`` < this threshold, the candidate is
     # soft-demoted by the same positional mechanism as the population /
     # rent / economics / demand legs. Operator is strict ``<``.
-    # Calibrated 2026-05-06 against the candidate-side distribution from
-    # the last 24h of production searches (515 confident rolling-6
-    # candidates). Distribution is bimodal with an empty gap between
-    # 1.5% and 3.0% YoY; 2.0 sits inside that gap and demotes 234 of
-    # 515 confident candidates (~45%) — concentrated in two single
-    # districts (~0.01% and ~1.46% YoY). Above-typical citywide growth
-    # is ~5%, so below 2% is not "strong growth" per Faisal's directive
-    # (Pillar 3). Distinct from
+    # Recalibrated 2026-05-10 against the rolling-6 candidate distribution
+    # (radiance_yoy_distribution.sql §7b): of 1,960 confident candidates
+    # over the last 30 days, only ~140 (~7.1%) sit below 0% YoY. The prior
+    # 2.0 threshold demoted ~49% of confident candidates (820 flat 0..2%
+    # + 140 shrinking), compressing top scores; 0.0 isolates the
+    # "confidently shrinking" tier — districts whose own NTL signal is
+    # contracting — which is the only group the demote leg should fire
+    # on per Pillar 3. Distinct from
     # ``EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD`` above (which drives
     # the rescue side, operator ``>=``); splitting the knobs prevents
     # calibrating one from silently affecting the other.
     EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD: float = float(
-        os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD", "2.0")
+        os.getenv("EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD", "0.0")
     )
     # Kill switch for the radiance-growth demote leg. Setting this to
     # ``false`` suppresses the leg's demote decision while leaving the

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -3338,7 +3338,7 @@ def _viability_cohort_with_radiance_growth_target(
 
 def test_viability_radiance_growth_only_leg_fires(disable_market_viability_floors):
     # Radiance leg alone: pop above p25, rent low, economics healthy, demand
-    # mid-cohort. Confident negative YoY (-2.0%) below the calibrated 2.0
+    # mid-cohort. Confident negative YoY (-2.0%) below the calibrated 0.0
     # demote threshold ⇒ leg fires alone with reason="radiance_growth_low".
     cohort = _viability_cohort_with_radiance_growth_target(
         target_yoy_pct=-2.0,
@@ -3355,7 +3355,7 @@ def test_viability_radiance_growth_only_leg_fires(disable_market_viability_floor
     assert flag["radiance_growth_demote"] is True
     assert flag["radiance_growth_pct"] == -2.0
     assert flag["radiance_confident"] is True
-    assert flag["radiance_yoy_demote_threshold"] == 2.0
+    assert flag["radiance_yoy_demote_threshold"] == 0.0
     assert flag["reason"] == "radiance_growth_low"
     # Score-delta refactor: -10 per fired leg, no swap.
     assert target["viability_legs_fired"] == ["radiance_growth_low"]
@@ -3398,7 +3398,7 @@ def test_viability_radiance_growth_leg_no_growth_rescue(
 ):
     # Confident negative YoY drives the radiance leg, AND the same row
     # carries the same negative YoY (which can't self-rescue anyway —
-    # rescue requires yoy >= radiance_yoy_threshold, default 0.0). Mirrors
+    # rescue requires yoy >= radiance_yoy_threshold, default 2.0). Mirrors
     # the economics/demand precedent: the leg whose own forward-looking
     # signal triggered the demote cannot self-rescue.
     cohort = _viability_cohort_with_radiance_growth_target(
@@ -3480,13 +3480,80 @@ def test_viability_radiance_growth_leg_threshold_boundary(
     )
 
 
+def test_viability_radiance_growth_neutral_zone_neither_rescue_nor_demote(
+    disable_market_viability_floors,
+):
+    # Post-calibration (2026-05-10) the rescue threshold is 2.0 and the
+    # demote threshold is 0.0, opening a neutral zone in 0..2% YoY where
+    # the radiance signal is confident but neither strong enough to
+    # rescue the pop/rent legs nor weak enough to fire the radiance
+    # demote leg. Per §7a of radiance_yoy_distribution.sql, ~42% of
+    # confident candidates sit in this band — they should be evaluated
+    # on the other legs as-is, with no growth-side intervention.
+    #
+    # Setup: target has low pop + high rent (which would normally fire
+    # pop_demote and rent_demote), confident YoY=1.0 in the neutral
+    # zone. Assertions: (a) radiance_growth_demote is False, and (b)
+    # pop_demote / rent_demote fire — proving the rescue branch did NOT
+    # mask them for this leg.
+    cohort = _viability_cohort_with_radiance_target(
+        target_radiance_confident=True,
+        target_radiance_yoy_pct=1.0,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["radiance_growth_demote"] is False, (
+        "YoY 1.0 is above the 0.0 demote threshold; leg must not fire"
+    )
+    assert flag["radiance_confident"] is True
+    assert flag["radiance_growth_pct"] == 1.0
+    # The rescue branch (operator >=, threshold 2.0) must NOT mask pop/rent
+    # when YoY sits in the neutral zone. Both legs fire as if no radiance
+    # signal had been considered.
+    assert flag["population_demote"] is True, (
+        "growth rescue must not apply in the neutral zone (1.0 < 2.0)"
+    )
+    assert flag["rent_demote"] is True, (
+        "growth rescue must not apply in the neutral zone (1.0 < 2.0)"
+    )
+
+
+def test_viability_radiance_growth_negative_fires_demote_under_new_defaults(
+    disable_market_viability_floors,
+):
+    # Post-calibration the demote threshold is 0.0 (operator strict <).
+    # Confident YoY=-1.0 sits in the "confidently shrinking" tier (§7b,
+    # ~7.1% of confident candidates) and must fire the radiance demote
+    # leg alone — pop/rent/econ/demand are neutral in this cohort, so
+    # the only firing leg is radiance_growth_low.
+    cohort = _viability_cohort_with_radiance_growth_target(
+        target_yoy_pct=-1.0,
+        target_confident=True,
+    )
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    target = next(c for c in out if c["id"] == "target")
+    flag = target["score_breakdown_json"].get("market_viability_flag")
+    assert flag is not None and flag["demoted"] is True
+    assert flag["radiance_growth_demote"] is True
+    assert flag["radiance_growth_pct"] == -1.0
+    assert flag["radiance_confident"] is True
+    assert flag["radiance_yoy_demote_threshold"] == 0.0
+    assert flag["population_demote"] is False
+    assert flag["rent_demote"] is False
+    assert flag["economics_demote"] is False
+    assert flag["demand_demote"] is False
+    assert flag["reason"] == "radiance_growth_low"
+
+
 def test_viability_all_five_legs_fire_with_compound_annotation(
     disable_market_viability_floors,
 ):
     # Five-leg variant of test_viability_all_four_legs_fire_with_compound_annotation:
     # pop below p25, rent high on confident scope, economics_score=60 < 65,
     # realized_demand_30d=400 in the bottom quartile with 5 branches,
-    # confident negative radiance YoY (-1.5%) below the 2.0 demote threshold.
+    # confident negative radiance YoY (-1.5%) below the 0.0 demote threshold.
     # Reason concatenates in stable order: pop, rent, econ, demand, radiance.
     cohort = _viability_cohort_with_demand_target(
         target_demand=400.0,
@@ -3567,7 +3634,7 @@ def test_viability_diagnostics_demote_legs_block_written(
         "rpc_cohort_n",
     }
     assert set(thresholds.keys()) == expected_threshold_keys
-    assert thresholds["radiance_yoy_demote_threshold"] == 2.0
+    assert thresholds["radiance_yoy_demote_threshold"] == 0.0
 
     leg_enabled = diagnostics["demote_legs"]["leg_enabled"]
     assert leg_enabled["demand"] is True


### PR DESCRIPTION
## Summary
Recalibrates the radiance-growth viability thresholds based on analysis of the rolling-6 candidate distribution (radiance_yoy_distribution.sql). This change adjusts both the rescue and demote thresholds to better isolate meaningful growth signals and prevent over-rescuing candidates.

## Key Changes

- **Rescue threshold**: Updated `EXPANSION_VIABILITY_RADIANCE_YOY_THRESHOLD` from 0.0 to 2.0
  - Operator remains `>=` (rescue when YoY is at or above threshold)
  - Rationale: At 0.0, ~93% of confident candidates were rescued, making the signal meaningless. At 2.0, only the upper ~51% of confident candidates (those with "meaningfully growing" signals) are rescued
  - Creates a neutral zone (0–2% YoY) where confident signals neither rescue nor demote

- **Demote threshold**: Updated `EXPANSION_VIABILITY_RADIANCE_YOY_DEMOTE_THRESHOLD` from 2.0 to 0.0
  - Operator remains strict `<` (demote when YoY is below threshold)
  - Rationale: The prior 2.0 threshold demoted ~49% of confident candidates, compressing top scores. At 0.0, only the ~7.1% of "confidently shrinking" candidates (those with negative YoY) are demoted, which aligns with Pillar 3 directive for "strong potential for business growth"
  - Isolates demoting to districts whose own NTL signal is contracting

## Implementation Details

- Both thresholds now have independent calibration, preventing one from silently affecting the other
- The neutral zone (0–2% YoY) allows candidates with confident but moderate growth to be evaluated on other legs (population, rent, economics, demand) without growth-side intervention
- Updated test cases and comments to reflect the new thresholds and expected behavior
- Added two new test cases:
  - `test_viability_radiance_growth_neutral_zone_neither_rescue_nor_demote`: Validates that YoY in the neutral zone (1.0%) neither rescues nor demotes
  - `test_viability_radiance_growth_negative_fires_demote_under_new_defaults`: Validates that negative YoY (-1.0%) fires the demote leg under the new 0.0 threshold

https://claude.ai/code/session_01SdC84cCsWNZ8nFX7oGpU4r