### PR TITLE
fix(expansion_advisor): make Score Contributions row chevron more visible

### DIFF
--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -4533,6 +4533,21 @@
   font-size: var(--oak-fs-xs, 12px);
   padding-block: 2px;
 }
+.ea-decision-logic__subsection--component-row > .ea-decision-logic__subsection-summary::before {
+  font-size: var(--oak-fs-sm, 14px);
+  color: var(--oak-primary, #14312c);
+  font-weight: 700;
+  margin-inline-end: 6px;
+  transition: transform 120ms ease;
+}
+.ea-decision-logic__subsection--component-row > .ea-decision-logic__subsection-summary:hover {
+  background: rgba(20, 49, 44, 0.04);
+  cursor: pointer;
+}
+.ea-decision-logic__subsection--component-row > .ea-decision-logic__subsection-summary:focus-visible {
+  outline: 2px solid var(--oak-primary, #14312c);
+  outline-offset: 2px;
+}
 .ea-decision-logic__subsection--component-row .ea-decision-logic__legend-swatch {
   inline-size: 10px;
   block-size: 10px;


### PR DESCRIPTION
## What's wrong

The Score Contributions accordion shipped in #1221. Post-deploy feedback from iPad users: the ▸ chevron on each per-component `<summary>` row is too small and low-contrast to be noticed — users assume the rows are static labels and never tap to expand them.

## Why it happens

The base `.ea-decision-logic__subsection-summary::before` rule renders the chevron at 10px in `--oak-text-light` (#828282). On the component-row variant the summary itself is already shrunk to `--oak-fs-xs` (12px), making the 10px gray glyph effectively invisible at iPad viewing distance.

## Fix

CSS-only patch, scoped exclusively to `.ea-decision-logic__subsection--component-row` so the Gates section, the Contributions wrapper `<details>`, and the Ranking Decision `<details>` chevrons are all unchanged.

On the component-row variant only:
- Chevron `font-size` → `var(--oak-fs-sm, 14px)`
- Chevron `color` → `var(--oak-primary, #14312c)` (the project's actual primary token — `--oak-primary` is used throughout this file with fallback `#14312c`, not `#2E4E3F`)
- Chevron `font-weight` → `700`
- Chevron `margin-inline-end` → `6px` so it doesn't crowd the legend swatch
- `transition: transform 120ms ease` preserved (rotation-when-open still inherits from the base `[open] > summary::before` rule — same element carries both classes, no specificity conflict because the new variant rule does not declare `transform`)
- `summary:hover` → subtle `rgba(20, 49, 44, 0.04)` tint + `cursor: pointer` (RGB matches the actual primary token)
- `summary:focus-visible` → `2px solid var(--oak-primary, #14312c)` with `2px` offset (no `--oak-focus-ring` token exists in this codebase, so the primary token is used directly — consistent with how the rest of `expansion-advisor.css` handles accent colors)

## Validation

- CSS-only change; no TSX, i18n, or test edits.
- Local `npm run build` fails on pre-existing TypeScript `esModuleInterop`/`moduleResolution` deprecation errors in `tsconfig.json` that are unrelated to this patch.
- Existing DecisionLogicCard tests don't assert on chevron size/color (only on `<details>` open/closed presence), so they remain green.
- Manual smoke (please verify on iPad before merge):
  - [ ] Open a Decision Memo → Diagnostics tab.
  - [ ] All 10 component rows show a visibly larger, darker chevron.
  - [ ] Tapping a row expands it and the chevron rotates 90°.
  - [ ] Gates and the outer Contributions chevrons are visually unchanged.
  - [ ] Desktop hover shows the subtle background tint.

## Context

Follow-up on #1221.

## Risk

Low — purely additive CSS rules under a single variant selector. No selector touches behavior outside the per-component rows.


---
_Generated by [Claude Code](https://claude.ai/code/session_014XbhqZZSkoDtEixweZyqfv)_