### PR TITLE
Calibrate realized-demand score reference to p75 (263)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -87,12 +87,11 @@ class Settings:
     # "delivery rating velocity", never as "orders".
     #
     # Default flipped ON (B3): the production coverage check confirmed
-    # 100% of recent candidates carry ≥3 branches in the 1200 m catchment
-    # (median realized_demand_30d ≈ 797, p90 ≈ 2,293 — well above the
-    # _delivery_score calibration reference of 200). The signal is now
-    # first-class, not opt-in. Set EXPANSION_REALIZED_DEMAND_ENABLED=false
-    # to restore the legacy behavior (snapshot fields suppressed and
-    # realized_demand_source reported as ``history_unavailable``).
+    # ~3,128 of 7,405 recent candidates (trailing 90d) carry ≥3 branches in
+    # the 1200 m catchment. The signal is now first-class, not opt-in. Set
+    # EXPANSION_REALIZED_DEMAND_ENABLED=false to restore the legacy behavior
+    # (snapshot fields suppressed and realized_demand_source reported as
+    # ``history_unavailable``).
     EXPANSION_REALIZED_DEMAND_ENABLED: bool = (
         os.getenv("EXPANSION_REALIZED_DEMAND_ENABLED", "true").strip().lower()
         in {"1", "true", "yes", "on"}
@@ -110,10 +109,14 @@ class Settings:
     )
     # Reference point for the square-root-scaled realized-demand score in
     # _delivery_score(): realized_demand == this value maps to a score of 100.
-    # Placeholder default 200.0 pending calibration against the trailing-90d
-    # Riyadh distribution (see scripts/diagnostics/realized_demand_calibration.sql).
+    # Calibrated 2026-05-15 from the trailing-90d realized_demand_30d
+    # distribution across 3,128 populated candidates (median 133, p75 263,
+    # p90 496, p95 840). Anchor at p75: a candidate at the 75th percentile of
+    # measured demand saturates the demand leg, median candidates score ~71,
+    # only the top quartile maxes out. See
+    # scripts/diagnostics/realized_demand_calibration.sql.
     EXPANSION_REALIZED_DEMAND_REFERENCE: float = float(
-        os.getenv("EXPANSION_REALIZED_DEMAND_REFERENCE", "200.0")
+        os.getenv("EXPANSION_REALIZED_DEMAND_REFERENCE", "263.0")
     )
 
     # --- Expansion Advisor structured decision memo (Phase 1) ---

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -108,6 +108,13 @@ class Settings:
     EXPANSION_REALIZED_DEMAND_BLEND: float = float(
         os.getenv("EXPANSION_REALIZED_DEMAND_BLEND", "0.5")
     )
+    # Reference point for the square-root-scaled realized-demand score in
+    # _delivery_score(): realized_demand == this value maps to a score of 100.
+    # Placeholder default 200.0 pending calibration against the trailing-90d
+    # Riyadh distribution (see scripts/diagnostics/realized_demand_calibration.sql).
+    EXPANSION_REALIZED_DEMAND_REFERENCE: float = float(
+        os.getenv("EXPANSION_REALIZED_DEMAND_REFERENCE", "200.0")
+    )
 
     # --- Expansion Advisor structured decision memo (Phase 1) ---
     # Model/token/temperature controls for the new structured memo path in

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -2179,10 +2179,14 @@ def _delivery_score(
     )
     if realized_demand is None or realized_demand <= 0:
         return listing_score
-    # Reference: 200 new ratings/window ≈ 100.  Square-root scaling mirrors
-    # the listing-count term so the two blend cleanly.  Calibrate once
-    # enough history has accumulated across Riyadh.
-    realized_score = _clamp((realized_demand / 200.0) ** 0.5 * 100.0)
+    # Reference point (EXPANSION_REALIZED_DEMAND_REFERENCE): realized_demand
+    # equal to the reference maps to a score of 100.  Square-root scaling
+    # mirrors the listing-count term so the two blend cleanly.  Calibrate via
+    # scripts/diagnostics/realized_demand_calibration.sql.
+    realized_score = _clamp(
+        (realized_demand / settings.EXPANSION_REALIZED_DEMAND_REFERENCE) ** 0.5
+        * 100.0
+    )
     bw = max(0.0, min(1.0, blend_weight))
     return _clamp(listing_score * (1.0 - bw) + realized_score * bw)
 

