### PR TITLE
Enforce deterministic verdict as mandatory source of truth for headlines

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -1448,42 +1448,17 @@ def _decision_memo_cache_lookup(
     search_id: str,
     parcel_id: str,
 ) -> tuple[str | None, dict[str, Any] | None] | None:
-    """Return (cached_text, cached_json) if a row exists with a memo
-    persisted under the CURRENT ``MEMO_PROMPT_VERSION``, else None.
+    """Always return None — memo cache reads are disabled.
 
-    A row whose ``decision_memo_prompt_version`` does not match the
-    current version (including NULL — pre-versioning rows) is treated as
-    a cache miss so the caller regenerates against the new prompt. Any
-    DB error is swallowed and treated as a cache miss.
+    Every POST /decision-memo and pre-warm task now regenerates against
+    the live LLM. Writes via ``_decision_memo_cache_write`` are still
+    issued so ``decision_memo_present`` keeps flipping True for the
+    frontend "View memo" affordance and GET /candidates/{id}/memo keeps
+    returning a stored payload. The persisted memo simply becomes the
+    most-recent generation rather than a cache.
     """
-    try:
-        row = db.execute(
-            text(
-                "SELECT decision_memo, decision_memo_json, "
-                "       decision_memo_prompt_version "
-                "FROM expansion_candidate "
-                "WHERE search_id = :sid AND parcel_id = :pid "
-                "LIMIT 1"
-            ),
-            {"sid": search_id, "pid": parcel_id},
-        ).fetchone()
-    except Exception as exc:
-        logger.warning(
-            "Decision memo cache lookup failed for (%s,%s): %s",
-            search_id, parcel_id, exc,
-        )
-        return None
-    if row is None:
-        return None
-    cached_text = row[0]
-    cached_json = row[1]
-    cached_version = row[2]
-    if cached_text is None and cached_json is None:
-        return None
-    if cached_version != MEMO_PROMPT_VERSION:
-        # Stale (different version) or pre-versioning (NULL) — regenerate.
-        return None
-    return cached_text, cached_json
+    del db, search_id, parcel_id
+    return None
 
 
 def _decision_memo_cache_write(

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -54,7 +54,7 @@ TEMPERATURE = 0.3
 # Bumped whenever STRUCTURED_MEMO_SYSTEM_PROMPT changes meaningfully.
 # Cached memos with a different version are treated as cache-miss and
 # regenerated lazily on next view.
-MEMO_PROMPT_VERSION = "v6-headline-rules-2026-05"
+MEMO_PROMPT_VERSION = "v7-verdict-mandatory-2026-05"
 
 # Soft daily ceiling in USD.  Raises RuntimeError before calling OpenAI
 # if the running total for today exceeds this value.
@@ -1603,14 +1603,17 @@ this prompt. Other instructions are subordinate to these.
    has weak signals or mixed evidence, you MUST choose one of the
    three allowed prefixes.
 
-2. Map the deterministic_verdict to the headline prefix as follows:
+2. Map the deterministic_verdict to the headline prefix as follows.
+   These mappings are MANDATORY when overall_pass == true. The
+   deterministic verdict is the source of truth for the headline verb;
+   do not re-adjudicate from raw scores or demand thresholds.
    - deterministic_verdict == "go"
        → "Recommend" (default)
        → "Recommend with reservations" only if blocking gates failed
+       → NEVER "Decline"
    - deterministic_verdict == "consider"
-       → "Recommend with reservations" (default)
-       → "Decline" only if blocking gates failed AND the case for
-         the candidate is materially weaker than rank-2
+       → "Recommend with reservations" (mandatory when overall_pass == true)
+       → NEVER "Decline" when overall_pass == true
    - deterministic_verdict == "caution"
        → "Decline" (default)
        → "Recommend with reservations" only if there is a strong,
@@ -1855,15 +1858,20 @@ def _headline_validity_reason(
     final_score: float | None,
     overall_pass: bool | None,
     blocking_failed: list,
+    deterministic_verdict: str | None = None,
 ) -> str | None:
     """Return None when ``headline`` satisfies the format rules; otherwise
     a short reason string suitable for logging and retry-prompt context.
 
-    Catches the three failure modes observed in production:
+    Catches the failure modes observed in production:
       1. Headlines that don't begin with an allowed prefix (e.g.,
          "consider due to ...").
       2. Rank-1 high-score Decline headlines with no blocking failures.
