### PR TITLE
feat(expansion_advisor): Score Contributions accordion + chain_strength + bonuses block

### DIFF
--- a/frontend/src/features/expansion-advisor/DecisionLogicCard.test.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionLogicCard.test.tsx
@@ -45,7 +45,7 @@ function productionGateReasons(): CandidateGateReasons {
 }
 
 function fullBreakdown(overrides?: Partial<CandidateScoreBreakdown>): CandidateScoreBreakdown {
-  // 9-component fixture; weighted_components sum to final_score (78.05).
+  // 10-component fixture; weighted_components sum to final_score.
   const weighted_components: Record<string, number> = {
     occupancy_economics: 22.5,
     listing_quality: 8.25,
@@ -56,6 +56,7 @@ function fullBreakdown(overrides?: Partial<CandidateScoreBreakdown>): CandidateS
     access_visibility: 7.5,
     delivery_demand: 4.0,
     confidence: 5.85,
+    chain_strength: 1.5,
   };
   const final_score = Object.values(weighted_components).reduce((a, b) => a + b, 0);
   return {
@@ -69,8 +70,20 @@ function fullBreakdown(overrides?: Partial<CandidateScoreBreakdown>): CandidateS
       access_visibility: 10,
       delivery_demand: 5,
       confidence: 5,
+      chain_strength: 3,
     },
-    inputs: {},
+    inputs: {
+      occupancy_economics: 75,
+      listing_quality: 75,
+      brand_fit: 85,
+      landlord_signal: 70,
+      competition_whitespace: 80,
+      demand_potential: 70,
+      access_visibility: 75,
+      delivery_demand: 80,
+      confidence: 117,
+      chain_strength: 50,
+    },
     weighted_components,
     final_score,
     display_score: final_score,
@@ -249,7 +262,7 @@ describe("DecisionLogicCard gate explanations", () => {
 /* ─── 5. Score contributions: 9 segments + legend totals final_score ───── */
 
 describe("DecisionLogicCard score contributions", () => {
-  it("renders 9 bar segments and 9 legend items, with summed weighted_points matching final_score", () => {
+  it("renders 10 bar segments and 10 legend items, with summed weighted_points matching final_score", () => {
     const breakdown = fullBreakdown();
     const html = renderToStaticMarkup(
       <DecisionLogicCard
@@ -260,21 +273,171 @@ describe("DecisionLogicCard score contributions", () => {
       />,
     );
     const segMatches = html.match(/ea-decision-logic__bar-segment(?!--| ea-decision-logic__legend-swatch)/g) ?? [];
-    // Count the actual bar segments by matching the data-component attribute.
+    // Each component renders: one bar segment, one legend item, and one
+    // component-row <details> — three data-component attributes per component,
+    // so 10 components × 2 (segment + legend) + 10 (component-row details) = 30.
     const dataComponentMatches = html.match(/data-component="/g) ?? [];
-    // Each component renders one segment and one legend item, so data-component
-    // should appear exactly 9 segments + 9 legend items = 18 times.
-    expect(segMatches.length).toBeGreaterThanOrEqual(9);
-    expect(dataComponentMatches.length).toBe(18);
+    expect(segMatches.length).toBeGreaterThanOrEqual(10);
+    expect(dataComponentMatches.length).toBe(30);
 
     // Parse out the weighted_points from the legend's rendered text and sum.
+    // The bonuses block also surfaces ".N pts" magnitudes inside chips, so
+    // restrict to the strict "{n}.{d} pts<" form rendered by the legend.
     const legendValueMatches = html.match(/>(\d+\.\d)\s+pts</g) ?? [];
-    expect(legendValueMatches.length).toBe(9);
-    const sum = legendValueMatches
+    expect(legendValueMatches.length).toBeGreaterThanOrEqual(10);
+    const legendOnly = legendValueMatches.slice(0, 10);
+    const sum = legendOnly
       .map((m) => parseFloat(m.replace(/[^\d.]/g, "")))
       .reduce((a, b) => a + b, 0);
     // Rounded-to-1-decimal legend values should sum within 0.5 of final_score.
     expect(Math.abs(sum - (breakdown.final_score as number))).toBeLessThan(0.5);
+  });
+});
+
+/* ─── 5b. Component-row accordion: 10 rows + definitions + chain_strength ─ */
+
+describe("DecisionLogicCard component-row accordion", () => {
+  it("renders 10 component accordion rows with labels and definitions", () => {
+    const breakdown = fullBreakdown();
+    const html = renderToStaticMarkup(
+      <DecisionLogicCard
+        gateReasons={productionGateReasons()}
+        scoreBreakdown={breakdown}
+        deterministicRank={1}
+        finalRank={1}
+      />,
+    );
+    // 10 component-row <details> wrappers.
+    const componentRows = html.match(/ea-decision-logic__subsection--component-row/g) ?? [];
+    expect(componentRows.length).toBe(10);
+    // Each component label and definition (or a leading word from each)
+    // appears at least once.
+    const componentKeys = [
+      "occupancy_economics",
+      "listing_quality",
+      "brand_fit",
+      "landlord_signal",
+      "competition_whitespace",
+      "demand_potential",
+      "access_visibility",
+      "delivery_demand",
+      "confidence",
+      "chain_strength",
+    ];
+    for (const key of componentKeys) {
+      const label = en.expansionAdvisor.scoreComponents[
+        key as keyof typeof en.expansionAdvisor.scoreComponents
+      ].label;
+      // renderToStaticMarkup HTML-escapes the ampersand, so compare against
+      // the escaped form.
+      const escaped = label.replace(/&/g, "&amp;");
+      expect(html).toContain(escaped);
+    }
+    // chain_strength rust color class is wired through.
+    expect(html).toContain("ea-decision-logic__bar-segment--chain_strength");
+  });
+});
+
+/* ─── 5c. Bonuses & adjustments sub-block ───────────────────────────────── */
+
+describe("DecisionLogicCard bonuses sub-block", () => {
+  it("renders bonus chips, total adjustment, and final score when bonus_detail present", () => {
+    const breakdown = fullBreakdown({
+      bonus_detail: {
+        base_deterministic: 72.5,
+        value_band_delta: 4.0,
+        viability_legs_fired: ["demand_low"],
+        viability_delta: -10.0,
+        freshness_bonus: 2.0,
+        freshness_label: "new",
+        momentum_bonus: 0.0,
+        total_delta: -4.0,
+        final_score_clamped: false,
+      },
+    } as unknown as Partial<CandidateScoreBreakdown>);
+    const html = renderToStaticMarkup(
+      <DecisionLogicCard
+        gateReasons={productionGateReasons()}
+        scoreBreakdown={breakdown}
+        deterministicRank={1}
+        finalRank={1}
+        candidate={{ value_band: "best_value", value_band_low_confidence: false } as any}
+      />,
+    );
+    // Heading and subtotal (ampersand is HTML-escaped in SSR output).
+    expect(html).toContain(
+      en.expansionAdvisor.decisionLogic.bonusesHeading.replace(/&/g, "&amp;"),
+    );
+    expect(html).toContain("72.50");
+    // Best Value +4 chip.
+    expect(html).toContain(en.expansionAdvisor.bonuses.bestValue);
+    expect(html).toContain("ea-decision-logic__delta--up");
+    // Freshness "new" +2 chip.
+    expect(html).toContain(en.expansionAdvisor.bonuses.freshnessNew);
+    // Viability demand_low −10 chip.
+    expect(html).toContain(en.expansionAdvisor.bonuses.viability.demand_low);
+    expect(html).toContain("ea-decision-logic__delta--down");
+    // Final score row.
+    expect(html).toContain(en.expansionAdvisor.decisionLogic.finalScore);
+  });
+
+  it("renders the clamped badge when bonus_detail.final_score_clamped is true", () => {
+    const breakdown = fullBreakdown({
+      bonus_detail: {
+        base_deterministic: 99.0,
+        value_band_delta: 4.0,
+        viability_legs_fired: [],
+        viability_delta: 0,
+        freshness_bonus: 0,
+        freshness_label: null,
+        momentum_bonus: 0,
+        total_delta: 4.0,
+        final_score_clamped: true,
+      },
+    } as unknown as Partial<CandidateScoreBreakdown>);
+    const html = renderToStaticMarkup(
+      <DecisionLogicCard
+        gateReasons={productionGateReasons()}
+        scoreBreakdown={breakdown}
+        deterministicRank={1}
+        finalRank={1}
+      />,
+    );
+    expect(html).toContain("ea-decision-logic__clamped-badge");
+    expect(html).toContain(en.expansionAdvisor.decisionLogic.clamped);
+  });
+});
+
+/* ─── 5d. Suppressed value_band renders as neutral chip ─────────────────── */
+
+describe("DecisionLogicCard suppressed value band", () => {
+  it("renders a suppressed-style chip with no signed magnitude when value_band_low_confidence is true and delta is 0", () => {
+    const breakdown = fullBreakdown({
+      bonus_detail: {
+        base_deterministic: 72.0,
+        value_band_delta: 0.0,
+        viability_legs_fired: [],
+        viability_delta: 0,
+        freshness_bonus: 0,
+        freshness_label: null,
+        momentum_bonus: 0,
+        total_delta: 0,
+        final_score_clamped: false,
+      },
+    } as unknown as Partial<CandidateScoreBreakdown>);
+    const html = renderToStaticMarkup(
+      <DecisionLogicCard
+        gateReasons={productionGateReasons()}
+        scoreBreakdown={breakdown}
+        deterministicRank={1}
+        finalRank={1}
+        candidate={{ value_band: "above_market", value_band_low_confidence: true } as any}
+      />,
+    );
+    expect(html).toContain("ea-decision-logic__delta--suppressed");
+    expect(html).toContain(en.expansionAdvisor.bonuses.aboveMarketSuppressed);
+    // Signed magnitude must NOT render alongside the suppressed chip.
+    expect(html).not.toContain("ea-decision-logic__delta--suppressed</span><span class=\"ea-decision-logic__delta-magnitude");
   });
 });
 

--- a/frontend/src/features/expansion-advisor/DecisionLogicCard.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionLogicCard.tsx
@@ -1,11 +1,28 @@
 import { useTranslation } from "react-i18next";
 import type {
+  CandidateFeatureSnapshot,
   CandidateGateReasons,
   CandidateScoreBreakdown,
+  ExpansionCandidate,
   RerankReason,
   RerankStatus,
 } from "../../lib/api/expansionAdvisor";
 import { humanGateLabel } from "./formatHelpers";
+import {
+  PER_COMPONENT_INPUTS,
+  VIABILITY_LEG_ORDER,
+  type ResolvedInputValue,
+  type SourceToken,
+} from "./scoreComponentMeta";
+
+// The memo response embeds a loose candidate shape (feature_snapshot,
+// not feature_snapshot_json). Accept a permissive partial so this component
+// can be fed from the list endpoint or the memo endpoint.
+type LooseCandidate = Partial<ExpansionCandidate> &
+  Record<string, unknown> & {
+    feature_snapshot?: CandidateFeatureSnapshot | Record<string, unknown>;
+    feature_snapshot_json?: CandidateFeatureSnapshot | Record<string, unknown>;
+  };
 
 type Props = {
   gateReasons?: CandidateGateReasons;
@@ -15,12 +32,17 @@ type Props = {
   rerankStatus?: RerankStatus | null;
   rerankReason?: RerankReason | null;
   rerankDelta?: number;
+  /** Whole candidate (ExpansionCandidate or memo.candidate). Optional — when
+   * omitted, contributions accordion still renders summaries but per-input
+   * values fall back to em-dashes. */
+  candidate?: LooseCandidate;
 };
 
 /* ─── Score-component display metadata ──────────────────────────────────── */
 
 // Canonical component order + labels matching
-// app/services/expansion_advisor.py:2409-2419 (9 components summing to 100%).
+// app/services/expansion_advisor.py:_score_breakdown (10 components summing
+// to 100% after the Patch B chain_strength split-off).
 const SCORE_COMPONENT_ORDER: readonly string[] = [
   "occupancy_economics",
   "listing_quality",
@@ -31,26 +53,8 @@ const SCORE_COMPONENT_ORDER: readonly string[] = [
   "access_visibility",
   "delivery_demand",
   "confidence",
+  "chain_strength",
 ] as const;
-
-const SCORE_COMPONENT_LABEL: Record<string, string> = {
-  occupancy_economics: "Economics",
-  listing_quality: "Listing Quality",
-  brand_fit: "Brand Fit",
-  landlord_signal: "Landlord Signal",
-  competition_whitespace: "Competitor Openness",
-  demand_potential: "Demand Strength",
-  access_visibility: "Access & Visibility",
-  delivery_demand: "Delivery Market",
-  confidence: "Data Quality",
-};
-
-function labelForComponent(key: string): string {
-  return (
-    SCORE_COMPONENT_LABEL[key] ||
-    key.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase())
-  );
-}
 
 /* ─── Inline gate-status icons (no icon library) ────────────────────────── */
 
@@ -243,33 +247,75 @@ function GatesSection({
   );
 }
 
+/* ─── Score contributions: input-value formatting ───────────────────────── */
+
+function formatInputValue(
+  v: ResolvedInputValue,
+  t: ReturnType<typeof useTranslation>["t"],
+): string {
+  if (v == null) return "—";
+  if (typeof v === "boolean") {
+    return v ? t("expansionAdvisor.decisionLogic.boolYes") : t("expansionAdvisor.decisionLogic.boolNo");
+  }
+  if (typeof v === "number") {
+    if (!Number.isFinite(v)) return "—";
+    return Number.isInteger(v) ? String(v) : v.toFixed(2);
+  }
+  return v;
+}
+
+function sourceLabel(
+  token: SourceToken,
+  t: ReturnType<typeof useTranslation>["t"],
+): string {
+  return t(`expansionAdvisor.scoreSources.${token}`, { defaultValue: token });
+}
+
 /* ─── Sub-component: score contributions ────────────────────────────────── */
 
 function ContributionsSection({
   breakdown,
+  candidate,
   t,
 }: {
   breakdown: CandidateScoreBreakdown | undefined;
+  candidate: LooseCandidate | undefined;
   t: ReturnType<typeof useTranslation>["t"];
 }) {
   const weightedRaw = (breakdown?.weighted_components ||
     {}) as Record<string, unknown>;
   const weights = (breakdown?.weights || {}) as Record<string, unknown>;
+  const inputs = (breakdown?.inputs || {}) as Record<string, unknown>;
   const finalScore = Number(
     breakdown?.display_score ?? breakdown?.final_score ?? 0,
   );
+
+  // Feature snapshot may arrive as `feature_snapshot` (memo response) or
+  // `feature_snapshot_json` (list/detail responses). Defensive: try both.
+  const featureSnapshot =
+    (candidate?.feature_snapshot_json as CandidateFeatureSnapshot | undefined) ||
+    (candidate?.feature_snapshot as CandidateFeatureSnapshot | undefined);
+  const contextSources =
+    (featureSnapshot?.context_sources as Record<string, unknown> | undefined) ||
+    {};
 
   const components = SCORE_COMPONENT_ORDER
     .filter((key) => key in weightedRaw)
     .map((key) => {
       const points = Number(weightedRaw[key]) || 0;
       const weight = Number(weights[key]) || 0;
-      return { key, points, weight };
+      const subScore = Number(inputs[key]) || 0;
+      return { key, points, weight, subScore };
     });
 
   const totalPoints = components.reduce((acc, c) => acc + c.points, 0);
 
-  const renderSegment = (key: string, points: number, weight: number) => {
+  const renderSegment = (
+    key: string,
+    points: number,
+    weight: number,
+    label: string,
+  ) => {
     const widthPct =
       totalPoints > 0 ? Math.max(0.01, (points / totalPoints) * 100) : 0;
     return (
@@ -277,10 +323,109 @@ function ContributionsSection({
         key={`seg-${key}`}
         className={`ea-decision-logic__bar-segment ea-decision-logic__bar-segment--${key}`}
         style={{ flexBasis: `${widthPct}%` }}
-        title={`${labelForComponent(key)}: ${points.toFixed(2)} / ${weight}`}
+        title={`${label}: ${points.toFixed(2)} / ${weight}`}
         data-component={key}
         data-points={points.toFixed(2)}
       />
+    );
+  };
+
+  const renderComponentRow = (c: {
+    key: string;
+    points: number;
+    weight: number;
+    subScore: number;
+  }) => {
+    const label = t(`expansionAdvisor.scoreComponents.${c.key}.label`, {
+      defaultValue: c.key.replace(/_/g, " "),
+    });
+    const definition = t(`expansionAdvisor.scoreComponents.${c.key}.definition`, {
+      defaultValue: "",
+    });
+    const descriptors = PER_COMPONENT_INPUTS[c.key] ?? [];
+    const resolved = descriptors.map((d) => ({
+      key: d.key,
+      ...d.resolve({
+        candidate: (candidate as Record<string, unknown>) || {},
+        scoreBreakdown: breakdown,
+        featureSnapshot,
+        contextSources,
+      }),
+    }));
+
+    return (
+      <details
+        key={`comp-${c.key}`}
+        className="ea-decision-logic__subsection ea-decision-logic__subsection--component-row"
+        data-component={c.key}
+      >
+        <summary className="ea-decision-logic__subsection-summary">
+          <span
+            className={`ea-decision-logic__legend-swatch ea-decision-logic__bar-segment--${c.key}`}
+            aria-hidden="true"
+          />
+          <span className="ea-decision-logic__subsection-title">{label}</span>
+          <span className="ea-decision-logic__subsection-status">
+            {t("expansionAdvisor.decisionLogic.weightAndPoints", {
+              weight: c.weight.toFixed(1),
+              points: c.points.toFixed(1),
+            })}
+          </span>
+        </summary>
+        <div className="ea-decision-logic__subsection-body">
+          {definition && (
+            <p className="ea-decision-logic__component-definition">
+              {definition}
+            </p>
+          )}
+          <dl className="ea-decision-logic__component-meta">
+            <div className="ea-decision-logic__component-meta-row">
+              <dt>{t("expansionAdvisor.decisionLogic.subScoreLabel")}</dt>
+              <dd>{c.subScore.toFixed(1)} / 100</dd>
+            </div>
+            <div className="ea-decision-logic__component-meta-row">
+              <dt>{t("expansionAdvisor.decisionLogic.weightLabel")}</dt>
+              <dd>{c.weight.toFixed(1)}%</dd>
+            </div>
+            <div className="ea-decision-logic__component-meta-row">
+              <dt>{t("expansionAdvisor.decisionLogic.contributionLabel")}</dt>
+              <dd>{c.points.toFixed(2)} pts</dd>
+            </div>
+          </dl>
+          {resolved.length > 0 && (
+            <>
+              <h6 className="ea-decision-logic__component-inputs-title">
+                {t("expansionAdvisor.decisionLogic.inputsHeading")}
+              </h6>
+              <dl className="ea-decision-logic__component-inputs">
+                {resolved.map((r) => {
+                  const inputLabel = t(
+                    `expansionAdvisor.scoreComponents.${c.key}.inputs.${r.key}.label`,
+                    { defaultValue: r.key.replace(/_/g, " ") },
+                  );
+                  return (
+                    <div
+                      key={`${c.key}-${r.key}`}
+                      className="ea-decision-logic__component-input-row"
+                      data-input={r.key}
+                    >
+                      <dt className="ea-decision-logic__component-input-label">
+                        {inputLabel}
+                      </dt>
+                      <dd className="ea-decision-logic__component-input-value">
+                        {formatInputValue(r.value, t)}
+                      </dd>
+                      <dd className="ea-decision-logic__component-input-source">
+                        {sourceLabel(r.source, t)}
+                      </dd>
+                    </div>
+                  );
+                })}
+              </dl>
+            </>
+          )}
+        </div>
+      </details>
     );
   };
 
@@ -300,7 +445,16 @@ function ContributionsSection({
         {components.length > 0 ? (
           <>
             <div className="ea-decision-logic__bar" aria-hidden="true">
-              {components.map((c) => renderSegment(c.key, c.points, c.weight))}
+              {components.map((c) =>
+                renderSegment(
+                  c.key,
+                  c.points,
+                  c.weight,
+                  t(`expansionAdvisor.scoreComponents.${c.key}.label`, {
+                    defaultValue: c.key,
+                  }),
+                ),
+              )}
             </div>
             <ul className="ea-decision-logic__legend">
               {components.map((c) => (
@@ -314,7 +468,9 @@ function ContributionsSection({
                     aria-hidden="true"
                   />
                   <span className="ea-decision-logic__legend-label">
-                    {labelForComponent(c.key)}
+                    {t(`expansionAdvisor.scoreComponents.${c.key}.label`, {
+                      defaultValue: c.key,
+                    })}
                   </span>
                   <span className="ea-decision-logic__legend-value">
                     {t("expansionAdvisor.decisionLogicWeightedPoints", {
@@ -324,10 +480,235 @@ function ContributionsSection({
                 </li>
               ))}
             </ul>
+            <div className="ea-decision-logic__component-rows">
+              {components.map((c) => renderComponentRow(c))}
+            </div>
+            <BonusesSubBlock
+              breakdown={breakdown}
+              candidate={candidate}
+              featureSnapshot={featureSnapshot}
+              t={t}
+            />
           </>
         ) : null}
       </div>
     </details>
+  );
+}
+
+/* ─── Sub-block: bonuses & adjustments ──────────────────────────────────── */
+
+type BonusDetail = {
+  base_deterministic?: number;
+  value_band_delta?: number;
+  viability_legs_fired?: string[];
+  viability_delta?: number;
+  freshness_bonus?: number;
+  freshness_label?: string | null;
+  momentum_bonus?: number;
+  total_delta?: number;
+  final_score_clamped?: boolean;
+};
+
+type ChipKind = "up" | "down" | "suppressed";
+
+function Chip({
+  kind,
+  label,
+  magnitude,
+}: {
+  kind: ChipKind;
+  label: string;
+  magnitude?: number | null;
+}) {
+  const cls = `ea-decision-logic__delta ea-decision-logic__delta--${kind}`;
+  return (
+    <span className={cls}>
+      {kind === "up" && magnitude != null && (
+        <span aria-hidden="true">↑</span>
+      )}
+      {kind === "down" && magnitude != null && (
+        <span aria-hidden="true">↓</span>
+      )}
+      <span className="ea-decision-logic__delta-label">{label}</span>
+      {kind !== "suppressed" && magnitude != null && (
+        <span className="ea-decision-logic__delta-magnitude">
+          {kind === "up" ? "+" : "−"}
+          {Math.abs(magnitude)}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function BonusesSubBlock({
+  breakdown,
+  candidate,
+  featureSnapshot,
+  t,
+}: {
+  breakdown: CandidateScoreBreakdown | undefined;
+  candidate: LooseCandidate | undefined;
+  featureSnapshot: CandidateFeatureSnapshot | Record<string, unknown> | undefined;
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
+  const bd = ((breakdown as unknown as { bonus_detail?: BonusDetail } | undefined)
+    ?.bonus_detail || null) as BonusDetail | null;
+  if (!bd) return null;
+
+  const base = typeof bd.base_deterministic === "number" ? bd.base_deterministic : null;
+  const valueBandDelta = typeof bd.value_band_delta === "number" ? bd.value_band_delta : 0;
+  const viabilityLegs = Array.isArray(bd.viability_legs_fired) ? bd.viability_legs_fired : [];
+  const freshness = bd.freshness_label || null;
+  const momentumBonus = typeof bd.momentum_bonus === "number" ? bd.momentum_bonus : 0;
+  const totalDelta = typeof bd.total_delta === "number" ? bd.total_delta : 0;
+  const clamped = bd.final_score_clamped === true;
+  const finalScore = Number(breakdown?.final_score ?? 0);
+
+  const valueBand = (candidate?.value_band as string | undefined) || null;
+  const valueBandLowConfidence = candidate?.value_band_low_confidence === true;
+
+  // Order chips by source order: value_band → freshness → momentum → viability.
+  type ChipDef = { key: string; kind: ChipKind; label: string; magnitude?: number | null };
+  const chips: ChipDef[] = [];
+
+  if (valueBandDelta === 4) {
+    chips.push({
+      key: "best_value",
+      kind: "up",
+      label: t("expansionAdvisor.bonuses.bestValue"),
+      magnitude: 4,
+    });
+  } else if (valueBandDelta === -6) {
+    chips.push({
+      key: "above_market",
+      kind: "down",
+      label: t("expansionAdvisor.bonuses.aboveMarket"),
+      magnitude: -6,
+    });
+  } else if (
+    valueBandDelta === 0 &&
+    valueBandLowConfidence &&
+    (valueBand === "best_value" || valueBand === "above_market")
+  ) {
+    chips.push({
+      key: "value_band_suppressed",
+      kind: "suppressed",
+      label:
+        valueBand === "above_market"
+          ? t("expansionAdvisor.bonuses.aboveMarketSuppressed")
+          : t("expansionAdvisor.bonuses.bestValueSuppressed"),
+    });
+  }
+
+  if (freshness === "new") {
+    chips.push({
+      key: "freshness_new",
+      kind: "up",
+      label: t("expansionAdvisor.bonuses.freshnessNew"),
+      magnitude: 2,
+    });
+  } else if (freshness === "updated") {
+    chips.push({
+      key: "freshness_updated",
+      kind: "up",
+      label: t("expansionAdvisor.bonuses.freshnessUpdated"),
+      magnitude: 1,
+    });
+  }
+
+  // Momentum: derive client-side from district_momentum, but only display
+  // when the backend awarded the bonus.
+  const momentum = (featureSnapshot as Record<string, unknown> | undefined)?.district_momentum as
+    | Record<string, unknown>
+    | undefined;
+  const momentumScore = typeof momentum?.momentum_score === "number" ? momentum.momentum_score : null;
+  const sampleFloorApplied = momentum?.sample_floor_applied === true;
+  if (
+    momentumBonus === 2 &&
+    momentumScore != null &&
+    momentumScore >= 70 &&
+    !sampleFloorApplied
+  ) {
+    chips.push({
+      key: "momentum_top_tier",
+      kind: "up",
+      label: t("expansionAdvisor.bonuses.momentumTopTier"),
+      magnitude: 2,
+    });
+  }
+
+  // Viability legs in stable backend order.
+  const firedSet = new Set(viabilityLegs);
+  for (const leg of VIABILITY_LEG_ORDER) {
+    if (!firedSet.has(leg)) continue;
+    chips.push({
+      key: `viability_${leg}`,
+      kind: "down",
+      label: t(`expansionAdvisor.bonuses.viability.${leg}`, {
+        defaultValue: leg.replace(/_/g, " "),
+      }),
+      magnitude: -10,
+    });
+  }
+  // Surface any unexpected legs the backend may have added, defensively.
+  for (const leg of viabilityLegs) {
+    if (VIABILITY_LEG_ORDER.includes(leg)) continue;
+    chips.push({
+      key: `viability_${leg}`,
+      kind: "down",
+      label: t(`expansionAdvisor.bonuses.viability.${leg}`, {
+        defaultValue: leg.replace(/_/g, " "),
+      }),
+      magnitude: -10,
+    });
+  }
+
+  return (
+    <div className="ea-decision-logic__bonuses">
+      <h5 className="ea-decision-logic__bonuses-title">
+        {t("expansionAdvisor.decisionLogic.bonusesHeading")}
+      </h5>
+      <dl className="ea-decision-logic__bonuses-meta">
+        <div className="ea-decision-logic__bonuses-row">
+          <dt>{t("expansionAdvisor.decisionLogic.subtotal")}</dt>
+          <dd>{base != null ? base.toFixed(2) : "—"}</dd>
+        </div>
+        {chips.length > 0 && (
+          <div className="ea-decision-logic__bonuses-row ea-decision-logic__bonuses-row--chips">
+            <dt>{t("expansionAdvisor.decisionLogic.adjustmentsLabel")}</dt>
+            <dd className="ea-decision-logic__bonuses-chips">
+              {chips.map((c) => (
+                <Chip
+                  key={c.key}
+                  kind={c.kind}
+                  label={c.label}
+                  magnitude={c.magnitude}
+                />
+              ))}
+            </dd>
+          </div>
+        )}
+        <div className="ea-decision-logic__bonuses-row">
+          <dt>{t("expansionAdvisor.decisionLogic.totalAdjustment")}</dt>
+          <dd>
+            {totalDelta > 0 ? "+" : ""}
+            {totalDelta.toFixed(2)}
+          </dd>
+        </div>
+        <div className="ea-decision-logic__bonuses-row ea-decision-logic__bonuses-row--final">
+          <dt>{t("expansionAdvisor.decisionLogic.finalScore")}</dt>
+          <dd>
+            {finalScore.toFixed(2)}
+            {clamped && (
+              <span className="ea-decision-logic__clamped-badge">
+                {t("expansionAdvisor.decisionLogic.clamped")}
+              </span>
+            )}
+          </dd>
+        </div>
+      </dl>
+    </div>
   );
 }
 
@@ -517,6 +898,7 @@ export default function DecisionLogicCard({
   rerankStatus,
   rerankReason,
   rerankDelta,
+  candidate,
 }: Props) {
   const { t } = useTranslation();
 
@@ -526,7 +908,7 @@ export default function DecisionLogicCard({
         {t("expansionAdvisor.decisionLogicTitle")}
       </h4>
       <GatesSection reasons={gateReasons} t={t} />
-      <ContributionsSection breakdown={scoreBreakdown} t={t} />
+      <ContributionsSection breakdown={scoreBreakdown} candidate={candidate} t={t} />
       <RankingDecisionSection
         deterministicRank={deterministicRank}
         finalRank={finalRank}

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
@@ -317,6 +317,7 @@ export default function ExpansionMemoPanel({
                         rerankStatus={cand.rerank_status ?? null}
                         rerankReason={cand.rerank_reason ?? null}
                         rerankDelta={typeof cand.rerank_delta === "number" ? cand.rerank_delta : 0}
+                        candidate={cand as Record<string, unknown>}
                       />
                     </div>
 

--- a/frontend/src/features/expansion-advisor/WhyThisRank.tsx
+++ b/frontend/src/features/expansion-advisor/WhyThisRank.tsx
@@ -39,7 +39,7 @@ export default function WhyThisRank({ candidate }: Props) {
           {/* Score components */}
           {components.length > 0 && (
             <div className="ea-why-rank__section">
-              <h6 className="ea-why-rank__section-title">{t("expansionAdvisor.scoreComponents")}</h6>
+              <h6 className="ea-why-rank__section-title">{t("expansionAdvisor.scoreComponentsHeading")}</h6>
               <div className="ea-why-rank__score-grid">
                 {components.map((comp) => (
                   <div key={comp.label} className="ea-why-rank__score-row">

--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -4319,6 +4319,7 @@
   --oak-ea-seg-access_visibility: #6a84c3;
   --oak-ea-seg-delivery_demand: #a86ba8;
   --oak-ea-seg-confidence: #7f7f7f;
+  --oak-ea-seg-chain_strength: #b8553a;
 
   margin-block: 12px;
   padding-block: 12px;
@@ -4456,6 +4457,7 @@
 .ea-decision-logic__bar-segment--access_visibility     { background: var(--oak-ea-seg-access_visibility); }
 .ea-decision-logic__bar-segment--delivery_demand       { background: var(--oak-ea-seg-delivery_demand); }
 .ea-decision-logic__bar-segment--confidence            { background: var(--oak-ea-seg-confidence); }
+.ea-decision-logic__bar-segment--chain_strength        { background: var(--oak-ea-seg-chain_strength); }
 .ea-decision-logic__legend {
   margin: 0;
   padding: 0;
@@ -4511,6 +4513,143 @@
 }
 .ea-decision-logic__delta--up   { color: var(--oak-status-pass); }
 .ea-decision-logic__delta--down { color: var(--oak-status-fail); }
+.ea-decision-logic__delta--suppressed {
+  color: var(--oak-text-light, #828282);
+  font-style: italic;
+  font-weight: var(--oak-fw-normal, 400);
+}
+
+/* ── Component-row accordion (denser than gates) ── */
+.ea-decision-logic__component-rows {
+  display: grid;
+  gap: 0;
+  margin-block-start: 6px;
+  border-block-start: 1px solid var(--oak-outlines, #d7d7d7);
+}
+.ea-decision-logic__subsection--component-row {
+  padding-block: 2px;
+}
+.ea-decision-logic__subsection--component-row > .ea-decision-logic__subsection-summary {
+  font-size: var(--oak-fs-xs, 12px);
+  padding-block: 2px;
+}
+.ea-decision-logic__subsection--component-row .ea-decision-logic__legend-swatch {
+  inline-size: 10px;
+  block-size: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.ea-decision-logic__component-definition {
+  margin: 0;
+  font-size: var(--oak-fs-xs, 12px);
+  color: var(--oak-text-gray, #4c4c4c);
+}
+.ea-decision-logic__component-meta,
+.ea-decision-logic__component-inputs {
+  margin: 4px 0 0 0;
+  display: grid;
+  gap: 2px;
+  font-size: var(--oak-fs-xs, 12px);
+}
+.ea-decision-logic__component-meta-row,
+.ea-decision-logic__component-input-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 6px;
+  align-items: baseline;
+}
+.ea-decision-logic__component-meta-row dt,
+.ea-decision-logic__component-input-row dt,
+.ea-decision-logic__component-input-label {
+  color: var(--oak-text-gray, #4c4c4c);
+  margin: 0;
+}
+.ea-decision-logic__component-meta-row dd,
+.ea-decision-logic__component-input-value {
+  margin: 0;
+  color: var(--oak-text-dark, #171717);
+  font-variant-numeric: tabular-nums;
+}
+.ea-decision-logic__component-input-source {
+  margin: 0;
+  color: var(--oak-text-light, #828282);
+  font-size: var(--oak-fs-xs, 12px);
+}
+.ea-decision-logic__component-inputs-title {
+  margin: 6px 0 2px 0;
+  font-size: var(--oak-fs-xs, 12px);
+  font-weight: var(--oak-fw-semibold, 600);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--oak-text-gray, #4c4c4c);
+}
+
+/* ── Bonuses & adjustments sub-block ── */
+.ea-decision-logic__bonuses {
+  margin-block-start: 10px;
+  padding-block-start: 8px;
+  border-block-start: 1px solid var(--oak-outlines, #d7d7d7);
+  display: grid;
+  gap: 4px;
+}
+.ea-decision-logic__bonuses-title {
+  margin: 0;
+  font-size: var(--oak-fs-sm, 14px);
+  font-weight: var(--oak-fw-semibold, 600);
+  color: var(--oak-text-dark, #171717);
+}
+.ea-decision-logic__bonuses-meta {
+  margin: 0;
+  display: grid;
+  gap: 4px;
+  font-size: var(--oak-fs-sm, 14px);
+}
+.ea-decision-logic__bonuses-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: baseline;
+}
+.ea-decision-logic__bonuses-row dt {
+  margin: 0;
+  color: var(--oak-text-gray, #4c4c4c);
+}
+.ea-decision-logic__bonuses-row dd {
+  margin: 0;
+  color: var(--oak-text-dark, #171717);
+  font-variant-numeric: tabular-nums;
+}
+.ea-decision-logic__bonuses-row--final dd {
+  font-weight: var(--oak-fw-semibold, 600);
+}
+.ea-decision-logic__bonuses-row--chips dd {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-self: end;
+}
+.ea-decision-logic__bonuses-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ea-decision-logic__delta-label {
+  margin-inline-start: 2px;
+}
+.ea-decision-logic__delta-magnitude {
+  margin-inline-start: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.ea-decision-logic__clamped-badge {
+  margin-inline-start: 6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: var(--oak-fs-xs, 12px);
+  font-weight: var(--oak-fw-semibold, 600);
+  color: var(--oak-text-gray, #4c4c4c);
+  background: var(--oak-secondary-elevated, #efecdc);
+  border: 1px solid var(--oak-outlines, #d7d7d7);
+}
 .ea-decision-logic__reason-block {
   margin-block-start: 6px;
   padding-block: 6px;

--- a/frontend/src/features/expansion-advisor/scoreComponentMeta.ts
+++ b/frontend/src/features/expansion-advisor/scoreComponentMeta.ts
@@ -1,0 +1,460 @@
+import type {
+  CandidateFeatureSnapshot,
+  CandidateScoreBreakdown,
+  ExpansionCandidate,
+} from "../../lib/api/expansionAdvisor";
+
+/* ─── Source tokens ────────────────────────────────────────────────────────
+ *
+ * Every input attribution renders against one of these tokens. The token
+ * is mapped to a human label via i18n key `expansionAdvisor.scoreSources.<token>`
+ * (see en.json / ar.json).
+ *
+ * Tokens are stable identifiers — the i18n label can change without
+ * touching the score-input wiring.
+ */
+export type SourceToken =
+  | "aqar"
+  | "google_places"
+  | "black_marble"
+  | "osm"
+  | "arcgis_riyadh_parcels"
+  | "operator_brief"
+  | "hungerstation"
+  | "talabat"
+  | "mrsool"
+  | "population_grid"
+  | "oaktree_llm"
+  | "oaktree_internal"
+  | "expansion_road_context"
+  | "expansion_parking_asset"
+  | "expansion_delivery_market";
+
+export type ResolvedInputValue = string | number | boolean | null;
+
+export type ResolvedInput = {
+  value: ResolvedInputValue;
+  source: SourceToken;
+};
+
+export type ResolveCtx = {
+  candidate: Partial<ExpansionCandidate> | Record<string, unknown>;
+  scoreBreakdown: CandidateScoreBreakdown | undefined;
+  featureSnapshot: CandidateFeatureSnapshot | Record<string, unknown> | undefined;
+  contextSources: Record<string, unknown>;
+};
+
+export type InputDescriptor = {
+  /** i18n key suffix under expansionAdvisor.scoreComponents.<comp>.inputs */
+  key: string;
+  resolve: (ctx: ResolveCtx) => ResolvedInput;
+};
+
+/* ─── Defensive readers ──────────────────────────────────────────────────── */
+
+function asNumber(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  return null;
+}
+function asString(v: unknown): string | null {
+  if (typeof v === "string" && v.length > 0) return v;
+  return null;
+}
+function asBool(v: unknown): boolean | null {
+  if (typeof v === "boolean") return v;
+  return null;
+}
+function readNested(obj: unknown, ...path: string[]): unknown {
+  let cur: unknown = obj;
+  for (const k of path) {
+    if (cur && typeof cur === "object" && k in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[k];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+/* ─── Per-source override resolution ─────────────────────────────────────── */
+
+/**
+ * Several inputs have conditional sources surfaced through
+ * feature_snapshot_json.context_sources.<X>_source. When the override is
+ * one of the known infrastructure tokens, use it; otherwise fall back to
+ * the supplied default.
+ */
+function overrideSource(
+  contextSources: Record<string, unknown>,
+  field: string,
+  fallback: SourceToken,
+): SourceToken {
+  const raw = contextSources[field];
+  if (typeof raw !== "string" || raw.length === 0) return fallback;
+  switch (raw) {
+    case "aqar":
+      return "aqar";
+    case "google_places":
+      return "google_places";
+    case "expansion_road_context":
+      return "expansion_road_context";
+    case "expansion_parking_asset":
+      return "expansion_parking_asset";
+    case "expansion_delivery_market":
+      return "expansion_delivery_market";
+    case "hungerstation":
+      return "hungerstation";
+    case "talabat":
+      return "talabat";
+    case "mrsool":
+      return "mrsool";
+    case "osm":
+      return "osm";
+    case "arcgis_riyadh_parcels":
+      return "arcgis_riyadh_parcels";
+    case "operator_brief":
+      return "operator_brief";
+    case "black_marble":
+      return "black_marble";
+    case "population_grid":
+      return "population_grid";
+    case "oaktree_llm":
+      return "oaktree_llm";
+    case "oaktree_internal":
+      return "oaktree_internal";
+    default:
+      return fallback;
+  }
+}
+
+/* ─── Component → inputs map ─────────────────────────────────────────────── */
+
+export const PER_COMPONENT_INPUTS: Record<string, InputDescriptor[]> = {
+  occupancy_economics: [
+    {
+      key: "estimated_annual_rent_sar",
+      resolve: ({ candidate, contextSources }) => ({
+        value: asNumber((candidate as Record<string, unknown>).estimated_annual_rent_sar),
+        source: overrideSource(contextSources, "rent_source", "aqar"),
+      }),
+    },
+    {
+      key: "estimated_fitout_cost_sar",
+      resolve: ({ candidate }) => ({
+        value: asNumber((candidate as Record<string, unknown>).estimated_fitout_cost_sar),
+        source: "operator_brief",
+      }),
+    },
+    {
+      key: "area_m2",
+      resolve: ({ candidate }) => {
+        const c = candidate as Record<string, unknown>;
+        const v = asNumber(c.area_m2) ?? asNumber(c.unit_area_sqm);
+        return { value: v, source: "arcgis_riyadh_parcels" };
+      },
+    },
+    {
+      key: "cannibalization_score",
+      resolve: ({ candidate }) => ({
+        value: asNumber((candidate as Record<string, unknown>).cannibalization_score),
+        source: "operator_brief",
+      }),
+    },
+    {
+      key: "rent_burden_percentile",
+      resolve: ({ scoreBreakdown, contextSources }) => {
+        const v = asNumber(readNested(scoreBreakdown, "economics_detail", "rent_burden", "percentile"));
+        return {
+          value: v != null ? Math.round(v * 100) / 100 : null,
+          source: overrideSource(contextSources, "rent_source", "aqar"),
+        };
+      },
+    },
+  ],
+
+  listing_quality: [
+    {
+      key: "effective_age_days",
+      resolve: ({ featureSnapshot }) => {
+        const la = readNested(featureSnapshot, "listing_age") as
+          | Record<string, unknown>
+          | undefined;
+        const v =
+          asNumber(la?.effective_age_days) ??
+          asNumber(la?.updated_days) ??
+          asNumber(la?.created_days);
+        const src = asString(la?.source);
+        return {
+          value: v,
+          source: src === "aqar" ? "aqar" : "aqar",
+        };
+      },
+    },
+    {
+      key: "has_image",
+      resolve: ({ candidate }) => ({
+        value: Boolean((candidate as Record<string, unknown>).image_url),
+        source: "aqar",
+      }),
+    },
+    {
+      key: "llm_suitability_score",
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "listing_quality_signals", "llm_suitability_score")),
+        source: "oaktree_llm",
+      }),
+    },
+    {
+      key: "llm_listing_quality_score",
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "listing_quality_signals", "llm_listing_quality_score")),
+        source: "oaktree_llm",
+      }),
+    },
+    {
+      key: "is_furnished",
+      resolve: ({ featureSnapshot }) => ({
+        value: asBool(readNested(featureSnapshot, "listing_quality_signals", "is_furnished")),
+        source: "aqar",
+      }),
+    },
+    {
+      key: "has_drive_thru",
+      resolve: ({ featureSnapshot }) => ({
+        value: asBool(readNested(featureSnapshot, "listing_quality_signals", "has_drive_thru")),
+        source: "aqar",
+      }),
+    },
+    {
+      key: "district_momentum_score",
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "district_momentum", "momentum_score")),
+        source: "oaktree_internal",
+      }),
+    },
+  ],
+
+  brand_fit: [
+    {
+      key: "district",
+      resolve: ({ candidate }) => {
+        const c = candidate as Record<string, unknown>;
+        const v = asString(c.district_display) ?? asString(c.district);
+        return { value: v, source: "operator_brief" };
+      },
+    },
+    {
+      key: "area_match",
+      resolve: ({ candidate }) => {
+        const c = candidate as Record<string, unknown>;
+        const v = asNumber(c.area_m2) ?? asNumber(c.unit_area_sqm);
+        return { value: v, source: "arcgis_riyadh_parcels" };
+      },
+    },
+    {
+      key: "service_model_fit",
+      resolve: ({ candidate }) => ({
+        value: asString((candidate as Record<string, unknown>).source_type),
+        source: "operator_brief",
+      }),
+    },
+    {
+      key: "cannibalization_distance_m",
+      resolve: ({ candidate }) => ({
+        value: asNumber((candidate as Record<string, unknown>).distance_to_nearest_branch_m),
+        source: "operator_brief",
+      }),
+    },
+  ],
+
+  access_visibility: [
+    {
+      key: "street_width_m",
+      resolve: ({ candidate, contextSources }) => {
+        const c = candidate as Record<string, unknown>;
+        return {
+          value: asNumber(c.unit_street_width_m),
+          source: overrideSource(contextSources, "road_source", "expansion_road_context"),
+        };
+      },
+    },
+    {
+      key: "nearest_major_road_distance_m",
+      resolve: ({ featureSnapshot, contextSources }) => ({
+        value: asNumber(readNested(featureSnapshot, "nearest_major_road_distance_m")),
+        source: overrideSource(contextSources, "road_source", "osm"),
+      }),
+    },
+    {
+      key: "touches_road",
+      resolve: ({ featureSnapshot, contextSources }) => ({
+        value: asBool(readNested(featureSnapshot, "touches_road")),
+        source: overrideSource(contextSources, "road_source", "osm"),
+      }),
+    },
+    {
+      key: "frontage_score",
+      resolve: ({ candidate }) => ({
+        value: asNumber((candidate as Record<string, unknown>).frontage_score),
+        source: "oaktree_internal",
+      }),
+    },
+    {
+      key: "parking_score",
+      resolve: ({ candidate, contextSources }) => ({
+        value: asNumber((candidate as Record<string, unknown>).parking_score),
+        source: overrideSource(contextSources, "parking_source", "expansion_parking_asset"),
+      }),
+    },
+  ],
+
+  demand_potential: [
+    {
+      key: "population_reach",
+      resolve: ({ scoreBreakdown }) => ({
+        value: asNumber(readNested(scoreBreakdown, "market_viability_flag", "population_reach")),
+        source: "population_grid",
+      }),
+    },
+    {
+      key: "realized_demand_30d",
+      resolve: ({ scoreBreakdown, contextSources }) => ({
+        value: asNumber(readNested(scoreBreakdown, "market_viability_flag", "realized_demand_30d")),
+        source: overrideSource(contextSources, "delivery_source", "expansion_delivery_market"),
+      }),
+    },
+    {
+      key: "realized_demand_branches",
+      resolve: ({ scoreBreakdown, contextSources }) => ({
+        value: asNumber(readNested(scoreBreakdown, "market_viability_flag", "realized_demand_branches")),
+        source: overrideSource(contextSources, "delivery_source", "expansion_delivery_market"),
+      }),
+    },
+    {
+      key: "radiance_growth_pct",
+      resolve: ({ scoreBreakdown }) => ({
+        value: asNumber(readNested(scoreBreakdown, "market_viability_flag", "radiance_growth_pct")),
+        source: "black_marble",
+      }),
+    },
+  ],
+
+  landlord_signal: [
+    {
+      key: "llm_landlord_signal_score",
+      resolve: ({ scoreBreakdown }) => ({
+        value: asNumber(readNested(scoreBreakdown, "inputs", "landlord_signal")),
+        source: "oaktree_llm",
+      }),
+    },
+  ],
+
+  competition_whitespace: [
+    {
+      key: "competitor_count",
+      resolve: ({ featureSnapshot, contextSources }) => ({
+        value: asNumber(readNested(featureSnapshot, "competitor_count")),
+        source: overrideSource(contextSources, "competitor_source", "google_places"),
+      }),
+    },
+    {
+      key: "nearest_branch_distance_m",
+      resolve: ({ candidate }) => ({
+        value: asNumber((candidate as Record<string, unknown>).distance_to_nearest_branch_m),
+        source: "operator_brief",
+      }),
+    },
+    {
+      key: "whitespace_input",
+      resolve: ({ scoreBreakdown }) => ({
+        value: asNumber(readNested(scoreBreakdown, "inputs", "competition_whitespace")),
+        source: "oaktree_internal",
+      }),
+    },
+  ],
+
+  chain_strength: [
+    {
+      key: "max_chain_strength",
+      resolve: ({ scoreBreakdown }) => {
+        const direct = asNumber(readNested(scoreBreakdown, "inputs", "chain_strength_max"));
+        const fallback = asNumber(readNested(scoreBreakdown, "inputs", "chain_strength"));
+        return { value: direct ?? fallback, source: "oaktree_internal" };
+      },
+    },
+    {
+      key: "top_chain_name",
+      resolve: ({ featureSnapshot }) => ({
+        value: asString(readNested(featureSnapshot, "brand_presence", "top_chain_strength_name")),
+        source: "google_places",
+      }),
+    },
+    {
+      key: "unique_brands",
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "brand_presence", "unique_brands")),
+        source: "google_places",
+      }),
+    },
+  ],
+
+  confidence: [
+    {
+      key: "data_completeness_score",
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "data_completeness_score")),
+        source: "oaktree_internal",
+      }),
+    },
+    {
+      key: "area_confidence",
+      resolve: ({ featureSnapshot }) => ({
+        value: asString(readNested(featureSnapshot, "area_confidence")),
+        source: "arcgis_riyadh_parcels",
+      }),
+    },
+    {
+      key: "missing_context_count",
+      resolve: ({ featureSnapshot }) => {
+        const v = readNested(featureSnapshot, "missing_context");
+        const n = Array.isArray(v) ? v.length : null;
+        return { value: n, source: "oaktree_internal" };
+      },
+    },
+  ],
+
+  delivery_demand: [
+    {
+      key: "provider_listing_count",
+      resolve: ({ featureSnapshot, contextSources }) => ({
+        value: asNumber(readNested(featureSnapshot, "provider_listing_count")),
+        source: overrideSource(contextSources, "delivery_source", "expansion_delivery_market"),
+      }),
+    },
+    {
+      key: "provider_platform_count",
+      resolve: ({ featureSnapshot, contextSources }) => ({
+        value: asNumber(readNested(featureSnapshot, "provider_platform_count")),
+        source: overrideSource(contextSources, "delivery_source", "expansion_delivery_market"),
+      }),
+    },
+    {
+      key: "multi_platform_presence_score",
+      resolve: ({ candidate }) => ({
+        value: asNumber((candidate as Record<string, unknown>).multi_platform_presence_score),
+        source: "oaktree_internal",
+      }),
+    },
+  ],
+};
+
+/* ─── Canonical viability legs (stable order, matches backend) ───────────── */
+
+export const VIABILITY_LEG_ORDER: readonly string[] = [
+  "rent_per_capita_high",
+  "population_below_quartile",
+  "rent_high",
+  "economics_below_threshold",
+  "demand_low",
+  "radiance_growth_low",
+] as const;

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -747,7 +747,7 @@
     "backendRank": "ترتيب النظام (التسجيل الأصلي)",
     "backendRankLabel": "الترتيب #{{rank}}",
     "whyThisRank": "لماذا هذا الترتيب؟",
-    "scoreComponents": "مكونات الدرجة",
+    "scoreComponentsHeading": "مكونات الدرجة",
     "dataQuality": "جودة البيانات",
     "filterLabel": "تصفية",
     "sortLabel": "ترتيب",
@@ -1008,7 +1008,21 @@
     "rerankReasonLabel": "مراجعة النموذج اللغوي",
     "rerankOutsideWindow": "خارج نطاق مراجعة النموذج اللغوي",
     "rerankDeterministicAccepted": "تم اعتماد الترتيب الحتمي",
-    "decisionLogic": "منطق القرار",
+    "decisionLogic": {
+      "boolYes": "نعم",
+      "boolNo": "لا",
+      "subScoreLabel": "الدرجة الفرعية",
+      "weightLabel": "الوزن",
+      "contributionLabel": "المساهمة",
+      "weightAndPoints": "{{weight}}٪ · {{points}} نقطة",
+      "inputsHeading": "المدخلات",
+      "bonusesHeading": "المكافآت والتعديلات",
+      "subtotal": "الدرجة الأساسية",
+      "adjustmentsLabel": "التعديلات",
+      "totalAdjustment": "إجمالي التعديل",
+      "finalScore": "الدرجة النهائية",
+      "clamped": "تم تقييدها بين 0 و100"
+    },
     "decisionLogicTitle": "منطق الترتيب",
     "decisionLogicGates": "البوابات",
     "decisionLogicContributions": "مساهمات الدرجات",
@@ -1028,6 +1042,140 @@
     "decisionLogicDeltaAria": "تحرك الترتيب {{direction}} بمقدار {{magnitude}}",
     "decisionLogicDeltaUp": "للأعلى",
     "decisionLogicDeltaDown": "للأسفل",
+    "scoreComponents": {
+      "occupancy_economics": {
+        "label": "الاقتصاد",
+        "definition": "تكلفة إيجار الموقع مقارنةً بالقوائم المشابهة وكيف تتفاعل مع التشطيب والمساحة والتنافس مع الفروع. الإيجار المنخفض يرفع الدرجة والإيجار الأعلى من السوق يخفضها.",
+        "inputs": {
+          "estimated_annual_rent_sar": { "label": "الإيجار السنوي (ريال)" },
+          "estimated_fitout_cost_sar": { "label": "تكلفة التشطيب (ريال)" },
+          "area_m2": { "label": "المساحة (م²)" },
+          "cannibalization_score": { "label": "خطر التنافس مع الفروع" },
+          "rent_burden_percentile": { "label": "المئوية للإيجار مقارنةً بالمقارنات" }
+        }
+      },
+      "listing_quality": {
+        "label": "جودة القائمة",
+        "definition": "مدى حداثة القائمة وجودة وصفها وعرضها، مع زخم الحي. القوائم الحديثة والمفروشة والمدعمة بصور في أحياء صاعدة تحصل على درجة أعلى.",
+        "inputs": {
+          "effective_age_days": { "label": "العمر الفعلي للقائمة (أيام)" },
+          "has_image": { "label": "تحتوي على صورة" },
+          "llm_suitability_score": { "label": "درجة الملاءمة (LLM)" },
+          "llm_listing_quality_score": { "label": "درجة جودة القائمة (LLM)" },
+          "is_furnished": { "label": "مفروش" },
+          "has_drive_thru": { "label": "خدمة السيارات" },
+          "district_momentum_score": { "label": "درجة زخم الحي" }
+        }
+      },
+      "brand_fit": {
+        "label": "ملاءمة العلامة",
+        "definition": "مدى توافق الموقع مع الحي المفضل للعلامة، ونطاق المساحة المستهدف، ونموذج الخدمة، وحد التنافس مع الفروع من ملف المشغل.",
+        "inputs": {
+          "district": { "label": "الحي" },
+          "area_match": { "label": "المساحة (م²)" },
+          "service_model_fit": { "label": "المصدر / الصيغة" },
+          "cannibalization_distance_m": { "label": "المسافة لأقرب فرع (م)" }
+        }
+      },
+      "landlord_signal": {
+        "label": "إشارة المؤجر",
+        "definition": "قراءة LLM لاستجابة المؤجر ونص القائمة — هل المؤجر يبدو محترفًا ومتحفزًا ومن المرجح أن يتفاوض بإنصاف؟",
+        "inputs": {
+          "llm_landlord_signal_score": { "label": "درجة إشارة المؤجر (LLM)" }
+        }
+      },
+      "competition_whitespace": {
+        "label": "انفتاح المنافسة",
+        "definition": "مدى ازدحام منطقة التجارة المباشرة بمنافسين من نفس الفئة. المساحة البيضاء (كثافة منافسين منخفضة مع طلب مقاس) تحصل على درجة أعلى.",
+        "inputs": {
+          "competitor_count": { "label": "عدد المنافسين القريبين" },
+          "nearest_branch_distance_m": { "label": "المسافة لأقرب فرع (م)" },
+          "whitespace_input": { "label": "درجة المساحة البيضاء الفرعية" }
+        }
+      },
+      "demand_potential": {
+        "label": "قوة الطلب",
+        "definition": "أدلة الطلب المركبة: السكان ضمن نطاق المشي/القيادة، الطلب الفعلي للتوصيل خلال 30 يومًا، واتجاه نمو إضاءة الحي ليلًا.",
+        "inputs": {
+          "population_reach": { "label": "نطاق السكان" },
+          "realized_demand_30d": { "label": "الطلب المحقق (30 يومًا)" },
+          "realized_demand_branches": { "label": "فروع الطلب النشطة" },
+          "radiance_growth_pct": { "label": "نمو الإضاءة سنويًا (٪)" }
+        }
+      },
+      "access_visibility": {
+        "label": "الوصول والوضوح",
+        "definition": "عرض الشارع والواجهة ومواقف السيارات والقرب من طريق رئيسي. الشوارع الأوسع والقطع الملاصقة للطريق ومواقف السيارات المرصودة ترفع الدرجة.",
+        "inputs": {
+          "street_width_m": { "label": "عرض الشارع (م)" },
+          "nearest_major_road_distance_m": { "label": "أقرب طريق رئيسي (م)" },
+          "touches_road": { "label": "ملامس للطريق" },
+          "frontage_score": { "label": "درجة الواجهة الفرعية" },
+          "parking_score": { "label": "درجة المواقف الفرعية" }
+        }
+      },
+      "delivery_demand": {
+        "label": "سوق التوصيل",
+        "definition": "حضور التوصيل متعدد المنصات في المنطقة — كم عدد المزودين النشطين، وعلى كم منصة، ومدى قوة الحضور متعدد المنصات.",
+        "inputs": {
+          "provider_listing_count": { "label": "عدد قوائم المزودين" },
+          "provider_platform_count": { "label": "عدد منصات المزودين" },
+          "multi_platform_presence_score": { "label": "الحضور متعدد المنصات" }
+        }
+      },
+      "confidence": {
+        "label": "جودة البيانات",
+        "definition": "اكتمال البيانات وموثوقيتها لهذا المرشح — تغطية الميزات، يقين المساحة، وعدد الإشارات المفقودة.",
+        "inputs": {
+          "data_completeness_score": { "label": "اكتمال البيانات" },
+          "area_confidence": { "label": "يقين المساحة" },
+          "missing_context_count": { "label": "الإشارات المفقودة" }
+        }
+      },
+      "chain_strength": {
+        "label": "قوة السلسلة",
+        "definition": "إشارة داعمة للتواجد: عندما تكون سلاسل راسخة وذات أداء جيد قريبة بالفعل، فهذا دليل على أن منطقة التجارة قادرة على دعم مفهوم قوي.",
+        "inputs": {
+          "max_chain_strength": { "label": "أعلى قوة سلسلة قريبة" },
+          "top_chain_name": { "label": "أعلى سلسلة قريبة" },
+          "unique_brands": { "label": "العلامات الفريدة القريبة" }
+        }
+      }
+    },
+    "scoreSources": {
+      "aqar": "عقار",
+      "google_places": "Google Places",
+      "black_marble": "Black Marble VNP46A3",
+      "osm": "OpenStreetMap",
+      "arcgis_riyadh_parcels": "ArcGIS (قطع الرياض)",
+      "operator_brief": "ملف المشغل",
+      "hungerstation": "هنقرستيشن",
+      "talabat": "طلبات",
+      "mrsool": "مرسول",
+      "population_grid": "Population grid",
+      "oaktree_llm": "Oaktree LLM",
+      "oaktree_internal": "Oaktree الداخلي",
+      "expansion_road_context": "سياق الطرق",
+      "expansion_parking_asset": "أصول المواقف",
+      "expansion_delivery_market": "سوق التوصيل"
+    },
+    "bonuses": {
+      "bestValue": "أفضل قيمة",
+      "aboveMarket": "أعلى من السوق",
+      "bestValueSuppressed": "أفضل قيمة (مكبوتة — ثقة المقارنة منخفضة)",
+      "aboveMarketSuppressed": "أعلى من السوق (مكبوتة — ثقة المقارنة منخفضة)",
+      "freshnessNew": "قائمة جديدة",
+      "freshnessUpdated": "تم تحديثها مؤخرًا",
+      "momentumTopTier": "زخم الحي في المرتبة العليا",
+      "viability": {
+        "rent_per_capita_high": "الإيجار للفرد مرتفع",
+        "population_below_quartile": "السكان دون الربع",
+        "rent_high": "الإيجار فوق العتبة",
+        "economics_below_threshold": "الاقتصاد دون العتبة",
+        "demand_low": "الطلب المحقق منخفض",
+        "radiance_growth_low": "نمو الإضاءة منخفض"
+      }
+    },
     "gateVerdictPass": "اجتاز",
     "gateVerdictFail": "لم يجتز",
     "gateVerdictUnknown": "غير مُتحقَّق",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -748,7 +748,7 @@
     "backendRank": "Backend rank (original scoring order)",
     "backendRankLabel": "Rank #{{rank}}",
     "whyThisRank": "Why this rank?",
-    "scoreComponents": "Score components",
+    "scoreComponentsHeading": "Score components",
     "dataQuality": "Data quality",
     "filterLabel": "Filter",
     "sortLabel": "Sort",
@@ -1080,7 +1080,21 @@
     "rerankReasonLabel": "LLM review",
     "rerankOutsideWindow": "Outside LLM review window",
     "rerankDeterministicAccepted": "Deterministic ranking accepted",
-    "decisionLogic": "Decision logic",
+    "decisionLogic": {
+      "boolYes": "Yes",
+      "boolNo": "No",
+      "subScoreLabel": "Sub-score",
+      "weightLabel": "Weight",
+      "contributionLabel": "Contribution",
+      "weightAndPoints": "{{weight}}% · {{points}} pts",
+      "inputsHeading": "Inputs",
+      "bonusesHeading": "Bonuses & adjustments",
+      "subtotal": "Base score",
+      "adjustmentsLabel": "Adjustments",
+      "totalAdjustment": "Total adjustment",
+      "finalScore": "Final score",
+      "clamped": "Clamped to 0–100"
+    },
     "decisionLogicTitle": "Ranking logic",
     "decisionLogicGates": "Gates",
     "decisionLogicContributions": "Score contributions",
@@ -1100,6 +1114,140 @@
     "decisionLogicDeltaAria": "Rank moved {{direction}} by {{magnitude}}",
     "decisionLogicDeltaUp": "up",
     "decisionLogicDeltaDown": "down",
+    "scoreComponents": {
+      "occupancy_economics": {
+        "label": "Economics",
+        "definition": "How much rent the site costs relative to comparable listings and how that interacts with fit-out, area, and cannibalization. Lower rent burden lifts the score; above-market rent drags it.",
+        "inputs": {
+          "estimated_annual_rent_sar": { "label": "Annual rent (SAR)" },
+          "estimated_fitout_cost_sar": { "label": "Fit-out cost (SAR)" },
+          "area_m2": { "label": "Area (m²)" },
+          "cannibalization_score": { "label": "Cannibalization risk" },
+          "rent_burden_percentile": { "label": "Rent percentile vs. comparables" }
+        }
+      },
+      "listing_quality": {
+        "label": "Listing Quality",
+        "definition": "How recent, well-described, and well-presented the listing is, combined with the district's underlying momentum. Fresh, furnished, image-backed listings in rising districts score higher.",
+        "inputs": {
+          "effective_age_days": { "label": "Effective listing age (days)" },
+          "has_image": { "label": "Has image" },
+          "llm_suitability_score": { "label": "LLM suitability score" },
+          "llm_listing_quality_score": { "label": "LLM listing quality score" },
+          "is_furnished": { "label": "Furnished" },
+          "has_drive_thru": { "label": "Drive-thru" },
+          "district_momentum_score": { "label": "District momentum score" }
+        }
+      },
+      "brand_fit": {
+        "label": "Brand Fit",
+        "definition": "How well the site matches the brand's preferred district, target area band, service model, and cannibalization tolerance from the operator brief.",
+        "inputs": {
+          "district": { "label": "District" },
+          "area_match": { "label": "Area (m²)" },
+          "service_model_fit": { "label": "Source / format" },
+          "cannibalization_distance_m": { "label": "Distance to nearest branch (m)" }
+        }
+      },
+      "landlord_signal": {
+        "label": "Landlord Signal",
+        "definition": "An LLM read of landlord responsiveness and listing copy — does the landlord look professional, motivated, and likely to negotiate fairly?",
+        "inputs": {
+          "llm_landlord_signal_score": { "label": "LLM landlord signal score" }
+        }
+      },
+      "competition_whitespace": {
+        "label": "Competitor Openness",
+        "definition": "How crowded the immediate trade area is with same-category competitors. Whitespace (low competitor density combined with measured demand) scores higher.",
+        "inputs": {
+          "competitor_count": { "label": "Competitor count (nearby)" },
+          "nearest_branch_distance_m": { "label": "Distance to nearest branch (m)" },
+          "whitespace_input": { "label": "Whitespace sub-score" }
+        }
+      },
+      "demand_potential": {
+        "label": "Demand Strength",
+        "definition": "Combined demand evidence: population reach within a walking/driving catchment, realized 30-day delivery demand, and the district's nighttime-light growth trend.",
+        "inputs": {
+          "population_reach": { "label": "Population reach" },
+          "realized_demand_30d": { "label": "Realized demand (30d)" },
+          "realized_demand_branches": { "label": "Active demand branches" },
+          "radiance_growth_pct": { "label": "Radiance YoY growth (%)" }
+        }
+      },
+      "access_visibility": {
+        "label": "Access & Visibility",
+        "definition": "Street width, frontage, parking, and proximity to a major road. Wider streets, road-adjacent parcels, and observed parking lift the score.",
+        "inputs": {
+          "street_width_m": { "label": "Street width (m)" },
+          "nearest_major_road_distance_m": { "label": "Nearest major road (m)" },
+          "touches_road": { "label": "Touches road" },
+          "frontage_score": { "label": "Frontage sub-score" },
+          "parking_score": { "label": "Parking sub-score" }
+        }
+      },
+      "delivery_demand": {
+        "label": "Delivery Market",
+        "definition": "Multi-platform delivery presence in the area — how many providers are active, how many platforms list food in this district, and how strong multi-platform presence is.",
+        "inputs": {
+          "provider_listing_count": { "label": "Provider listing count" },
+          "provider_platform_count": { "label": "Provider platform count" },
+          "multi_platform_presence_score": { "label": "Multi-platform presence" }
+        }
+      },
+      "confidence": {
+        "label": "Data Quality",
+        "definition": "How complete and trustworthy the input data is for this candidate — feature coverage, area certainty, and the count of missing signals.",
+        "inputs": {
+          "data_completeness_score": { "label": "Data completeness" },
+          "area_confidence": { "label": "Area confidence" },
+          "missing_context_count": { "label": "Missing signals" }
+        }
+      },
+      "chain_strength": {
+        "label": "Chain Strength",
+        "definition": "Pro-presence signal: when established, well-performing chains are already nearby, that's evidence the trade area can support a strong concept.",
+        "inputs": {
+          "max_chain_strength": { "label": "Max nearby chain strength" },
+          "top_chain_name": { "label": "Top nearby chain" },
+          "unique_brands": { "label": "Unique nearby brands" }
+        }
+      }
+    },
+    "scoreSources": {
+      "aqar": "Aqar",
+      "google_places": "Google Places",
+      "black_marble": "Black Marble VNP46A3",
+      "osm": "OpenStreetMap",
+      "arcgis_riyadh_parcels": "ArcGIS (Riyadh parcels)",
+      "operator_brief": "Operator brief",
+      "hungerstation": "HungerStation",
+      "talabat": "Talabat",
+      "mrsool": "Mrsool",
+      "population_grid": "Population grid",
+      "oaktree_llm": "Oaktree LLM",
+      "oaktree_internal": "Oaktree internal",
+      "expansion_road_context": "Expansion road context",
+      "expansion_parking_asset": "Expansion parking asset",
+      "expansion_delivery_market": "Expansion delivery market"
+    },
+    "bonuses": {
+      "bestValue": "Best Value",
+      "aboveMarket": "Above Market",
+      "bestValueSuppressed": "Best Value (suppressed — low comparable confidence)",
+      "aboveMarketSuppressed": "Above Market (suppressed — low comparable confidence)",
+      "freshnessNew": "New listing",
+      "freshnessUpdated": "Recently updated",
+      "momentumTopTier": "District momentum top-tier",
+      "viability": {
+        "rent_per_capita_high": "Rent-per-capita too high",
+        "population_below_quartile": "Population below quartile",
+        "rent_high": "Rent above threshold",
+        "economics_below_threshold": "Economics below threshold",
+        "demand_low": "Realized demand too low",
+        "radiance_growth_low": "Radiance growth too low"
+      }
+    },
     "gateVerdictPass": "Passed",
     "gateVerdictFail": "Failed",
     "gateVerdictUnknown": "Unverified",


### PR DESCRIPTION
## Summary

Upgrades the Decision Memo **Diagnostics → Score contributions** section so the CEO and operators can trace why each component scored what it did:

- **Inline accordion** (native `<details>`/`<summary>`, matching the Gates pattern) — one row per component, expanding reveals the plain-English definition, sub-score (0–100), weight, contribution in points, and each input with source attribution.
- **chain_strength** added as the 10th row (already rendered by `ScoreBreakdownCompact` / Executive Report / Candidate Detail — this aligns Diagnostics with the rest of the app and closes the long-standing "9 segments sum to 79, total shows 86.7" chart math gap).
- **Bonuses & adjustments** sub-block below the bar+legend: subtotal (base deterministic), one chip per applied adjustment (Best Value +4, Above Market −6, suppressed value-band neutral chip, freshness, district-momentum top-tier, each fired viability leg −10), total adjustment, final score, and a "Clamped to 0–100" badge when applicable.

This is the **frontend half** of the work; the backend plumbing for the 8 diagnostic fields was already merged (#1220).

### Locked design decisions (from prior discussion)

- Pattern: inline accordion, independent `<details>` per row (multiple may be open).
- Source provenance: frontend constants map with override from `feature_snapshot_json.context_sources.*_source` for the inputs that have conditional sources (rent, road, parking, delivery, competitor).
- Conditional value-band rendering: when `value_band_low_confidence === true` and `bonus_detail.value_band_delta === 0`, render a neutral "suppressed" chip with no signed magnitude.
- i18n collision: existing flat `expansionAdvisor.scoreComponents` renamed to `scoreComponentsHeading`; the nested namespace takes the flat name.
- Source localization: consumer brands transliterated in Arabic (عقار, هنقرستيشن, طلبات, مرسول); technical identifiers (Black Marble VNP46A3, ArcGIS, OpenStreetMap, Google Places, Population grid) left in English in both locales.
- Tenth chart color: `#b8553a` (rust). Designer may swap post-merge with a one-line CSS revert.

### Files

- `DecisionLogicCard.tsx` — adds `candidate` prop, renders 10 component-row `<details>` nested inside the contributions wrapper, renders the bonuses sub-block defensively (every input access uses optional chaining; missing values render as `—` rather than crashing the panel).
- `scoreComponentMeta.ts` (new) — `PER_COMPONENT_INPUTS` (descriptor list per component) and `SourceToken` union + `VIABILITY_LEG_ORDER` for stable backend ordering of fired legs.
- `expansion-advisor.css` — `--oak-ea-seg-chain_strength: #b8553a`, `--component-row` styling, `--suppressed` chip modifier, bonuses divider/grid.
- `en.json` / `ar.json` — nested `scoreComponents.<key>.{label,definition,inputs.*}`, `scoreSources.*`, `bonuses.*`, `decisionLogic.*` helpers. `scoreComponents` renamed to `scoreComponentsHeading` at the flat-key site (only consumer is `WhyThisRank.tsx`, updated in the same patch).
- `ExpansionMemoPanel.tsx` — passes the whole `cand` to `DecisionLogicCard` (one new prop, no scalar prop bloat).
- Tests:
  - `DecisionLogicCard.test.tsx` — fixture now includes chain_strength; count assertions bumped 9 → 10 / 18 → 30. Three new tests: 10 accordion rows + definitions, bonuses chips + final score, suppressed value-band chip styling.

## Test plan

- [x] `npx vitest run src/features/expansion-advisor/DecisionLogicCard.test.tsx src/features/expansion-advisor/ExpansionMemoPanel.test.tsx` — 67/67 pass
- [x] `npm run build` — TypeScript compiles cleanly
- [x] Existing 15 pre-existing failures in `ExpansionAdvisorPage.test.tsx` are unchanged (confirmed via `git stash` baseline)
- [ ] Manual smoke on production-like data: expand each of 10 component rows, confirm Best Value / Above Market / suppressed / no-bonus / multi-leg-viability candidates render correctly, confirm Arabic locale renders correctly, confirm the contributions outer `<details>` is closed by default.
- [ ] Visual designer review of `#b8553a` (rust) — accept as working default; one-line CSS revert if rejected.

## Out of scope

- Backend changes (separate PR, already merged).
- `ScoreBreakdownCompact`, `ExpansionReportPanel`, `CandidateDetailPanel`, `WhyThisRank` — already render `chain_strength` correctly via their own data path.
- Single-open accordion behavior — independent `<details>` for now; revisit post-merge if iPad review reveals it's too busy.
- Any change to gates, viability legs, score formula, weights, or thresholds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lr83CgVMhMENTsdH2JF1Ez)_