### PR TITLE
feat(expansion_advisor): plumb 8 score-input fields for diagnostics UI

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -6052,13 +6052,22 @@ def _bulk_enrich_competitors(
                         i.parcel_id,
                         COALESCE(comp.competitor_count, 0) AS competitor_count,
                         COALESCE(comp.broader_count, 0) AS broader_count,
-                        comp.max_chain_strength AS max_chain_strength
+                        comp.max_chain_strength AS max_chain_strength,
+                        comp.top_chain_strength_name AS top_chain_strength_name
                     FROM inputs i
                     LEFT JOIN LATERAL (
                         SELECT
                             COUNT(*) FILTER (WHERE in_category) AS competitor_count,
                             COUNT(*) AS broader_count,
-                            MAX(chain_strength) FILTER (WHERE in_category) AS max_chain_strength
+                            MAX(chain_strength) FILTER (WHERE in_category) AS max_chain_strength,
+                            -- Brand provenance for the chain_strength leg:
+                            -- the name attached to the same-category row that
+                            -- carried the MAX chain_strength_score above.
+                            -- Distinct from brand_presence.top_chains[0],
+                            -- which orders by branch_count.
+                            (array_agg(brand_name ORDER BY chain_strength DESC NULLS LAST)
+                                FILTER (WHERE in_category AND chain_strength IS NOT NULL))[1]
+                                AS top_chain_strength_name
                         FROM (
                             -- Source 1: restaurant_poi (Google Places).
                             -- LEFT JOIN expansion_competitor_quality so the
@@ -6066,7 +6075,8 @@ def _bulk_enrich_competitors(
                             -- category POI row; rows without an ECQ match
                             -- contribute NULL (ignored by MAX).
                             SELECT (lower(rp.category) = ANY(:category_keys)) AS in_category,
-                                   ecq.chain_strength_score AS chain_strength
+                                   ecq.chain_strength_score AS chain_strength,
+                                   rp.name AS brand_name
                             FROM restaurant_poi rp
                             LEFT JOIN expansion_competitor_quality ecq
                                    ON ecq.restaurant_poi_id = rp.id
@@ -6083,7 +6093,8 @@ def _bulk_enrich_competitors(
                             SELECT (lower(COALESCE(dsr.category_raw, '')) ~* :category_regex
                                     OR lower(COALESCE(dsr.cuisine_raw, '')) ~* :category_regex
                                    ) AS in_category,
-                                   NULL::double precision AS chain_strength
+                                   NULL::double precision AS chain_strength,
+                                   NULL::text AS brand_name
                             FROM delivery_source_record dsr
                             WHERE {_dsr_where}
                               AND ST_DWithin(
@@ -6106,6 +6117,11 @@ def _bulk_enrich_competitors(
                 "max_chain_strength": (
                     float(r["max_chain_strength"])
                     if r["max_chain_strength"] is not None
+                    else None
+                ),
+                "top_chain_strength_name": (
+                    str(r["top_chain_strength_name"])
+                    if r.get("top_chain_strength_name") is not None
                     else None
                 ),
             }
@@ -6744,6 +6760,7 @@ def run_expansion_search(
                     _r["competitor_count"] = _entry["competitor_count"]
                     _r["competitor_count_confident"] = _entry["confident"]
                     _r["max_chain_strength"] = _entry.get("max_chain_strength")
+                    _r["top_chain_strength_name"] = _entry.get("top_chain_strength_name")
             logger.info(
                 "expansion_search: bulk competitor enrichment applied to %d/%d candidates, search_id=%s",
                 len(_bulk_comp), len(rows), search_id,
@@ -6787,6 +6804,7 @@ def run_expansion_search(
                         _r["competitor_count"] = _entry["competitor_count"]
                         _r["competitor_count_confident"] = _entry["confident"]
                         _r["max_chain_strength"] = _entry.get("max_chain_strength")
+                        _r["top_chain_strength_name"] = _entry.get("top_chain_strength_name")
 
             # ── Resolve commercial unit districts to Arabic names ──────────
             # Commercial units store English neighborhood names from Aqar,
@@ -8455,6 +8473,12 @@ def run_expansion_search(
         # Top 5 by branch count, with unique brand count and total branch
         # count summarized for the Breakdown tab header.
         _bp_brands_for_candidate = _bulk_brand_presence.get(_pid_str, [])
+        # top_chain_strength_name: brand whose chain_strength_score was the
+        # MAX in the competition catchment (surfaced from
+        # _bulk_enrich_competitors). Distinct from top_chains[0], which is
+        # ordered by branch_count. None when no same-category POI carried a
+        # non-NULL chain_strength_score.
+        _top_chain_strength_name = row.get("top_chain_strength_name")
         if _bp_brands_for_candidate:
             _bp_canonical_count = sum(
                 1 for b in _bp_brands_for_candidate
@@ -8471,6 +8495,7 @@ def run_expansion_search(
                 "unique_brands_total": len(_bp_brands_for_candidate),
                 "total_branches": sum(b["branch_count"] for b in _bp_brands_for_candidate),
                 "top_chains": _bp_brands_for_candidate[:5],
+                "top_chain_strength_name": _top_chain_strength_name,
             }
         else:
             feature_snapshot_json["brand_presence"] = {
@@ -8480,6 +8505,7 @@ def run_expansion_search(
                 "unique_brands_total": 0,
                 "total_branches": 0,
                 "top_chains": [],
+                "top_chain_strength_name": _top_chain_strength_name,
             }
         # Construction proximity (CEO directive — exclude areas with heavy
         # construction). Every persisted candidate must have this key set,
@@ -8857,6 +8883,40 @@ def run_expansion_search(
                 feature_snapshot_json["comparable_source_label"] = str(
                     _comparable_source_label
                 )
+
+        # ── Score Contributions diagnostics surface ──
+        # Per-input candidate values that the score functions read but the
+        # snapshot did not previously persist. Purely additive — no score
+        # formula change. The frontend Decision Memo Diagnostics tab reads
+        # these to show per-component candidate inputs.
+        feature_snapshot_json["is_listing"] = bool(_is_listing)
+        _area_confidence_val = row.get("area_confidence")
+        feature_snapshot_json["area_confidence"] = (
+            str(_area_confidence_val) if _area_confidence_val is not None else None
+        )
+        # listing_quality_signals: only meaningful for listing-backed
+        # candidates. For parcel candidates, emit an empty dict (consumers
+        # treat missing keys as "not applicable"); do not raise when the
+        # unit_* columns are absent.
+        if _is_listing:
+            def _opt_bool(value: Any) -> bool | None:
+                return None if value is None else bool(value)
+
+            feature_snapshot_json["listing_quality_signals"] = {
+                "llm_suitability_score": _safe_float(row.get("unit_llm_suitability_score"))
+                    if row.get("unit_llm_suitability_score") is not None
+                    else None,
+                "llm_listing_quality_score": _safe_float(
+                    row.get("unit_llm_listing_quality_score")
+                ) if row.get("unit_llm_listing_quality_score") is not None else None,
+                "is_furnished": _opt_bool(row.get("unit_is_furnished")),
+                "has_drive_thru": _opt_bool(row.get("unit_has_drive_thru")),
+                "unit_restaurant_score": _safe_float(row.get("unit_restaurant_score"))
+                    if row.get("unit_restaurant_score") is not None
+                    else None,
+            }
+        else:
+            feature_snapshot_json["listing_quality_signals"] = {}
 
         candidates.append(
             {

--- a/frontend/src/lib/api/expansionAdvisor.ts
+++ b/frontend/src/lib/api/expansionAdvisor.ts
@@ -111,10 +111,35 @@ export type CandidateGateStatusJson = {
   [key: string]: boolean | null | undefined;
 };
 
+export type FeatureBrandPresence = {
+  radius_m?: number;
+  unique_brands?: number;
+  unique_brands_canonical?: number;
+  unique_brands_total?: number;
+  total_branches?: number;
+  top_chains?: Array<Record<string, unknown>>;
+  top_chain_strength_name?: string | null;
+  [key: string]: unknown;
+};
+
+export type FeatureListingQualitySignals = {
+  llm_suitability_score?: number | null;
+  llm_listing_quality_score?: number | null;
+  is_furnished?: boolean | null;
+  has_drive_thru?: boolean | null;
+  unit_restaurant_score?: number | null;
+};
+
 export type CandidateFeatureSnapshot = {
   context_sources: Record<string, unknown>;
   missing_context: string[];
   data_completeness_score: number;
+  // Score Contributions diagnostics surface (additive plumbing for the
+  // Decision Memo Diagnostics tab). All optional; absent on legacy rows.
+  listing_quality_signals?: FeatureListingQualitySignals;
+  area_confidence?: "actual" | "estimate" | null;
+  is_listing?: boolean;
+  brand_presence?: FeatureBrandPresence;
   [key: string]: unknown;
 };
 

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -4547,3 +4547,133 @@ def test_existing_branches_present_no_score_change():
     # untouched on the candidate dict (the score-delta pass must not strip it).
     assert out[0]["final_score"] == 72.0
     assert out[0]["cannibalization_score"] == 35.0
+
+
+class _DiagnosticsFakeDB(FakeDB):
+    """FakeDB variant that routes the rent-comparable percentile query and
+    the listing-district momentum CTE to empty results so listing-backed
+    candidates don't accidentally match the generic "FROM commercial_unit"
+    branch and feed the candidate row back in as a rent comparable."""
+
+    def execute(self, stmt, params=None):
+        sql = stmt.text if hasattr(stmt, "text") else str(stmt)
+        if "PERCENTILE_CONT" in sql:
+            return _Result([])
+        return super().execute(stmt, params)
+
+
+def test_feature_snapshot_includes_listing_quality_signals_and_chain_provenance(
+    disable_market_viability_floors,
+):
+    """Score Contributions diagnostics: per-input candidate values that the
+    score functions read but the snapshot did not previously persist must
+    flow into ``feature_snapshot_json`` as a purely additive surface."""
+    db = _DiagnosticsFakeDB(
+        candidate_rows=[
+            {
+                "parcel_id": "p1",
+                "commercial_unit_id": "cu-1",
+                "landuse_label": "Commercial",
+                "landuse_code": "C",
+                "area_m2": 180,
+                "lon": 46.7,
+                "lat": 24.7,
+                "district": "حي العليا",
+                "population_reach": 15000,
+                "competitor_count": 4,
+                "delivery_listing_count": 12,
+                # Listing quality input scalars (consumed by _listing_quality_score)
+                "unit_llm_suitability_score": 72.5,
+                "unit_llm_listing_quality_score": 64.0,
+                "unit_is_furnished": True,
+                "unit_has_drive_thru": False,
+                "unit_restaurant_score": 81.0,
+                # Confidence inputs (consumed by _confidence_score)
+                "area_confidence": "actual",
+                # Chain-strength provenance from bulk competitor enrichment.
+                # The bulk enricher returns {} against FakeDB (no POI rows),
+                # so we inject these directly on the row to simulate the
+                # post-enrichment state.
+                "max_chain_strength": 78.0,
+                "top_chain_strength_name": "Test Chain Brand",
+            }
+        ]
+    )
+
+    items = run_expansion_search(
+        db,
+        search_id="search-diag",
+        brand_name="Brand X",
+        category="burger",
+        service_model="qsr",
+        min_area_m2=100,
+        max_area_m2=300,
+        target_area_m2=180,
+        limit=10,
+    )
+
+    assert len(items) == 1
+    snapshot = items[0]["feature_snapshot_json"]
+
+    # Group A — listing_quality_signals (5 keys, listing-backed candidate).
+    lqs = snapshot["listing_quality_signals"]
+    assert lqs["llm_suitability_score"] == 72.5
+    assert lqs["llm_listing_quality_score"] == 64.0
+    assert lqs["is_furnished"] is True
+    assert lqs["has_drive_thru"] is False
+    assert lqs["unit_restaurant_score"] == 81.0
+
+    # Group B — confidence inputs surfaced top-level.
+    assert snapshot["area_confidence"] == "actual"
+    assert snapshot["is_listing"] is True
+
+    # Group C — chain_strength provenance under brand_presence.
+    assert snapshot["brand_presence"]["top_chain_strength_name"] == "Test Chain Brand"
+
+
+def test_feature_snapshot_parcel_candidate_omits_listing_quality_signals(
+    disable_market_viability_floors,
+):
+    """Parcel-only (non-listing) candidate: is_listing must be False and the
+    listing_quality_signals block must be empty (consumers treat missing
+    keys as not-applicable). The unit_* columns are absent on parcel rows
+    and the snapshot assembly must not raise."""
+    db = FakeDB(
+        candidate_rows=[
+            {
+                "parcel_id": "p1",
+                # No commercial_unit_id → _is_listing is False.
+                "landuse_label": "Commercial",
+                "landuse_code": "C",
+                "area_m2": 180,
+                "lon": 46.7,
+                "lat": 24.7,
+                "district": "حي العليا",
+                "population_reach": 15000,
+                "competitor_count": 4,
+                "delivery_listing_count": 12,
+            }
+        ]
+    )
+
+    items = run_expansion_search(
+        db,
+        search_id="search-parcel-diag",
+        brand_name="Brand X",
+        category="burger",
+        service_model="qsr",
+        min_area_m2=100,
+        max_area_m2=300,
+        target_area_m2=180,
+        limit=10,
+    )
+
+    assert len(items) == 1
+    snapshot = items[0]["feature_snapshot_json"]
+    assert snapshot["is_listing"] is False
+    assert snapshot["listing_quality_signals"] == {}
+    # area_confidence is absent on the parcel row → key present, value None.
+    assert snapshot["area_confidence"] is None
+    # brand_presence still has the chain_strength provenance key, but with
+    # a None value because the bulk enricher returned no chain_strength rows.
+    assert snapshot["brand_presence"]["top_chain_strength_name"] is None


### PR DESCRIPTION
## Summary

Backend plumbing for the Score Contributions UI upgrade on the Decision
Memo Diagnostics tab. Purely additive payload surface — no score
formula, weight, threshold, gate-logic, or memo-prompt change. The
consuming frontend PR will follow once merged.

The investigation that identified the 8 missing fields lives on branch
`claude/investigate-oaktree-atlas-pjzAu`.

## What lands on `feature_snapshot_json`

Group A — `listing_quality_signals` block (only meaningful when
`is_listing` is true; empty dict for parcel candidates so consumers
don't trip over a missing key):

- `llm_suitability_score`
- `llm_listing_quality_score`
- `is_furnished`
- `has_drive_thru`
- `unit_restaurant_score`

Group B — confidence inputs at the top level:

- `area_confidence`
- `is_listing`

Group C — chain-strength provenance under `brand_presence`:

- `top_chain_strength_name` — the brand whose `chain_strength_score`
  was MAX in the candidate's competition catchment. Distinct from
  `top_chains[0]`, which is ordered by branch count. Surfaced by
  enriching `_bulk_enrich_competitors`' SQL with an
  `array_agg(brand_name ORDER BY chain_strength DESC NULLS LAST)[1]`
  expression.

## Out of scope

- Score formulas, weights, thresholds.
- Gate logic and viability legs.
- Frontend rendering (separate PR).
- The structured memo prompt and its required keys.
- DB migrations — these are JSON keys, not columns.

## Frontend impact

`CandidateFeatureSnapshot` in `frontend/src/lib/api/expansionAdvisor.ts`
gains matching optional typings (plus new `FeatureBrandPresence` and
`FeatureListingQualitySignals` shapes). All optional — no existing
consumer is forced to change.

## Test plan

- [x] `pytest tests/test_expansion_advisor_service.py` — 146 passed
  (144 pre-existing + 2 new tests, listing & parcel variants).
- [x] `CandidateFeatureSnapshotResponse` uses
  `FlexibleResponseModel(extra="allow")` — additive keys are safe; no
  Pydantic model change required.
- [ ] Smoke-test the API endpoint locally to confirm the 8 fields
  appear when populated and are null/empty when not.


---
_Generated by [Claude Code](https://claude.ai/code/session_0116HMbnwuSyYrLV8Bi3Heh3)_