-      3. Confabulated gate failures (Decline citing "failed [X]" when
+      3. ``overall_pass == False`` candidates with a Recommend headline.
+      4. ``overall_pass == True`` candidates whose deterministic verdict
+         is "go" or "consider" but whose headline starts with "Decline"
+         (mutually exclusive with #3 by construction).
+      5. Confabulated gate failures (Decline citing "failed [X]" when
          ``gates.failed`` is empty).
     """
     if not isinstance(headline, str) or not headline.strip():
@@ -1905,6 +1913,21 @@ def _headline_validity_reason(
         return (
             "overall_pass=False candidate must have a Decline headline, "
             "not Recommend"
+        )
+
+    # Symmetric guard: overall_pass=True candidates whose deterministic
+    # verdict is "go" or "consider" must not have a Decline headline.
+    # Mutually exclusive with the False-guard above (overall_pass is True
+    # XOR False); deterministic_verdict is None when scores are missing,
+    # in which case this guard is intentionally inert.
+    if (
+        overall_pass is True
+        and deterministic_verdict in ("go", "consider")
+        and starts_with_decline
+    ):
+        return (
+            f"overall_pass=True with deterministic_verdict="
+            f"{deterministic_verdict!r} must not have a Decline headline"
         )
 
     # Confabulation guard: a Decline headline citing failed gates when
@@ -2106,10 +2129,11 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
     On a successful shape-validated response, run an additional headline-
     validity check. If the headline violates the format / consistency
     rules (banned prefix, rank-1 high-score Decline, overall_pass=False
-    Recommend, or confabulated gate failure), retry the call once with a
-    corrective preamble. If the retry also fails, log an error and rewrite
-    the headline locally so a contradicting recommendation never reaches
-    the user.
+    Recommend, overall_pass=True with go/consider verdict Decline, or
+    confabulated gate failure), retry the call once with a corrective
+    preamble. If the retry also fails, log an error and rewrite the
+    headline locally so a contradicting recommendation never reaches the
+    user.
 
     Returns the parsed JSON dict on success. Token usage is recorded against
     the same ``_daily_cost_tracker`` as the legacy path so the $/day ceiling
@@ -2167,6 +2191,7 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
         final_score=ctx.final_score,
         overall_pass=ctx.overall_pass,
         blocking_failed=blocking_failed,
+        deterministic_verdict=ctx.deterministic_verdict,
     )
 
     usage = getattr(response, "usage", None)
@@ -2225,6 +2250,7 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
                     final_score=ctx.final_score,
                     overall_pass=ctx.overall_pass,
                     blocking_failed=blocking_failed,
+                    deterministic_verdict=ctx.deterministic_verdict,
                 )
                 retry_usage = getattr(retry_response, "usage", None)
                 input_tokens += int(
@@ -2268,8 +2294,7 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
             # state and would contradict the rewritten headline. Empty them so
             # the frontend renders verdict + headline only on the safety-net
             # path. This is intentional graceful degradation, not data loss —
-            # the next view-time regeneration (after the v6 prompt-version bump
-            # invalidates the cache) will repopulate everything.
+            # the next view-time regeneration will repopulate everything.
             parsed["ranking_explanation"] = ""
             parsed["key_evidence"] = []
             parsed["risks"] = []


### PR DESCRIPTION
## Summary

This change strengthens the consistency rules for decision memo headlines by making the `deterministic_verdict` the mandatory source of truth when `overall_pass == true`. It also disables memo cache reads to ensure all memos are regenerated against the live LLM, while keeping cache writes to maintain the "View memo" affordance in the frontend.

## Key Changes

- **Prompt version bump** (`v6` → `v7-verdict-mandatory-2026-05`): Updated system prompt to clarify that deterministic verdict mappings are mandatory when `overall_pass == true`, preventing re-adjudication from raw scores or demand thresholds.

- **Enhanced headline validation**: Added a new guard in `_headline_validity_reason()` to catch the symmetric failure mode: `overall_pass == True` candidates whose deterministic verdict is "go" or "consider" must not have a "Decline" headline. This complements the existing guard that prevents `overall_pass == False` candidates from having "Recommend" headlines.

- **Deterministic verdict passed to validation**: Updated both initial and retry calls to `_headline_validity_reason()` to include `deterministic_verdict` parameter, enabling the new validation check.

- **Cache reads disabled**: Modified `_decision_memo_cache_lookup()` to always return `None`, forcing all POST /decision-memo and pre-warm tasks to regenerate against the live LLM. Cache writes remain active so the persisted memo becomes the most-recent generation rather than a stale cache, preserving the frontend "View memo" affordance and GET /candidates/{id}/memo behavior.

- **Documentation updates**: Clarified docstrings and comments to reflect the new mandatory verdict mapping rules and the cache-read-disabled behavior.

## Implementation Details

- The new validation guard is intentionally inert when `deterministic_verdict` is `None` (when scores are missing), maintaining backward compatibility.
- The symmetric guards (`overall_pass == False` → no Recommend, `overall_pass == True` with go/consider → no Decline) are mutually exclusive by construction.
- Cache writes continue to update the database, so the frontend's decision_memo_present flag and memo retrieval endpoints remain functional.
- On headline validation failure, the system retries once with corrective context; if the retry also fails, it rewrites the headline locally as graceful degradation.

## Validation

- Prompt version bump will invalidate all cached memos, triggering regeneration on next view.
- New validation rules are enforced at both initial generation and retry stages.
- Cache behavior change is transparent to the frontend; memo availability and retrieval remain unchanged.

https://claude.ai/code/session_01DSQpLKPKvxbnLK1LhKuyXW