### PR TITLE
Thread `lang` parameter through expansion advisor endpoints

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -7,7 +7,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from datetime import datetime
 import time as _prewarm_time
 
@@ -130,6 +130,7 @@ class ExpansionAdvisorSearchRequest(BaseModel):
     bbox: ExpansionAdvisorBBox | None = None
     limit: int = Field(15, ge=1, le=100)
     brand_profile: ExpansionBrandProfileInput | None = None
+    lang: str = "en"
 
 
 
@@ -468,6 +469,7 @@ class SavedSearchListResponse(StrictResponseModel):
 class CompareCandidatesRequest(BaseModel):
     search_id: str = Field(..., min_length=1, max_length=36)
     candidate_ids: list[str] = Field(..., min_length=2, max_length=6)
+    lang: str = "en"
 
 
 
@@ -479,6 +481,7 @@ class SavedSearchCreateRequest(BaseModel):
     selected_candidate_ids: list[str] = Field(default_factory=list)
     filters_json: dict[str, Any] = Field(default_factory=dict)
     ui_state_json: dict[str, Any] = Field(default_factory=dict)
+    lang: str = "en"
 
 
 class SavedSearchPatchRequest(BaseModel):
@@ -488,6 +491,7 @@ class SavedSearchPatchRequest(BaseModel):
     selected_candidate_ids: list[str] = Field(default_factory=list)
     filters_json: dict[str, Any] = Field(default_factory=dict)
     ui_state_json: dict[str, Any] = Field(default_factory=dict)
+    lang: str = "en"
 
 
 