--- a/scripts/diagnostics/realized_demand_calibration.sql
+++ b/scripts/diagnostics/realized_demand_calibration.sql
@@ -1,0 +1,57 @@
+\pset footer off
+--
+-- realized_demand_calibration.sql
+--
+-- Trailing-90d distribution of realized_demand_30d across Riyadh expansion
+-- candidates, used to calibrate the _delivery_score realized-demand
+-- reference point (settings.EXPANSION_REALIZED_DEMAND_REFERENCE, currently
+-- 200.0 as a placeholder). Run this in Codespace against the production
+-- DB; feed the p75 from section C into the EXPANSION_REALIZED_DEMAND_REFERENCE
+-- default with a dated calibration comment.
+--
+-- "Populated" means the candidate carries a realized_demand_30d value AND
+-- realized_demand_branches >= 3 — the same minimum-branch gate the snapshot
+-- writer applies (app/services/expansion_advisor.py). Candidates below that
+-- gate never contribute a realized-demand score, so they are excluded from
+-- the calibration distribution.
+--
+-- The product is Riyadh-only, so no city filter is applied. Trailing-90d is
+-- derived from expansion_search.created_at (expansion_candidate has no own
+-- timestamp).
+--
+\echo ''
+\echo '=== A. Total candidate count (trailing 90d) ==='
+SELECT
+  COUNT(*) AS total_candidates
+FROM expansion_candidate c
+JOIN expansion_search s ON s.id = c.search_id
+WHERE s.created_at >= now() - interval '90 days';
+
+\echo ''
+\echo '=== B. Candidates with realized_demand_30d populated (branches >= 3) ==='
+SELECT
+  COUNT(*) AS populated_candidates
+FROM expansion_candidate c
+JOIN expansion_search s ON s.id = c.search_id
+WHERE s.created_at >= now() - interval '90 days'
+  AND c.feature_snapshot_json ? 'realized_demand_30d'
+  AND (c.feature_snapshot_json->>'realized_demand_30d') IS NOT NULL
+  AND COALESCE((c.feature_snapshot_json->>'realized_demand_branches')::numeric, 0) >= 3;
+
+\echo ''
+\echo '=== C. realized_demand_30d percentiles over populated values ==='
+SELECT
+  COUNT(*)                                                            AS n,
+  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY rd), 1)           AS median,
+  ROUND(percentile_cont(0.75) WITHIN GROUP (ORDER BY rd), 1)           AS p75,
+  ROUND(percentile_cont(0.90) WITHIN GROUP (ORDER BY rd), 1)           AS p90,
+  ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY rd), 1)           AS p95
+FROM (
+  SELECT (c.feature_snapshot_json->>'realized_demand_30d')::numeric AS rd
+  FROM expansion_candidate c
+  JOIN expansion_search s ON s.id = c.search_id
+  WHERE s.created_at >= now() - interval '90 days'
+    AND c.feature_snapshot_json ? 'realized_demand_30d'
+    AND (c.feature_snapshot_json->>'realized_demand_30d') IS NOT NULL
+    AND COALESCE((c.feature_snapshot_json->>'realized_demand_branches')::numeric, 0) >= 3
+) populated;

--- a/scripts/diagnostics/realized_demand_calibration.sql
+++ b/scripts/diagnostics/realized_demand_calibration.sql
@@ -41,11 +41,11 @@ WHERE s.created_at >= now() - interval '90 days'
 \echo ''
 \echo '=== C. realized_demand_30d percentiles over populated values ==='
 SELECT
