### PR TITLE
Fix demand potential inputs to read from featureSnapshot

### DIFF
--- a/frontend/src/features/expansion-advisor/scoreComponentMeta.ts
+++ b/frontend/src/features/expansion-advisor/scoreComponentMeta.ts
@@ -308,32 +308,36 @@ export const PER_COMPONENT_INPUTS: Record<string, InputDescriptor[]> = {
     },
   ],
 
+  // All four demand inputs read from feature_snapshot_json, which is always
+  // populated. The score_breakdown_json.market_viability_flag block is only
+  // written when a viability demotion leg fires, so non-demoted candidates
+  // (the common case) would otherwise strand these rows as em-dashes.
   demand_potential: [
     {
       key: "population_reach",
-      resolve: ({ scoreBreakdown }) => ({
-        value: asNumber(readNested(scoreBreakdown, "market_viability_flag", "population_reach")),
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "population_reach")),
         source: "population_grid",
       }),
     },
     {
       key: "realized_demand_30d",
-      resolve: ({ scoreBreakdown, contextSources }) => ({
-        value: asNumber(readNested(scoreBreakdown, "market_viability_flag", "realized_demand_30d")),
+      resolve: ({ featureSnapshot, contextSources }) => ({
+        value: asNumber(readNested(featureSnapshot, "realized_demand_30d")),
         source: overrideSource(contextSources, "delivery_source", "expansion_delivery_market"),
       }),
     },
     {
       key: "realized_demand_branches",
-      resolve: ({ scoreBreakdown, contextSources }) => ({
-        value: asNumber(readNested(scoreBreakdown, "market_viability_flag", "realized_demand_branches")),
+      resolve: ({ featureSnapshot, contextSources }) => ({
+        value: asNumber(readNested(featureSnapshot, "realized_demand_branches")),
         source: overrideSource(contextSources, "delivery_source", "expansion_delivery_market"),
       }),
     },
     {
       key: "radiance_growth_pct",
-      resolve: ({ scoreBreakdown }) => ({
-        value: asNumber(readNested(scoreBreakdown, "market_viability_flag", "radiance_growth_pct")),
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "radiance_growth", "value_yoy_pct")),
         source: "black_marble",
       }),
     },


### PR DESCRIPTION
## Summary

Corrects the data source for four demand potential score components in the Expansion Advisor. These inputs were incorrectly reading from `scoreBreakdown.market_viability_flag`, which is only populated when a viability demotion leg fires. This caused non-demoted candidates (the common case) to display em-dashes instead of actual demand values.

## Changes

- **population_reach**: Now reads from `featureSnapshot.population_reach` instead of `scoreBreakdown.market_viability_flag.population_reach`
- **realized_demand_30d**: Now reads from `featureSnapshot.realized_demand_30d` instead of `scoreBreakdown.market_viability_flag.realized_demand_30d`
- **realized_demand_branches**: Now reads from `featureSnapshot.realized_demand_branches` instead of `scoreBreakdown.market_viability_flag.realized_demand_branches`
- **radiance_growth_pct**: Now reads from `featureSnapshot.radiance_growth.value_yoy_pct` instead of `scoreBreakdown.market_viability_flag.radiance_growth_pct`

All four demand inputs are always populated in `feature_snapshot_json` (the source of truth), whereas `score_breakdown_json.market_viability_flag` is only written when a viability demotion leg fires.

## Implementation Details

- Added clarifying comment explaining why `featureSnapshot` is the correct source for these metrics
- Fixed the nested path for `radiance_growth_pct` to match the actual structure in the feature snapshot (`radiance_growth.value_yoy_pct`)
- No changes to resolver signatures or downstream logic; this is a pure data-source correction

https://claude.ai/code/session_01KANuAZF6kU2afJYsmoiAK8