@@ -768,6 +772,8 @@ def _prewarm_decision_memos(
             ctx = build_memo_context(
                 candidate=spec,
                 brief={"brand_profile": brand_profile or {}},
+                # Hardcoded "en" until heuristic strings have Arabic parity (PR #3).
+                # Threading lang here would emit memos with mixed-language sections.
                 lang="en",
             )
             memo_json = generate_structured_memo(ctx)
@@ -892,6 +898,8 @@ def create_expansion_search(
             status_code=400,
             detail="min_area_m2 must be less than or equal to max_area_m2",
         )
+    lang = req.lang if req.lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     # Clear cached lookups at the start of each new search so they pick up
     # any data changes since the last request.
     clear_expansion_caches()
@@ -928,7 +936,7 @@ def create_expansion_search(
         resolved_target_districts.append(resolved if resolved else td)
     req_target_districts = resolved_target_districts
 
-    request_json = req.model_dump()
+    request_json = req.model_dump(exclude={"lang"})
     bbox_json = req.bbox.model_dump() if req.bbox else None
     existing_branches_payload = [branch.model_dump() for branch in req.existing_branches]
     brand_profile_payload = req.brand_profile.model_dump() if req.brand_profile else None
@@ -1122,7 +1130,13 @@ def create_expansion_search(
 
 
 @router.get("/searches/{search_id}", response_model=ExpansionSearchDetailResponse)
-def get_expansion_search(search_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+def get_expansion_search(
+    search_id: str,
+    lang: str = Query("en"),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    lang = lang if lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     search = get_search(db, search_id)
     if not search:
         raise HTTPException(status_code=404, detail="Expansion search not found")
@@ -1130,7 +1144,13 @@ def get_expansion_search(search_id: str, db: Session = Depends(get_db)) -> dict[
 
 
 @router.get("/searches/{search_id}/candidates", response_model=ExpansionCandidatesListResponse)
-def get_expansion_search_candidates(search_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+def get_expansion_search_candidates(
+    search_id: str,
+    lang: str = Query("en"),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    lang = lang if lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     search = get_search(db, search_id)
     if not search:
         raise HTTPException(status_code=404, detail="Expansion search not found")
@@ -1138,7 +1158,13 @@ def get_expansion_search_candidates(search_id: str, db: Session = Depends(get_db
 
 
 @router.get("/searches/{search_id}/report", response_model=RecommendationReportResponse)
-def get_expansion_search_report(search_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+def get_expansion_search_report(
+    search_id: str,
+    lang: str = Query("en"),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    lang = lang if lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     import time as _time
     t0 = _time.monotonic()
 
@@ -1202,7 +1228,13 @@ def get_expansion_search_report(search_id: str, db: Session = Depends(get_db)) -
 
 
 @router.get("/candidates/{candidate_id}/memo", response_model=CandidateMemoResponse)
-def get_expansion_candidate_memo(candidate_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+def get_expansion_candidate_memo(
+    candidate_id: str,
+    lang: str = Query("en"),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    lang = lang if lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     memo = get_candidate_memo(db, candidate_id)
     if not memo:
         raise HTTPException(status_code=404, detail="Expansion candidate not found")
@@ -1213,6 +1245,8 @@ def compare_expansion_candidates(
     req: CompareCandidatesRequest,
     db: Session = Depends(get_db),
 ) -> dict[str, Any]:
+    lang = req.lang if req.lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     try:
         return compare_candidates(db, req.search_id, req.candidate_ids)
     except ValueError:
@@ -1221,6 +1255,8 @@ def compare_expansion_candidates(
 
 @router.post("/saved-searches", response_model=SavedSearchResponse)
 def create_expansion_saved_search(req: SavedSearchCreateRequest, db: Session = Depends(get_db)) -> dict[str, Any]:
+    lang = req.lang if req.lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     if not get_search(db, req.search_id):
         raise HTTPException(status_code=404, detail="Expansion search not found")
     try:
@@ -1245,8 +1281,11 @@ def create_expansion_saved_search(req: SavedSearchCreateRequest, db: Session = D
 def list_expansion_saved_searches(
     status: Literal["draft", "final"] | None = None,
     limit: int = 20,
+    lang: str = Query("en"),
     db: Session = Depends(get_db),
 ) -> dict[str, Any]:
+    lang = lang if lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     safe_limit = min(max(limit, 1), 100)
     try:
         return {"items": list_saved_searches(db, status=status, limit=safe_limit)}
@@ -1260,7 +1299,13 @@ def list_expansion_saved_searches(
 
 
 @router.get("/saved-searches/{saved_id}", response_model=SavedSearchResponse)
-def get_expansion_saved_search(saved_id: str, db: Session = Depends(get_db)) -> dict[str, Any]:
+def get_expansion_saved_search(
+    saved_id: str,
+    lang: str = Query("en"),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    lang = lang if lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     saved = get_saved_search(db, saved_id)
     if not saved:
         raise HTTPException(status_code=404, detail="Saved search not found")
@@ -1273,7 +1318,10 @@ def patch_expansion_saved_search(
     req: SavedSearchPatchRequest,
     db: Session = Depends(get_db),
 ) -> dict[str, Any]:
+    lang = req.lang if req.lang in ("en", "ar") else "en"
+    # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     payload = req.model_dump(exclude_unset=True)
+    payload.pop("lang", None)
     try:
         saved = update_saved_search(db, saved_id, payload)
         if not saved:

--- a/tests/test_expansion_advisor_api.py
+++ b/tests/test_expansion_advisor_api.py
@@ -1077,3 +1077,250 @@ def test_meta_demote_leg_fields_default_none_when_block_absent(monkeypatch):
     assert meta["demote_leg_drops"] is None
     assert meta["demote_leg_thresholds"] is None
     assert meta["demote_leg_enabled"] is None
+
+
+# ---------------------------------------------------------------------------
+# PR #1: `lang` parameter threading — plumbing only.
+#
+# Each updated endpoint must accept `lang` (body field for POST/PATCH, query
+# param for GET), default to "en", coerce any invalid value to "en" (always
+# 200, never 422), and produce output identical to omitting `lang` — because
+# this PR wires the parameter but does not consume it yet.
+# ---------------------------------------------------------------------------
+
+
+def _setup_searches_mocks(monkeypatch):
+    from app.api import expansion_advisor as expansion_api
+
+    monkeypatch.setattr(expansion_api, "persist_existing_branches", lambda *_a, **_k: None)
+    monkeypatch.setattr(expansion_api, "persist_brand_profile", lambda *_a, **_k: None)
+    # Constant candidate payload so `lang` is the only variable under test:
+    # the real run_expansion_search stamps the fresh per-call search_id onto
+    # each candidate, which would otherwise mask the comparison.
+    monkeypatch.setattr(
+        expansion_api,
+        "run_expansion_search",
+        lambda **kwargs: [
+            {
+                "id": "candidate-1",
+                "search_id": "search-fixed",
+                "parcel_id": "parcel-123",
+                "district": "Olaya",
+                "final_score": 80.0,
+            }
+        ],
+    )
+
+
+def _post_search(client, **body_overrides):
+    payload = {"brand_name": "Brand X", "category": "burger"}
+    payload.update(body_overrides)
+    return client.post("/v1/expansion-advisor/searches", json=payload)
+
+
+def test_post_searches_lang_accepted_defaulted_and_coerced(monkeypatch):
+    """POST /searches accepts lang en/ar, defaults to en when omitted, and
+    coerces invalid values to en (200, not 422). Response is identical to
+    omitting lang (search_id masked — it is a fresh UUID per call)."""
+    _setup_searches_mocks(monkeypatch)
+    client = _client_with_db(DummyDB())
+    try:
+        omitted = _post_search(client)
+        en = _post_search(client, lang="en")
+        ar = _post_search(client, lang="ar")
+        invalid = _post_search(client, lang="fr")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+
+    def _masked(resp):
+        body = resp.json()
+        body.pop("search_id", None)
+        return body
+
+    base = _masked(omitted)
+    assert _masked(en) == base
+    assert _masked(ar) == base
+    assert _masked(invalid) == base
+
+
+def test_post_searches_lang_not_persisted_in_request_json(monkeypatch):
+    """R1: the persisted expansion_search.request_json blob must NOT gain a
+    `lang` key — otherwise rows written before/after this PR drift."""
+    _setup_searches_mocks(monkeypatch)
+    db = DummyDB()
+    client = _client_with_db(db)
+    try:
+        response = _post_search(client, lang="ar")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200
+    insert_rows = [
+        params for sql, params in db.executed
+        if "INSERT INTO expansion_search" in sql
+    ]
+    assert insert_rows, "expected an INSERT INTO expansion_search"
+    request_json = insert_rows[0]["request_json"]
+    assert "lang" not in request_json
+    assert '"lang"' not in request_json
+
+
+def test_get_search_detail_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as expansion_api
+
+    monkeypatch.setattr(
+        expansion_api,
+        "get_search",
+        lambda _db, _search_id: {
+            "id": "search-1",
+            "created_at": "2026-01-01T00:00:00Z",
+            "brand_name": "Brand X",
+            "category": "burger",
+            "service_model": "qsr",
+            "target_districts": [],
+            "min_area_m2": 100,
+            "max_area_m2": 300,
+            "target_area_m2": 180,
+            "bbox": None,
+            "request_json": {},
+            "notes": {"version": "expansion_advisor_v7"},
+            "existing_branches": [],
+            "brand_profile": None,
+            "meta": {"version": "expansion_advisor_v7"},
+        },
+    )
+    client = _client_with_db(DummyDB())
+    try:
+        omitted = client.get("/v1/expansion-advisor/searches/search-1")
+        en = client.get("/v1/expansion-advisor/searches/search-1?lang=en")
+        ar = client.get("/v1/expansion-advisor/searches/search-1?lang=ar")
+        invalid = client.get("/v1/expansion-advisor/searches/search-1?lang=fr")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()
+
+
+def test_get_search_candidates_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as expansion_api
+
+    monkeypatch.setattr(expansion_api, "get_search", lambda _db, _search_id: {"id": "search-1"})
+    monkeypatch.setattr(
+        expansion_api,
+        "get_candidates",
+        lambda _db, _search_id: [
+            {"id": "candidate-1", "search_id": "search-1", "district": "Olaya"}
+        ],
+    )
+    client = _client_with_db(DummyDB())
+    try:
+        omitted = client.get("/v1/expansion-advisor/searches/search-1/candidates")
+        en = client.get("/v1/expansion-advisor/searches/search-1/candidates?lang=en")
+        ar = client.get("/v1/expansion-advisor/searches/search-1/candidates?lang=ar")
+        invalid = client.get("/v1/expansion-advisor/searches/search-1/candidates?lang=EN")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()
+
+
+def test_get_search_report_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as expansion_api
+
+    monkeypatch.setattr(
+        expansion_api,
+        "get_recommendation_report",
+        lambda _db, _search_id: {
+            "search_id": "search-1",
+            "meta": {"version": "expansion_advisor_v7"},
+            "recommendation": {
+                "best_candidate_id": "c1",
+                "why_best": "",
+                "main_risk": "",
+                "best_format": "",
+                "summary": "",
+                "report_summary": "",
+            },
+            "assumptions": {},
+            "top_candidates": [],
+        },
+    )
+    client = _client_with_db(DummyDB())
+    try:
+        omitted = client.get("/v1/expansion-advisor/searches/search-1/report")
+        en = client.get("/v1/expansion-advisor/searches/search-1/report?lang=en")
+        ar = client.get("/v1/expansion-advisor/searches/search-1/report?lang=ar")
+        invalid = client.get("/v1/expansion-advisor/searches/search-1/report?lang=")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()
+
+
+def test_compare_endpoint_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as expansion_api
+
+    monkeypatch.setattr(
+        expansion_api,
+        "compare_candidates",
+        lambda _db, _search_id, _candidate_ids: {
+            "items": [{"candidate_id": "c1"}, {"candidate_id": "c2"}],
+            "summary": {"best_overall_candidate_id": "c1"},
+        },
+    )
+    client = _client_with_db(DummyDB())
+
+    def _compare(**extra):
+        body = {"search_id": "search-1", "candidate_ids": ["c1", "c2"]}
+        body.update(extra)
+        return client.post("/v1/expansion-advisor/candidates/compare", json=body)
+
+    try:
+        omitted = _compare()
+        en = _compare(lang="en")
+        ar = _compare(lang="ar")
+        invalid = _compare(lang="fr")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()
+
+
+def test_candidate_memo_endpoint_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as expansion_api
+
+    monkeypatch.setattr(
+        expansion_api,
+        "get_candidate_memo",
+        lambda _db, _candidate_id: {
+            "candidate_id": "c1",
+            "search_id": "search-1",
+            "brand_profile": {},
+            "candidate": {},
+            "recommendation": {},
+            "market_research": {},
+        },
+    )
+    client = _client_with_db(DummyDB())
+    try:
+        omitted = client.get("/v1/expansion-advisor/candidates/c1/memo")
+        en = client.get("/v1/expansion-advisor/candidates/c1/memo?lang=en")
+        ar = client.get("/v1/expansion-advisor/candidates/c1/memo?lang=ar")
+        invalid = client.get("/v1/expansion-advisor/candidates/c1/memo?lang=fr")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()

--- a/tests/test_expansion_saved_search_api.py
+++ b/tests/test_expansion_saved_search_api.py
@@ -194,3 +194,136 @@ def test_list_saved_searches_generic_error_propagates(monkeypatch):
         app.dependency_overrides.pop(get_db, None)
 
     assert res.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# PR #1: `lang` parameter threading — plumbing only.
+#
+# The candidate-shaped saved-search endpoints (create / list / get / patch)
+# must accept `lang`, default to "en", coerce invalid values to "en" (200,
+# not 422), and behave identically to omitting it. DELETE is out of scope.
+# ---------------------------------------------------------------------------
+
+_SAVED_ROW = {
+    "id": "saved-1",
+    "search_id": "search-1",
+    "title": "Study A",
+    "status": "draft",
+    "selected_candidate_ids": [],
+    "filters_json": {},
+    "ui_state_json": {},
+    "description": None,
+    "search": None,
+    "candidates": [],
+}
+
+
+def test_create_saved_search_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as api
+
+    monkeypatch.setattr(api, "get_search", lambda *_: {"id": "search-1"})
+    monkeypatch.setattr(api, "create_saved_search", lambda *_a, **_k: dict(_SAVED_ROW))
+
+    client = _client(DummyDB())
+
+    def _create(**extra):
+        body = {"search_id": "search-1", "title": "Study A", "status": "draft"}
+        body.update(extra)
+        return client.post("/v1/expansion-advisor/saved-searches", json=body)
+
+    try:
+        omitted = _create()
+        en = _create(lang="en")
+        ar = _create(lang="ar")
+        invalid = _create(lang="fr")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()
+
+
+def test_list_saved_searches_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as api
+
+    monkeypatch.setattr(api, "list_saved_searches", lambda *_a, **_k: [dict(_SAVED_ROW)])
+
+    client = _client(DummyDB())
+    try:
+        omitted = client.get("/v1/expansion-advisor/saved-searches")
+        en = client.get("/v1/expansion-advisor/saved-searches?lang=en")
+        ar = client.get("/v1/expansion-advisor/saved-searches?lang=ar")
+        invalid = client.get("/v1/expansion-advisor/saved-searches?lang=fr")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()
+
+
+def test_get_saved_search_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as api
+
+    monkeypatch.setattr(api, "get_saved_search", lambda *_a, **_k: dict(_SAVED_ROW))
+
+    client = _client(DummyDB())
+    try:
+        omitted = client.get("/v1/expansion-advisor/saved-searches/saved-1")
+        en = client.get("/v1/expansion-advisor/saved-searches/saved-1?lang=en")
+        ar = client.get("/v1/expansion-advisor/saved-searches/saved-1?lang=ar")
+        invalid = client.get("/v1/expansion-advisor/saved-searches/saved-1?lang=fr")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()
+
+
+def test_patch_saved_search_accepts_lang(monkeypatch):
+    from app.api import expansion_advisor as api
+
+    monkeypatch.setattr(api, "update_saved_search", lambda *_a, **_k: dict(_SAVED_ROW))
+
+    client = _client(DummyDB())
+    try:
+        omitted = client.patch("/v1/expansion-advisor/saved-searches/saved-1", json={"title": "Renamed"})
+        en = client.patch("/v1/expansion-advisor/saved-searches/saved-1", json={"title": "Renamed", "lang": "en"})
+        ar = client.patch("/v1/expansion-advisor/saved-searches/saved-1", json={"title": "Renamed", "lang": "ar"})
+        invalid = client.patch("/v1/expansion-advisor/saved-searches/saved-1", json={"title": "Renamed", "lang": "fr"})
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    for resp in (omitted, en, ar, invalid):
+        assert resp.status_code == 200
+        assert resp.json() == omitted.json()
+
+
+def test_patch_saved_search_does_not_pass_lang_to_update(monkeypatch):
+    """R3: `lang` must be popped from the payload before it reaches
+    update_saved_search — it is not a persisted saved-search column."""
+    from app.api import expansion_advisor as api
+
+    captured = {}
+
+    def _spy_update(_db, _saved_id, payload):
+        captured["payload"] = payload
+        return dict(_SAVED_ROW)
+
+    monkeypatch.setattr(api, "update_saved_search", _spy_update)
+
+    client = _client(DummyDB())
+    try:
+        res = client.patch(
+            "/v1/expansion-advisor/saved-searches/saved-1",
+            json={"title": "Renamed", "lang": "ar"},
+        )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert res.status_code == 200
+    assert "payload" in captured
+    assert "lang" not in captured["payload"]
+    assert captured["payload"]["title"] == "Renamed"


### PR DESCRIPTION
## Summary

Add `lang` parameter plumbing to expansion advisor and saved-search endpoints. The parameter is accepted (body field for POST/PATCH, query param for GET), defaults to "en", and coerces invalid values to "en" (always 200, never 422). No output changes in this PR—the parameter is threaded but not yet consumed by business logic.

## Key Changes

- **Request models**: Added `lang: str = "en"` field to:
  - `ExpansionAdvisorSearchRequest` (POST /searches)
  - `CompareCandidatesRequest` (POST /candidates/compare)
  - `SavedSearchCreateRequest` (POST /saved-searches)
  - `SavedSearchPatchRequest` (PATCH /saved-searches/{id})

- **Query parameters**: Added `lang: str = Query("en")` to GET endpoints:
  - `GET /searches/{search_id}`
  - `GET /searches/{search_id}/candidates`
  - `GET /searches/{search_id}/report`
  - `GET /candidates/{candidate_id}/memo`
  - `GET /saved-searches`
  - `GET /saved-searches/{id}`

- **Validation**: All endpoints coerce invalid `lang` values to "en" with inline logic:
  ```python
  lang = lang if lang in ("en", "ar") else "en"
  ```

- **Data isolation**: 
  - `lang` is excluded from `request_json` when persisting expansion searches (prevents schema drift)
  - `lang` is popped from payload before calling `update_saved_search` (not a persisted column)

- **Tests**: Added comprehensive test coverage in both test files:
  - Verify parameter acceptance and coercion
  - Confirm responses are identical regardless of `lang` value
  - Validate that `lang` is not persisted where it shouldn't be

## Implementation Notes

- Parameter threading is complete but dormant—no English-output changes in this PR
- Hardcoded "en" remains in memo generation (comment notes this will change in PR #3 when Arabic parity is achieved)
- All endpoints return 200 for any `lang` value; invalid values silently coerce to "en"
- Follows existing repo patterns for request/response validation via Pydantic models

https://claude.ai/code/session_011bSDDWPh2keDPM8auxZ5Y5