-  COUNT(*)                                                            AS n,
-  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY rd), 1)           AS median,
-  ROUND(percentile_cont(0.75) WITHIN GROUP (ORDER BY rd), 1)           AS p75,
-  ROUND(percentile_cont(0.90) WITHIN GROUP (ORDER BY rd), 1)           AS p90,
-  ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY rd), 1)           AS p95
+  COUNT(*)                                                                  AS n,
+  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY rd)::numeric, 1)        AS median,
+  ROUND(percentile_cont(0.75) WITHIN GROUP (ORDER BY rd)::numeric, 1)        AS p75,
+  ROUND(percentile_cont(0.90) WITHIN GROUP (ORDER BY rd)::numeric, 1)        AS p90,
+  ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY rd)::numeric, 1)        AS p95
 FROM (
   SELECT (c.feature_snapshot_json->>'realized_demand_30d')::numeric AS rd
   FROM expansion_candidate c

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -1993,18 +1993,19 @@ def test_delivery_score_blends_realized_demand_when_provided():
     from app.services.expansion_advisor import _delivery_score
 
     listing_only = _delivery_score(10)  # ~50
-    # Realized demand of 200 Δ ratings ≈ 100 on the realized curve
-    blended = _delivery_score(10, realized_demand=200.0, blend_weight=0.5)
+    # Realized demand at the calibration reference (p75 = 263 Δ ratings)
+    # ≈ 100 on the realized curve.
+    blended = _delivery_score(10, realized_demand=263.0, blend_weight=0.5)
     # Blend pulls the score toward the stronger realized signal
     assert blended > listing_only
     # Full-realized weight = realized score only
     realized_only = _delivery_score(
-        10, realized_demand=200.0, blend_weight=1.0
+        10, realized_demand=263.0, blend_weight=1.0
     )
     assert abs(realized_only - 100.0) < 0.01
     # Zero blend weight = listing-only
     ignore_realized = _delivery_score(
-        10, realized_demand=200.0, blend_weight=0.0
+        10, realized_demand=263.0, blend_weight=0.0
     )
     assert abs(ignore_realized - listing_only) < 0.01
 


### PR DESCRIPTION
## Summary

PR B of the realized-demand workstream (PR A — the "orders" → "delivery rating velocity" relabel — merged as #1228). This PR replaces the uncalibrated hardcoded `200` reference point in `_delivery_score()` with a percentile-anchored calibration against the actual Riyadh distribution.

- **Make the reference configurable** — replace the literal `200` in `_delivery_score()` with the new env-driven `EXPANSION_REALIZED_DEMAND_REFERENCE` setting (`config.py`), placed next to the other `EXPANSION_REALIZED_DEMAND_*` settings.
- **Add a re-runnable calibration script** — `scripts/diagnostics/realized_demand_calibration.sql` measures the trailing-90d Riyadh distribution of `realized_demand_30d` (total candidates, populated count with `realized_demand_branches >= 3`, then median/p75/p90/p95 via `percentile_cont`), mirroring `rd_category_discovery.sql`.
- **Calibrate to p75 = 263** — the Codespace run over 3,128 populated candidates returned median 133, p75 263, p90 496, p95 840. Anchoring at p75 keeps the demand leg discriminating: median candidates score ~71, only the top quartile saturates. Median would be too generous (half of candidates max out); p90 too pessimistic.
- **Correct a stale comment** — the old `config.py` note claimed median ≈ 797 / p90 ≈ 2,293, which is 6×/4.6× above the freshly measured distribution. Replaced with a dated calibration block (May-12 density-threshold pattern).
- **Re-pin the one affected test** — `test_delivery_score_blends_realized_demand_when_provided` moves from `realized_demand=200.0` to `263.0` so `blend_weight=1.0 → ≈ 100.0` holds against the new reference.

## Commits

- `df421468` — Make realized-demand score reference configurable (knob + calibration script; default still 200.0)
- `5e653cf3` — Fix `percentile_cont`/`ROUND` type mismatch in the SQL script's section C
- `12dc5baa` — Calibrate the default to p75 = 263.0, dated calibration comment, test re-pin

## Validation

- No schema changes or migrations. No API contract changes.
- Curve sanity: `sqrt(263/263)*100 = 100.0`, `sqrt(133/263)*100 = 71.1` (median).
- `pytest tests/test_expansion_advisor_service.py -k delivery_score` could not be run in the sandboxed session (network policy blocks `pip`; `sqlalchemy` not preinstalled) — recommend a CI/local run before merge.

## Test plan

- [ ] CI runs `pytest tests/test_expansion_advisor_service.py -k delivery_score` green
- [ ] Confirm no other test fixtures assume a specific `_delivery_score` output at a specific demand level

https://claude.ai/code/session_01GE4tCaK6fa3PxVuti3etkF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GE4tCaK6fa3PxVuti3etkF)_