### PR TITLE
PR #2b: Add locale-aware rendering for Expansion Advisor structured records

### DIFF
--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -1013,6 +1013,7 @@ def create_expansion_search(
             target_districts=req_target_districts,
             existing_branches=existing_branches_payload,
             brand_profile=brand_profile_payload,
+            lang=lang,
         )
         # Handle both dict (new format) and list (legacy/test mocks)
         if isinstance(_search_result, dict):
@@ -1154,7 +1155,7 @@ def get_expansion_search_candidates(
     search = get_search(db, search_id)
     if not search:
         raise HTTPException(status_code=404, detail="Expansion search not found")
-    return {"items": get_candidates(db, search_id), "meta": {"version": "expansion_advisor_v7"}}
+    return {"items": get_candidates(db, search_id, lang=lang), "meta": {"version": "expansion_advisor_v7"}}
 
 
 @router.get("/searches/{search_id}/report", response_model=RecommendationReportResponse)
@@ -1169,7 +1170,7 @@ def get_expansion_search_report(
     t0 = _time.monotonic()
 
     try:
-        report = get_recommendation_report(db, search_id)
+        report = get_recommendation_report(db, search_id, lang=lang)
     except (ValueError, KeyError, TypeError, AttributeError, ProgrammingError) as exc:
         # Recoverable data-shape / query errors: return sparse report with degraded flag.
         logger.warning(
@@ -1235,7 +1236,7 @@ def get_expansion_candidate_memo(
 ) -> dict[str, Any]:
     lang = lang if lang in ("en", "ar") else "en"
     # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
-    memo = get_candidate_memo(db, candidate_id)
+    memo = get_candidate_memo(db, candidate_id, lang=lang)
     if not memo:
         raise HTTPException(status_code=404, detail="Expansion candidate not found")
     return memo
@@ -1248,7 +1249,7 @@ def compare_expansion_candidates(
     lang = req.lang if req.lang in ("en", "ar") else "en"
     # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     try:
-        return compare_candidates(db, req.search_id, req.candidate_ids)
+        return compare_candidates(db, req.search_id, req.candidate_ids, lang=lang)
     except ValueError:
         raise HTTPException(status_code=404, detail="Expansion search/candidates not found")
 
@@ -1269,6 +1270,7 @@ def create_expansion_saved_search(req: SavedSearchCreateRequest, db: Session = D
             selected_candidate_ids=req.selected_candidate_ids,
             filters_json=req.filters_json,
             ui_state_json=req.ui_state_json,
+            lang=lang,
         )
         db.commit()
         return saved
@@ -1288,7 +1290,7 @@ def list_expansion_saved_searches(
     # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
     safe_limit = min(max(limit, 1), 100)
     try:
-        return {"items": list_saved_searches(db, status=status, limit=safe_limit)}
+        return {"items": list_saved_searches(db, status=status, limit=safe_limit, lang=lang)}
     except ProgrammingError:
         # Table may not exist if the migration hasn't been applied yet.
         # Return an empty list instead of a 500 so the UI shows a clean
@@ -1306,7 +1308,7 @@ def get_expansion_saved_search(
 ) -> dict[str, Any]:
     lang = lang if lang in ("en", "ar") else "en"
     # Threaded for PR #2/#3 consumers; no English-output changes in this PR.
-    saved = get_saved_search(db, saved_id)
+    saved = get_saved_search(db, saved_id, lang=lang)
     if not saved:
         raise HTTPException(status_code=404, detail="Saved search not found")
     return saved
@@ -1323,7 +1325,7 @@ def patch_expansion_saved_search(
     payload = req.model_dump(exclude_unset=True)
     payload.pop("lang", None)
     try:
-        saved = update_saved_search(db, saved_id, payload)
+        saved = update_saved_search(db, saved_id, payload, lang=lang)
         if not saved:
             db.rollback()
             raise HTTPException(status_code=404, detail="Saved search not found")

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -109,11 +109,11 @@ ADVISORY_ONLY_GATES: frozenset[str] = frozenset({
 })
 
 
-def _humanize_gate_list(values: list[Any] | None) -> list[str]:
+def _humanize_gate_list(values: list[Any] | None, lang: str = "en") -> list[str]:
     labels: list[str] = []
     seen: set[str] = set()
     for value in values or []:
-        label = _gate_key_to_label(str(value))
+        label = _gate_key_to_label(str(value), lang)
         if not label or label in seen:
             continue
         seen.add(label)
@@ -121,9 +121,16 @@ def _humanize_gate_list(values: list[Any] | None) -> list[str]:
     return labels
 
 
-def _gate_key_to_label(gate_key: str) -> str:
-    """Return a human-friendly label for an internal gate key."""
-    return _GATE_HUMAN_LABELS.get(gate_key, gate_key.replace("_pass", "").replace("_", " "))
+def _gate_key_to_label(gate_key: str, lang: str = "en") -> str:
+    """Return a human-friendly label for an internal gate key.
+
+    Delegates to the i18n module so the gate vocabulary has a single
+    source of truth. ``humanize_gate(key, "en")`` reproduces the legacy
+    ``_GATE_HUMAN_LABELS`` lookup + fallback byte-for-byte.
+    """
+    from app.services.expansion_advisor_i18n import humanize_gate
+
+    return humanize_gate(gate_key, lang)
 
 
 def _gate_verdict_label(overall_pass: Any) -> str:
@@ -1175,7 +1182,7 @@ def _normalize_gate_status(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, dict) else {}
 
 
-def _normalize_gate_reasons(value: Any) -> dict[str, Any]:
+def _normalize_gate_reasons(value: Any, lang: str = "en") -> dict[str, Any]:
     base = {
         "passed": [],
         "failed": [],
@@ -1184,9 +1191,9 @@ def _normalize_gate_reasons(value: Any) -> dict[str, Any]:
         "explanations": {},
     }
     if isinstance(value, dict):
-        base["passed"] = _humanize_gate_list(value.get("passed") or [])
-        base["failed"] = _humanize_gate_list(value.get("failed") or [])
-        base["unknown"] = _humanize_gate_list(value.get("unknown") or [])
+        base["passed"] = _humanize_gate_list(value.get("passed") or [], lang)
+        base["failed"] = _humanize_gate_list(value.get("failed") or [], lang)
+        base["unknown"] = _humanize_gate_list(value.get("unknown") or [], lang)
         base["thresholds"] = value.get("thresholds") or {}
         base["explanations"] = value.get("explanations") or {}
     return base
@@ -1218,23 +1225,110 @@ def _normalize_score_breakdown(value: Any, final_score: Any) -> dict[str, Any]:
     return raw
 
 
+# ── PR #2b structured-record read path ──────────────────────────────
+# These render the locale-invariant structured records (PR #2a) into
+# the requested language. They always fall back to the English
+# persisted column when the structured record is NULL (pre-PR-2a rows)
+# or fails to render — so a missing/malformed structured record can
+# never degrade the response below the English baseline (rule #4).
+_STRUCTURED_CANDIDATE_COLS: tuple[str, ...] = (
+    "top_positives_structured_json",
+    "top_risks_structured_json",
+    "decision_summary_structured_json",
+    "demand_thesis_structured_json",
+    "cost_thesis_structured_json",
+)
+
+
+def _render_structured_list(
+    structured: Any,
+    english_fallback: Any,
+    lang: str,
+) -> list[str]:
+    """Render a list of structured records; fall back to the English
+    persisted list on any failure (rule #4)."""
+    from app.services.expansion_advisor_i18n import render
+
+    if isinstance(structured, list) and structured:
+        out: list[str] = []
+        for rec in structured:
+            rendered = render(rec, lang) if isinstance(rec, dict) else ""
+            if not rendered:
+                # Single-record failure → fall back to the whole
+                # English list (safer than mixing rendered + raw).
+                return english_fallback or []
+            out.append(rendered)
+        return out
+    return english_fallback or []
+
+
+def _render_structured_one(
+    structured: Any,
+    english_fallback: Any,
+    lang: str,
+) -> str:
+    """Render a single structured record; fall back to the English
+    persisted string on any failure (rule #4)."""
+    from app.services.expansion_advisor_i18n import render
+
+    if isinstance(structured, dict):
+        rendered = render(structured, lang)
+        return rendered or (english_fallback or "")
+    return english_fallback or ""
+
+
 def _normalize_candidate_payload(
     candidate: dict[str, Any],
     district_lookup: dict[str, dict[str, str]] | None = None,
+    lang: str = "en",
 ) -> dict[str, Any]:
     payload = dict(candidate)
+
+    # R-6 idempotency guard. If this payload was normalized before at a
+    # different lang, the structured columns may already be dropped —
+    # the only safe path is to stay in en (the persisted English
+    # columns are still present and authoritative).
+    _prior_lang = payload.pop("_eai_normalized_lang", None)
+    if _prior_lang is not None and _prior_lang != lang:
+        lang = "en"
+
     payload["gate_status_json"] = _normalize_gate_status(payload.get("gate_status_json"))
-    payload["gate_reasons_json"] = _normalize_gate_reasons(payload.get("gate_reasons_json"))
+    payload["gate_reasons_json"] = _normalize_gate_reasons(payload.get("gate_reasons_json"), lang)
     payload["feature_snapshot_json"] = _normalize_feature_snapshot(payload.get("feature_snapshot_json"))
     payload["score_breakdown_json"] = _normalize_score_breakdown(payload.get("score_breakdown_json"), payload.get("final_score"))
-    payload["top_positives_json"] = payload.get("top_positives_json") or []
-    payload["top_risks_json"] = payload.get("top_risks_json") or []
+
+    if lang == "ar":
+        payload["top_positives_json"] = _render_structured_list(
+            candidate.get("top_positives_structured_json"),
+            payload.get("top_positives_json"), lang)
+        payload["top_risks_json"] = _render_structured_list(
+            candidate.get("top_risks_structured_json"),
+            payload.get("top_risks_json"), lang)
+        payload["decision_summary"] = _render_structured_one(
+            candidate.get("decision_summary_structured_json"),
+            payload.get("decision_summary"), lang)
+        payload["demand_thesis"] = _render_structured_one(
+            candidate.get("demand_thesis_structured_json"),
+            payload.get("demand_thesis"), lang)
+        payload["cost_thesis"] = _render_structured_one(
+            candidate.get("cost_thesis_structured_json"),
+            payload.get("cost_thesis"), lang)
+    else:
+        # byte-identical to HEAD
+        payload["top_positives_json"] = payload.get("top_positives_json") or []
+        payload["top_risks_json"] = payload.get("top_risks_json") or []
+        payload["decision_summary"] = payload.get("decision_summary") or ""
+        payload["demand_thesis"] = payload.get("demand_thesis") or ""
+        payload["cost_thesis"] = payload.get("cost_thesis") or ""
+
     payload["comparable_competitors_json"] = payload.get("comparable_competitors_json") or []
     payload["rank_position"] = payload.get("rank_position") or payload.get("compare_rank")
     payload["confidence_grade"] = payload.get("confidence_grade") or "D"
-    payload["decision_summary"] = payload.get("decision_summary") or ""
-    payload["demand_thesis"] = payload.get("demand_thesis") or ""
-    payload["cost_thesis"] = payload.get("cost_thesis") or ""
+
+    # The five structured columns are internal — never part of the API
+    # response shape. Drop them from the outgoing payload.
+    for _col in _STRUCTURED_CANDIDATE_COLS:
+        payload.pop(_col, None)
 
     # ── Commercial unit fields (pass through) ──
     payload["source_type"] = payload.get("source_type", "parcel")
@@ -1328,6 +1422,7 @@ def _normalize_saved_search_payload(
     *,
     search: dict[str, Any] | None = None,
     candidates: list[dict[str, Any]] | None = None,
+    lang: str = "en",
 ) -> dict[str, Any] | None:
     if saved is None:
         return None
@@ -1338,7 +1433,7 @@ def _normalize_saved_search_payload(
     payload["description"] = payload.get("description")
     payload["search"] = _normalize_search_payload(search if search is not None else payload.get("search"))
     normalized_candidates = candidates if candidates is not None else payload.get("candidates")
-    payload["candidates"] = [_normalize_candidate_payload(dict(item)) for item in (normalized_candidates or [])]  # district_lookup=None is OK: additive fields filled from raw district
+    payload["candidates"] = [_normalize_candidate_payload(dict(item), lang=lang) for item in (normalized_candidates or [])]  # district_lookup=None is OK: additive fields filled from raw district
 
     search_payload = payload.get("search") or {}
     if search_payload.get("brand_profile"):
@@ -6322,6 +6417,7 @@ def run_expansion_search(
     target_districts: list[str] | None = None,
     existing_branches: list[dict[str, Any]] | None = None,
     brand_profile: dict[str, Any] | None = None,
+    lang: str = "en",
 ) -> list[dict[str, Any]]:
     t_start = time.monotonic()
     bbox = bbox or {}
@@ -9562,7 +9658,7 @@ def run_expansion_search(
     result: list[dict[str, Any]] = []
     for candidate in persisted_candidates:
         try:
-            result.append(_normalize_candidate_payload(candidate, district_lookup))
+            result.append(_normalize_candidate_payload(candidate, district_lookup, lang=lang))
         except Exception:
             logger.warning(
                 "Failed to normalize candidate id=%s search_id=%s – skipping",
@@ -9722,7 +9818,7 @@ def get_search(db: Session, search_id: str) -> dict[str, Any] | None:
     return _normalize_search_payload(payload)
 
 
-def get_candidates(db: Session, search_id: str, district_lookup: dict[str, dict[str, str]] | None = None) -> list[dict[str, Any]]:
+def get_candidates(db: Session, search_id: str, district_lookup: dict[str, dict[str, str]] | None = None, lang: str = "en") -> list[dict[str, Any]]:
     if district_lookup is None:
         district_lookup = _cached_district_lookup(db)
     rows = db.execute(
@@ -9759,6 +9855,11 @@ def get_candidates(db: Session, search_id: str, district_lookup: dict[str, dict[
                 cost_thesis,
                 top_positives_json,
                 top_risks_json,
+                top_positives_structured_json,
+                top_risks_structured_json,
+                decision_summary_structured_json,
+                demand_thesis_structured_json,
+                cost_thesis_structured_json,
                 comparable_competitors_json,
                 cannibalization_score,
                 distance_to_nearest_branch_m,
@@ -9816,7 +9917,7 @@ def get_candidates(db: Session, search_id: str, district_lookup: dict[str, dict[
     # response — the frontend reads ``decision_memo_present`` to know
     # whether to enable the "View decision memo" affordance and fetches
     # the full memo via GET /candidates/{id}/memo on demand.
-    return [_normalize_candidate_payload(dict(row), district_lookup) for row in rows]
+    return [_normalize_candidate_payload(dict(row), district_lookup, lang=lang) for row in rows]
 
 
 
@@ -9831,6 +9932,7 @@ def create_saved_search(
     selected_candidate_ids: list[str] | None,
     filters_json: dict[str, Any] | None,
     ui_state_json: dict[str, Any] | None,
+    lang: str = "en",
 ) -> dict[str, Any]:
     saved_id = str(uuid.uuid4())
     row = db.execute(
@@ -9881,7 +9983,7 @@ def create_saved_search(
             "ui_state_json": json.dumps(ui_state_json, ensure_ascii=False) if ui_state_json is not None else None,
         },
     ).mappings().first()
-    return _normalize_saved_search_payload(dict(row) if row else {})
+    return _normalize_saved_search_payload(dict(row) if row else {}, lang=lang)
 
 
 def list_saved_searches(
@@ -9889,6 +9991,7 @@ def list_saved_searches(
     *,
     status: str | None,
     limit: int,
+    lang: str = "en",
 ) -> list[dict[str, Any]]:
     rows = db.execute(
         text(
@@ -9912,10 +10015,10 @@ def list_saved_searches(
         ),
         {"status": status, "limit": limit},
     ).mappings().all()
-    return [_normalize_saved_search_payload(dict(row)) for row in rows]
+    return [_normalize_saved_search_payload(dict(row), lang=lang) for row in rows]
 
 
-def get_saved_search(db: Session, saved_id: str) -> dict[str, Any] | None:
+def get_saved_search(db: Session, saved_id: str, lang: str = "en") -> dict[str, Any] | None:
     row = db.execute(
         text(
             """
@@ -9941,14 +10044,15 @@ def get_saved_search(db: Session, saved_id: str) -> dict[str, Any] | None:
 
     saved = dict(row)
     search = get_search(db, str(saved["search_id"]))
-    candidates = get_candidates(db, str(saved["search_id"]))
-    return _normalize_saved_search_payload(saved, search=search, candidates=candidates)
+    candidates = get_candidates(db, str(saved["search_id"]), lang=lang)
+    return _normalize_saved_search_payload(saved, search=search, candidates=candidates, lang=lang)
 
 
 def update_saved_search(
     db: Session,
     saved_id: str,
     payload: dict[str, Any],
+    lang: str = "en",
 ) -> dict[str, Any] | None:
     if not payload:
         row = db.execute(
@@ -10009,7 +10113,7 @@ def update_saved_search(
         ),
         params,
     ).mappings().first()
-    return _normalize_saved_search_payload(dict(row)) if row else None
+    return _normalize_saved_search_payload(dict(row), lang=lang) if row else None
 
 
 _COMPARE_SUMMARY_KEYS = [
@@ -10044,7 +10148,7 @@ def delete_saved_search(db: Session, saved_id: str) -> bool:
         {"saved_id": saved_id},
     ).first()
     return bool(row)
-def compare_candidates(db: Session, search_id: str, candidate_ids: list[str]) -> dict[str, Any]:
+def compare_candidates(db: Session, search_id: str, candidate_ids: list[str], lang: str = "en") -> dict[str, Any]:
     search = db.execute(text("SELECT id FROM expansion_search WHERE id = :search_id"), {"search_id": search_id}).first()
     if not search:
         raise ValueError("not_found")
@@ -10211,7 +10315,7 @@ def compare_candidates(db: Session, search_id: str, candidate_ids: list[str]) ->
             "unit_street_width_m": row.get("unit_street_width_m"),
             "unit_neighborhood": row.get("unit_neighborhood"),
             "unit_listing_type": row.get("unit_listing_type"),
-        }, district_lookup)
+        }, district_lookup, lang=lang)
         item["pros"] = pros
         item["cons"] = cons
         items.append(item)
@@ -10268,7 +10372,7 @@ def compare_candidates(db: Session, search_id: str, candidate_ids: list[str]) ->
     return {"items": items, "summary": summary}
 
 
-def get_candidate_memo(db: Session, candidate_id: str) -> dict[str, Any] | None:
+def get_candidate_memo(db: Session, candidate_id: str, lang: str = "en") -> dict[str, Any] | None:
     t_start = time.monotonic()
     row = db.execute(
         text(
@@ -10308,6 +10412,11 @@ def get_candidate_memo(db: Session, candidate_id: str) -> dict[str, Any] | None:
                 c.cost_thesis,
                 c.top_positives_json,
                 c.top_risks_json,
+                c.top_positives_structured_json,
+                c.top_risks_structured_json,
+                c.decision_summary_structured_json,
+                c.demand_thesis_structured_json,
+                c.cost_thesis_structured_json,
                 c.comparable_competitors_json,
                 c.cannibalization_score,
                 c.distance_to_nearest_branch_m,
@@ -10355,7 +10464,7 @@ def get_candidate_memo(db: Session, candidate_id: str) -> dict[str, Any] | None:
         return None
 
     district_lookup = _cached_district_lookup(db)
-    candidate = _normalize_candidate_payload(dict(row), district_lookup)
+    candidate = _normalize_candidate_payload(dict(row), district_lookup, lang=lang)
     brand_profile = get_brand_profile(db, str(candidate.get("search_id"))) or {}
     strengths = candidate.get("key_strengths_json") or []
     risks = candidate.get("key_risks_json") or []
@@ -10496,7 +10605,7 @@ def get_candidate_memo(db: Session, candidate_id: str) -> dict[str, Any] | None:
     }
 
 
-def get_recommendation_report(db: Session, search_id: str) -> dict[str, Any] | None:
+def get_recommendation_report(db: Session, search_id: str, lang: str = "en") -> dict[str, Any] | None:
     t_start = time.monotonic()
     search = get_search(db, search_id)
     if not search:
@@ -10504,8 +10613,11 @@ def get_recommendation_report(db: Session, search_id: str) -> dict[str, Any] | N
     district_lookup = _cached_district_lookup(db)
     t_lookup = time.monotonic()
     try:
-        raw_candidates = get_candidates(db, search_id, district_lookup=district_lookup)
+        raw_candidates = get_candidates(db, search_id, district_lookup=district_lookup, lang=lang)
     except TypeError:
+        # Legacy-compat fallback for a 2-arg get_candidates (e.g. a test
+        # double). lang cannot be threaded through such a callable —
+        # degrade to the English read path.
         raw_candidates = get_candidates(db, search_id)
     t_candidates = time.monotonic()
     # Candidates are already normalized by get_candidates — skip redundant re-normalization

--- a/app/services/expansion_advisor_i18n.py
+++ b/app/services/expansion_advisor_i18n.py
@@ -1,0 +1,446 @@
+"""Locale-invariant rendering for Expansion Advisor structured records.
+
+PR #2a persists structured records of the form {"id": ..., "params": ...}
+in five JSONB columns on expansion_candidate. PR #2b renders them
+into the requested language at read time. The en-side templates are
+byte-identical to the producer's English f-strings/append literals
+at HEAD; the ar-side templates are Arabic anchor translations
+following these formatting conventions:
+
+  - Latin digits throughout (78.4, not ٧٨٫٤)
+  - English units inline: "SAR", "m²", "km"
+  - Parenthetical English for jargon without a stable Arabic
+    equivalent: "providers", "whitespace"
+  - Em-dash (U+2014) preserved in both langs
+  - "gate" is translated as "معيار" (criterion) — the domain term
+  - "gate failed" vs "gate could not be verified" use two distinct
+    Arabic frames, not one
+
+When a requested-lang template is missing, render() falls back to
+"en" (degraded, never raises). When a structured record itself is
+missing/malformed, the caller falls back to the English persisted
+column (rule #4 spirit).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+TEMPLATES: dict[str, dict[str, str]] = {
+    "pos.demand_strong": {
+        "en": "Demand potential is strong for this district.",
+        "ar": "إمكانية الطلب قوية في هذا الحي.",
+    },
+    "pos.bnm_whitespace_favorable": {
+        "en": "Brick-and-mortar competitor whitespace remains favorable.",
+        "ar": "فجوة المنافسين في المتاجر الفعلية لا تزال مواتية.",
+    },
+    "pos.inferred_whitespace": {
+        "en": "Inferred competitor whitespace opportunity — low observed delivery activity nearby.",
+        "ar": "فرصة فجوة سوقية مُستنتَجة — نشاط توصيل ملاحَظ منخفض في المحيط القريب.",
+    },
+    "pos.brand_fit_aligned": {
+        "en": "Brand-fit profile aligns with site characteristics.",
+        "ar": "ملاءمة العلامة التجارية تتوافق مع خصائص الموقع.",
+    },
+    "pos.economics_meets_band": {
+        "en": "Economics profile meets target screening band.",
+        "ar": "الجدوى الاقتصادية ضمن النطاق المستهدف.",
+    },
+    "pos.all_gates_pass": {
+        "en": "All required gates pass under available context.",
+        "ar": "جميع المعايير المطلوبة مستوفاة وفق البيانات المتاحة.",
+    },
+    "pos.area_well_aligned": {
+        "en": "Site area is well-aligned with target range.",
+        "ar": "مساحة الموقع متوافقة جيداً مع النطاق المستهدف.",
+    },
+    "pos.strong_economics": {
+        "en": "Strong economics with favorable rent-to-revenue ratio.",
+        "ar": "جدوى اقتصادية قوية مع نسبة إيجار إلى إيرادات مواتية.",
+    },
+    "pos.well_separated_branch": {
+        "en": "Well-separated from nearest branch ({nearest_km:.1f} km) — low overlap.",
+        "ar": "بعيد بدرجة كافية عن أقرب فرع ({nearest_km:.1f} km) — تداخل منخفض.",
+    },
+    "pos.low_competitor_density": {
+        "en": "Low same-category competitor density — potential first-mover advantage.",
+        "ar": "كثافة منخفضة لمنافسي نفس الفئة — ميزة محتملة للحركة المبكرة.",
+    },
+    "pos.new_in_top_market": {
+        "en": "Newly listed in a top-tier market.",
+        "ar": "إعلان جديد في سوق من الفئة الأعلى.",
+    },
+    "pos.refreshed_in_top_market": {
+        "en": "Recently refreshed listing in a top-tier market.",
+        "ar": "إعلان مُحدَّث مؤخراً في سوق من الفئة الأعلى.",
+    },
+    "pos.newly_listed": {
+        "en": "Newly listed within the last week.",
+        "ar": "إعلان جديد خلال الأسبوع الماضي.",
+    },
+    "pos.refreshed_listing": {
+        "en": "Listing refreshed by the owner within the last week.",
+        "ar": "إعلان حدَّثه المالك خلال الأسبوع الماضي.",
+    },
+    "pos.top_tier_market": {
+        "en": "District ranks in the top tier for recent listing activity.",
+        "ar": "الحي ضمن الفئة الأعلى من حيث نشاط الإعلانات الأخيرة.",
+    },
+    "risk.cannibalization_elevated": {
+        "en": "Cannibalization risk is elevated versus branch network.",
+        "ar": "مخاطر التهام المبيعات (cannibalization) مرتفعة مقابل شبكة الفروع.",
+    },
+    "risk.economics_below_threshold": {
+        "en": "Economics score is below preferred threshold.",
+        "ar": "درجة الجدوى الاقتصادية دون الحد المفضَّل.",
+    },
+    "risk.delivery_competition_high": {
+        "en": "Delivery competition intensity is high.",
+        "ar": "حدة منافسة التوصيل مرتفعة.",
+    },
+    "risk.delivery_whitespace_limited": {
+        "en": "Delivery platform competition is dense — limited delivery-channel whitespace.",
+        "ar": "منافسة منصات التوصيل كثيفة — فجوة سوقية محدودة في قناة التوصيل.",
+    },
+    "risk.gate_failed": {
+        "en": "{_gate_label_capitalized} gate failed.",
+        "ar": "معيار {_gate_label_ar} لم يتحقق.",
+    },
+    "risk.gate_unknown": {
+        "en": "{_gate_label_capitalized} could not be verified from current data.",
+        "ar": "تعذّر التحقق من معيار {_gate_label_ar} من البيانات الحالية.",
+    },
+    "risk.delivery_district_estimates": {  # K7 defensive — unreachable at HEAD
+        "en": "Delivery data is based on district-level estimates — no listings observed within 1.2 km.",
+        "ar": "بيانات التوصيل مبنية على تقديرات على مستوى الحي — لا توجد إعلانات ملاحَظة ضمن 1.2 km.",
+    },
+    "risk.delivery_inferred": {
+        "en": "Delivery market data is inferred — no observed listings near site.",
+        "ar": "بيانات سوق التوصيل مُستنتَجة — لا توجد إعلانات ملاحَظة قرب الموقع.",
+    },
+    "risk.area_near_min": {
+        "en": "Area ({area_m2:.0f} m²) is near the minimum of the requested range.",
+        "ar": "المساحة ({area_m2:.0f} m²) قريبة من الحد الأدنى للنطاق المطلوب.",
+    },
+    "risk.area_near_max": {
+        "en": "Area ({area_m2:.0f} m²) is near the maximum — may increase fit-out cost.",
+        "ar": "المساحة ({area_m2:.0f} m²) قريبة من الحد الأعلى — قد ترفع تكلفة التجهيز.",
+    },
+    "risk.economics_marginal": {
+        "en": "Economics are marginal — rent burden may be high relative to revenue potential.",
+        "ar": "الجدوى الاقتصادية حدّية — عبء الإيجار قد يكون مرتفعاً مقارنةً بالإيرادات المحتملة.",
+    },
+    "risk.nearest_branch_close": {
+        "en": "Nearest own branch is only {nearest_km:.1f} km away — high overlap risk.",
+        "ar": "أقرب فرع للعلامة على بُعد {nearest_km:.1f} km فقط — مخاطر تداخل مرتفعة.",
+    },
+    "risk.high_competitor_density": {
+        "en": "High competitor density ({count} nearby) — market may be saturated.",
+        "ar": "كثافة المنافسين مرتفعة ({count} في المحيط القريب) — السوق قد يكون مشبعاً.",
+    },
+    "demand_thesis": {
+        "en": ("Demand is {_demand_label} (score {demand_score:.1f}) with "
+               "population reach around {population_reach:.0f}; provider "
+               "activity is {_provider_label}, whitespace is "
+               "{_whitespace_label}, and delivery competition is "
+               "{_competition_label}."),
+        "ar": ("الطلب {_demand_label} (الدرجة {demand_score:.1f}) مع "
+               "وصول سكاني يقارب {population_reach:.0f}؛ نشاط المنصات "
+               "(providers) {_provider_label}، الفجوة السوقية (whitespace) "
+               "{_whitespace_label}، ومنافسة التوصيل {_competition_label}."),
+    },
+    "cost_thesis": {
+        "en": ("Estimated rent is {estimated_rent_sar_m2_year:.0f} "
+               "SAR/m²/year (~{estimated_annual_rent_sar:,.0f} SAR "
+               "annually), fit-out is "
+               "~{estimated_fitout_cost_sar:,.0f} SAR."),
+        "ar": ("الإيجار التقديري {estimated_rent_sar_m2_year:.0f} "
+               "SAR/m²/سنة (~{estimated_annual_rent_sar:,.0f} SAR "
+               "سنوياً)، وتكلفة التجهيز "
+               "~{estimated_fitout_cost_sar:,.0f} SAR."),
+    },
+    # decision_summary is composed. The dict uses non-standard keys
+    # (en_main, en_suffix_*, ar_main, ar_suffix_*); render() handles
+    # this in a dedicated branch.
+    "decision_summary": {
+        "en_main": ("This {_area_label} candidate in {_district_label} "
+                    "scores {final_score:.1f}/100 overall with an "
+                    "economics score of {economics_score:.1f}/100. "
+                    "It is a practical first-pass option for {_use_case}."),
+        "en_suffix_from_key_risks": " Biggest commercial risk: {_risk_text_en}.",
+        "en_suffix_tight_economics": (
+            " Biggest commercial risk: Rent economics are tight and "
+            "should be validated with actual lease terms."),
+        "en_suffix_execution": (
+            " Biggest commercial risk: Execution risk should be "
+            "managed during leasing and design."),
+        "ar_main": ("هذا الموقع المرشّح {_area_label} في {_district_label} "
+                    "يحصل على {final_score:.1f}/100 إجمالاً وعلى "
+                    "{economics_score:.1f}/100 في الجدوى الاقتصادية. "
+                    "خيار عملي كمرحلة أولى لـ {_use_case}."),
+        "ar_suffix_from_key_risks": " أبرز مخاطر تجارية: {_risk_text_en}.",
+        "ar_suffix_tight_economics": (
+            " أبرز مخاطر تجارية: الإيجار حدّي وينبغي التحقق منه عبر "
+            "شروط العقد الفعلية."),
+        "ar_suffix_execution": (
+            " أبرز مخاطر تجارية: مخاطر التنفيذ تستلزم الإدارة خلال "
+            "مرحلتَي التأجير والتصميم."),
+    },
+}
+
+
+DEMAND_LABELS: dict[str, dict[str, str]] = {
+    "en": {"strong": "strong", "moderate": "moderate", "limited": "limited"},
+    "ar": {"strong": "قوي", "moderate": "متوسط", "limited": "محدود"},
+}
+
+PROVIDER_LABELS: dict[str, dict[str, str]] = {
+    "en": {
+        "dense": "dense",
+        "steady": "steady",
+        "thin": "thin",
+        "district_estimate": "district-level estimate",
+        "limited_district": "limited district data",
+        "not_observed": "not observed (inferred)",
+    },
+    "ar": {
+        "dense": "كثيف",
+        "steady": "مستقر",
+        "thin": "ضعيف",
+        "district_estimate": "تقدير على مستوى الحي",
+        "limited_district": "بيانات حي محدودة",
+        "not_observed": "غير ملاحَظ (مُستنتَج)",
+    },
+}
+
+WHITESPACE_LABELS: dict[str, dict[str, str]] = {
+    "en": {
+        "attractive": "attractive",
+        "balanced": "balanced",
+        "tight": "tight",
+        "district_inferred": "district-inferred",
+        "tight_district": "potentially tight (district-level)",
+        "inferred_opportunity": "inferred whitespace opportunity",
+    },
+    "ar": {
+        "attractive": "جذابة",
+        "balanced": "متوازنة",
+        "tight": "ضيقة",
+        "district_inferred": "مُستنتَجة على مستوى الحي",
+        "tight_district": "ضيقة محتملاً (على مستوى الحي)",
+        "inferred_opportunity": "فرصة فجوة سوقية مُستنتَجة",
+    },
+}
+
+COMPETITION_LABELS: dict[str, dict[str, str]] = {
+    "en": {
+        "intense": "intense",
+        "manageable": "manageable",
+        "district_estimate": "district-level estimate",
+        "not_directly_observed": "not directly observed",
+    },
+    "ar": {
+        "intense": "حادة",
+        "manageable": "في حدود يمكن إدارتها",
+        "district_estimate": "تقدير على مستوى الحي",
+        "not_directly_observed": "غير ملاحَظة مباشرةً",
+    },
+}
+
+AREA_LABELS: dict[str, dict[str, str]] = {
+    "en": {"compact": "compact", "standard": "standard"},
+    "ar": {"compact": "المتوسط الحجم", "standard": "القياسي"},
+}
+
+USE_CASE_LABELS: dict[str, dict[str, str]] = {
+    "en": {
+        "flagship_dine_in": "flagship dine-in",
+        "neighborhood_dine_in": "neighborhood dine-in",
+        "delivery_led_branch": "delivery-led branch",
+        "compact_cafe": "compact cafe",
+        "destination_cafe": "destination cafe",
+        "neighborhood_qsr": "neighborhood qsr",
+    },
+    "ar": {
+        "flagship_dine_in": "فرع رئيسي للأكل في الموقع",
+        "neighborhood_dine_in": "فرع حي للأكل في الموقع",
+        "delivery_led_branch": "فرع موجَّه للتوصيل",
+        "compact_cafe": "مقهى مدمج",
+        "destination_cafe": "مقهى وجهة",
+        "neighborhood_qsr": "مطعم وجبات سريعة في الحي",
+    },
+}
+
+# Default district label when params.district_label is None.
+_DISTRICT_DEFAULT: dict[str, str] = {
+    "en": "the target district",
+    "ar": "الحي المستهدف",
+}
+
+
+GATE_LABELS: dict[str, dict[str, str]] = {
+    "en": {
+        "zoning_fit_pass": "zoning fit",
+        "area_fit_pass": "area fit",
+        "frontage_access_pass": "frontage/access",
+        "parking_pass": "parking",
+        "district_pass": "district",
+        "cannibalization_pass": "cannibalization",
+        "delivery_market_pass": "delivery market",
+        "economics_pass": "economics",
+        "radiance_growth_pass": "Market growth signal",
+        "population_floor_pass": "Population reach floor",
+        "commercial_floor_pass": "Commercial activity floor",
+        "construction_proximity_pass": "Construction proximity floor",
+    },
+    "ar": {
+        "zoning_fit_pass": "ملاءمة التنطيق",
+        "area_fit_pass": "ملاءمة المساحة",
+        "frontage_access_pass": "الواجهة/الوصول",
+        "parking_pass": "مواقف السيارات",
+        "district_pass": "الحي",
+        "cannibalization_pass": "التهام المبيعات",
+        "delivery_market_pass": "سوق التوصيل",
+        "economics_pass": "الجدوى الاقتصادية",
+        "radiance_growth_pass": "إشارة نمو السوق",
+        "population_floor_pass": "الحد الأدنى للوصول السكاني",
+        "commercial_floor_pass": "الحد الأدنى للنشاط التجاري",
+        "construction_proximity_pass": "الحد الأدنى للقرب الإنشائي",
+    },
+}
+
+
+def humanize_gate(gate_key: str, lang: str) -> str:
+    """Translate a raw gate key (e.g. 'parking_pass') to the lang's
+    label. Falls back to the en table, then to the legacy derivation
+    ``key.replace("_pass","").replace("_"," ")`` for unknown keys.
+
+    ``humanize_gate(key, "en")`` reproduces ``_gate_key_to_label(key)``
+    at HEAD byte-for-byte.
+    """
+    table = GATE_LABELS.get(lang) or GATE_LABELS["en"]
+    if gate_key in table:
+        return table[gate_key]
+    if gate_key in GATE_LABELS["en"]:
+        return GATE_LABELS["en"][gate_key]
+    return gate_key.replace("_pass", "").replace("_", " ")
+
+
+def _token(table: dict[str, dict[str, str]], lang: str, key: str) -> str:
+    """Resolve a token through a label table with en fallback."""
+    sub = table.get(lang) or table["en"]
+    if key in sub:
+        return sub[key]
+    if key in table["en"]:
+        return table["en"][key]
+    return key  # unknown token — pass through
+
+
+def _render_decision_summary(
+    resolved: dict[str, Any],
+    tmpl_set: dict[str, str],
+    lang: str,
+) -> str:
+    """Compose main + suffix for decision_summary."""
+    main_key = "ar_main" if lang == "ar" else "en_main"
+    main_tmpl = tmpl_set.get(main_key) or tmpl_set.get("en_main")
+    if not main_tmpl:
+        return ""
+    summary = main_tmpl.format(**resolved)
+
+    risk_kind = resolved.get("risk_kind")
+    if risk_kind == "from_key_risks":
+        suffix_key = f"{lang}_suffix_from_key_risks" if lang == "ar" else "en_suffix_from_key_risks"
+    elif risk_kind == "tight_economics":
+        suffix_key = f"{lang}_suffix_tight_economics" if lang == "ar" else "en_suffix_tight_economics"
+    elif risk_kind == "execution":
+        suffix_key = f"{lang}_suffix_execution" if lang == "ar" else "en_suffix_execution"
+    else:
+        return summary
+
+    suffix_tmpl = tmpl_set.get(suffix_key)
+    if lang == "ar" and not suffix_tmpl:
+        # ar fallback to en
+        suffix_tmpl = tmpl_set.get(suffix_key.replace("ar_", "en_"))
+    if not suffix_tmpl:
+        return summary
+    try:
+        return summary + suffix_tmpl.format(**resolved)
+    except (KeyError, IndexError, ValueError, TypeError):
+        return summary
+
+
+def render(record: dict[str, Any], lang: str) -> str:
+    """Render a structured record to a string in the requested lang.
+
+    Returns "" on any error; the caller falls back to the English
+    persisted column.
+    """
+    if not isinstance(record, dict):
+        return ""
+    try:
+        tid = record["id"]
+        params = dict(record.get("params") or {})
+    except (TypeError, KeyError):
+        return ""
+
+    resolved = dict(params)
+
+    # Token resolutions — populate the leading-_ variants the
+    # templates reference.
+    if "demand_label" in params:
+        resolved["_demand_label"] = _token(DEMAND_LABELS, lang, params["demand_label"])
+    if "provider_label" in params:
+        resolved["_provider_label"] = _token(PROVIDER_LABELS, lang, params["provider_label"])
+    if "whitespace_label" in params:
+        resolved["_whitespace_label"] = _token(WHITESPACE_LABELS, lang, params["whitespace_label"])
+    if "competition_label" in params:
+        resolved["_competition_label"] = _token(COMPETITION_LABELS, lang, params["competition_label"])
+    if "area_label" in params:
+        resolved["_area_label"] = _token(AREA_LABELS, lang, params["area_label"])
+    if "use_case" in params:
+        resolved["_use_case"] = _token(USE_CASE_LABELS, lang, params["use_case"])
+
+    # district_label: raw string passes through; None → default.
+    if "district_label" in params:
+        dl = params["district_label"]
+        if dl is None:
+            resolved["_district_label"] = _DISTRICT_DEFAULT.get(lang) or _DISTRICT_DEFAULT["en"]
+        else:
+            resolved["_district_label"] = dl
+
+    # gate_key: humanize + (en only) .capitalize() to mirror the
+    # producer at expansion_advisor.py (risk.gate_failed/gate_unknown).
+    if "gate_key" in params:
+        en_label = humanize_gate(params["gate_key"], "en")
+        ar_label = humanize_gate(params["gate_key"], lang)
+        resolved["_gate_label_capitalized"] = en_label.capitalize()
+        resolved["_gate_label_ar"] = ar_label
+
+    # risk_text_en: mirror the producer's normalization for the
+    # decision_summary risk clause — ``strip().rstrip(".").strip()`` then
+    # first-letter-upper (the template re-appends the period). For ar,
+    # the English text is reused unchanged — degraded fallback
+    # documented as PR #3 work.
+    if "risk_text_en" in params:
+        rt = params["risk_text_en"]
+        if rt and isinstance(rt, str):
+            rs = rt.strip().rstrip(".").strip()
+            if rs and not rs[0].isupper():
+                rs = rs[0].upper() + rs[1:]
+            resolved["_risk_text_en"] = rs
+        else:
+            resolved["_risk_text_en"] = rt or ""
+
+    try:
+        tmpl_set = TEMPLATES.get(tid) or {}
+        if tid == "decision_summary":
+            return _render_decision_summary(resolved, tmpl_set, lang)
+        tmpl = tmpl_set.get(lang) or tmpl_set.get("en")
+        if not tmpl:
+            return ""
+        return tmpl.format(**resolved)
+    except (KeyError, IndexError, ValueError, TypeError):
+        return ""

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -18,18 +18,15 @@ from typing import Any, Literal
 
 from app.core.config import settings
 
-def _hard_fail_gate_labels() -> frozenset[str]:
-    """Humanized labels of the live hard-fail gate set.
+def _hard_fail_gate_keys() -> frozenset[str]:
+    """Raw (locale-invariant) hard-fail gate keys.
 
-    Derived lazily from ``expansion_advisor.HARD_FAIL_GATES`` so env-driven
-    optional hard-fail gates (population_floor_pass, commercial_floor_pass,
+    Returns the live ``expansion_advisor.HARD_FAIL_GATES`` set directly so
+    the blocking/advisory split compares on raw keys, independent of the
+    memo's display language. Env-driven optional hard-fail gates
+    (population_floor_pass, commercial_floor_pass,
     construction_proximity_pass) are picked up automatically and stay in
     sync with the canonical source of truth.
-
-    Labels (not raw keys) because the gate dicts the comparison runs
-    against — produced by ``_normalize_gate_reasons`` → ``_humanize_gate_list``
-    in expansion_advisor — only carry the humanized name by the time they
-    reach this module.
 
     Lazy-imported to preserve this module's import-graph footprint
     (expansion_advisor pulls in SQLAlchemy/PostGIS). Every real call path
@@ -37,11 +34,9 @@ def _hard_fail_gate_labels() -> frozenset[str]:
     which imports expansion_advisor before importing this module — so
     HARD_FAIL_GATES is reliably populated by the time this helper runs.
     """
-    from app.services.expansion_advisor import (
-        HARD_FAIL_GATES,
-        _gate_key_to_label,
-    )
-    return frozenset(_gate_key_to_label(g) for g in HARD_FAIL_GATES)
+    from app.services.expansion_advisor import HARD_FAIL_GATES
+
+    return HARD_FAIL_GATES
 
 logger = logging.getLogger(__name__)
 
@@ -700,23 +695,56 @@ def _coerce_gate_verdicts(raw: Any) -> list[dict]:
 def _build_gate_buckets(
     gate_reasons: dict[str, Any] | None,
     gate_verdicts: list[dict],
+    gate_status: dict[str, Any] | None = None,
+    lang: str = "en",
 ) -> dict[str, list[dict]]:
     """Return ``{"passed": [...], "failed": [...], "unknown": [...]}`` of
-    ``{name, explanation}`` entries.
+    ``{key, name, explanation}`` entries.
 
-    Prefers ``gate_reasons`` (``passed/failed/unknown`` arrays + ``explanations``)
-    as the authoritative source, because the bucket arrays carry the right
-    tri-state semantics. Falls back to ``gate_verdicts`` when
-    ``gate_reasons`` is unavailable or empty.
+    ``key`` is the raw, locale-invariant gate key (e.g. ``parking_pass``)
+    resolved from ``gate_status`` — the flat raw-keyed ``gate_status_json``
+    map — or ``None`` when it cannot be resolved (legacy candidates with
+    no ``gate_status_json``). The blocking/advisory split compares on
+    ``key``; entries with ``key=None`` are treated as advisory, never
+    blocking. ``key`` is internal — it is stripped before the buckets
+    reach the LLM prompt (see ``_gate_buckets_for_prompt``).
+
+    ``name`` is the display label: byte-identical to HEAD for
+    ``lang="en"`` (the humanized label carried by ``gate_reasons``); the
+    Arabic label when ``lang="ar"`` and the raw key is known.
+
+    Prefers ``gate_reasons`` (``passed/failed/unknown`` arrays +
+    ``explanations``) for membership / order / explanation so the English
+    prompt addendum stays byte-identical. Falls back to ``gate_verdicts``
+    when ``gate_reasons`` is unavailable or empty.
     """
+    from app.services.expansion_advisor import _gate_key_to_label
+
     buckets: dict[str, list[dict]] = {"passed": [], "failed": [], "unknown": []}
+
+    # Index humanized-en label -> raw gate key, built from the flat
+    # raw-keyed gate_status_json. Lets us attach a locale-invariant key
+    # to each humanized bucket entry without lossy label inversion.
+    label_to_key: dict[str, str] = {}
+    if isinstance(gate_status, dict):
+        for raw_key in gate_status:
+            if raw_key == "overall_pass":
+                continue
+            label_to_key[_gate_key_to_label(str(raw_key), "en")] = str(raw_key)
 
     def _append(bucket: str, name: str, explanation: str) -> None:
         gate_name = str(name or "").strip()
         if not gate_name:
             return
+        raw_key = label_to_key.get(gate_name)
+        display_name = gate_name
+        if lang == "ar" and raw_key is not None:
+            from app.services.expansion_advisor_i18n import humanize_gate
+
+            display_name = humanize_gate(raw_key, "ar")
         buckets[bucket].append({
-            "name": gate_name,
+            "key": raw_key,
+            "name": display_name,
             "explanation": explanation or "",
         })
 
@@ -900,6 +928,8 @@ def build_memo_context(
     gate_buckets = _build_gate_buckets(
         raw_gate_reasons if isinstance(raw_gate_reasons, dict) else None,
         gate_verdicts,
+        gate_status=raw_gate_status if isinstance(raw_gate_status, dict) else None,
+        lang=lang,
     )
 
     comparable_competitors = _as_list(
@@ -1686,6 +1716,25 @@ _MAX_USER_PAYLOAD_CHARS = 12000
 _FEATURE_SNAPSHOT_SOFT_LIMIT = 4000
 
 
+def _gate_buckets_for_prompt(buckets: dict | None) -> dict:
+    """Project gate buckets to the HEAD ``{name, explanation}`` entry
+    shape for the LLM user message. The internal ``key`` field (PR #2b,
+    used only for the locale-invariant blocking/advisory split) must not
+    leak into the prompt — rule #7: the English prompt text stays
+    byte-identical to HEAD.
+    """
+    src = buckets or {}
+    out: dict[str, list[dict]] = {"passed": [], "failed": [], "unknown": []}
+    for bucket_key in ("passed", "failed", "unknown"):
+        for e in src.get(bucket_key) or []:
+            if isinstance(e, dict):
+                out[bucket_key].append({
+                    "name": e.get("name", ""),
+                    "explanation": e.get("explanation", ""),
+                })
+    return out
+
+
 def _serialize_context_for_user_message(ctx: MemoContext) -> str:
     """Serialize the MemoContext to a compact JSON string for the user turn,
     truncating ``feature_snapshot`` to the whitelist if the full payload would
@@ -1716,7 +1765,7 @@ def _serialize_context_for_user_message(ctx: MemoContext) -> str:
         # Kept for backward-compat with any downstream consumer. The
         # authoritative tri-state view for the LLM is ``gates`` below.
         "gate_verdicts": ctx.gate_verdicts,
-        "gates": ctx.gate_buckets or {"passed": [], "failed": [], "unknown": []},
+        "gates": _gate_buckets_for_prompt(ctx.gate_buckets),
         "overall_pass": ctx.overall_pass,
         "final_rank": ctx.final_rank,
         "final_score": ctx.final_score,
@@ -1774,15 +1823,16 @@ def render_structured_memo_prompt(ctx: MemoContext) -> list[dict]:
     # Split failures into blocking vs advisory. Only blocking failures
     # justify a "Decline" instruction — advisory-only failures (e.g.,
     # ``radiance_growth_pass``) leave ``overall_pass`` at True and must
-    # NOT push the LLM toward a Decline headline. Compare on humanized
-    # labels because ``failed_entries`` (from ``_build_gate_buckets``) only
-    # carries the humanized name by the time it reaches this point.
-    hard_fail_labels = _hard_fail_gate_labels()
+    # NOT push the LLM toward a Decline headline. Compare on the raw,
+    # locale-invariant gate key so the split is identical regardless of
+    # the memo's display language. Entries with ``key=None`` (legacy
+    # candidates with no gate_status_json) are treated as advisory.
+    hard_fail_keys = _hard_fail_gate_keys()
     blocking_failed = [
-        e for e in failed_entries if str(e.get("name")) in hard_fail_labels
+        e for e in failed_entries if e.get("key") in hard_fail_keys
     ]
     advisory_failed = [
-        e for e in failed_entries if str(e.get("name")) not in hard_fail_labels
+        e for e in failed_entries if e.get("key") not in hard_fail_keys
     ]
 
     if blocking_failed:
@@ -2108,19 +2158,20 @@ def _parse_and_validate_memo_shape(
 
 
 def _blocking_failed_from_buckets(buckets: dict | None) -> list[dict]:
-    """Return the subset of ``buckets["failed"]`` whose gate label matches
-    the live hard-fail set — i.e., failures that flipped overall_pass to
-    False. Mirrors the same split used in render_structured_memo_prompt so
-    the retry layer's view of "blocking" stays consistent with what the
-    LLM saw in the prompt addendum.
+    """Return the subset of ``buckets["failed"]`` whose raw gate key
+    matches the live hard-fail set — i.e., failures that flipped
+    overall_pass to False. Mirrors the same split used in
+    render_structured_memo_prompt so the retry layer's view of
+    "blocking" stays consistent with what the LLM saw in the prompt
+    addendum.
     """
     if not isinstance(buckets, dict):
         return []
     failed = buckets.get("failed") or []
-    hard_fail_labels = _hard_fail_gate_labels()
+    hard_fail_keys = _hard_fail_gate_keys()
     return [
         e for e in failed
-        if isinstance(e, dict) and str(e.get("name")) in hard_fail_labels
+        if isinstance(e, dict) and e.get("key") in hard_fail_keys
     ]
 
 

--- a/scripts/gen_pr2b_golden.py
+++ b/scripts/gen_pr2b_golden.py
@@ -1,0 +1,279 @@
+"""Generate PR #2b golden fixtures for the read-path byte-identity guard.
+
+Run this ONCE against HEAD (before the PR #2b edits to
+``_normalize_candidate_payload``) to capture the English read-path
+output. ``tests/test_pr2b_lang_en_byte_identity.py`` then asserts the
+post-edit code reproduces these byte-for-byte (discipline rule #2).
+
+Usage:  python scripts/gen_pr2b_golden.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.services.expansion_advisor import (
+    _normalize_candidate_payload,
+    _normalize_saved_search_payload,
+)
+
+OUT = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "pr2b_golden"
+
+# PR #2b's _normalize_candidate_payload explicitly drops these internal
+# columns from the outgoing payload (spec §2.1). The byte-identity guard
+# therefore compares against HEAD output with these keys removed — every
+# other key (English strings, gate chain, value bands, district canon)
+# stays byte-identical.
+_STRUCTURED_COLS = (
+    "top_positives_structured_json",
+    "top_risks_structured_json",
+    "decision_summary_structured_json",
+    "demand_thesis_structured_json",
+    "cost_thesis_structured_json",
+)
+
+
+def _strip_structured(payload: dict) -> dict:
+    out = {k: v for k, v in payload.items() if k not in _STRUCTURED_COLS}
+    cands = out.get("candidates")
+    if isinstance(cands, list):
+        out["candidates"] = [
+            {k: v for k, v in c.items() if k not in _STRUCTURED_COLS}
+            if isinstance(c, dict) else c
+            for c in cands
+        ]
+    return out
+
+
+_GATE_STATUS = {
+    "overall_pass": False,
+    "zoning_fit_pass": True,
+    "area_fit_pass": False,
+    "parking_pass": None,
+    "economics_pass": True,
+}
+_GATE_REASONS = {
+    "passed": ["zoning_fit_pass", "economics_pass"],
+    "failed": ["area_fit_pass"],
+    "unknown": ["parking_pass"],
+    "thresholds": {"area_fit_pass": {"min": 80}},
+    "explanations": {"area_fit_pass": "Area below the requested minimum."},
+}
+_SCORE_BREAKDOWN = {
+    "weights": {"demand": 0.3},
+    "inputs": {"landlord_signal": 0.7},
+    "weighted_components": {"demand": 21.0},
+    "display": {},
+    "final_score": 72.5,
+    "economics_detail": {
+        "value_score": 63.0,
+        "value_band": "best_value",
+        "value_band_low_confidence": False,
+        "rent_burden": {"mode": "percentile", "median_monthly_rent_per_m2": 90.0},
+    },
+}
+
+_CANDIDATES: dict[str, dict] = {
+    "full_en_fields": {
+        "candidate_id": "c-full-1",
+        "parcel_id": "P-1001",
+        "district": "Al Olaya",
+        "area_m2": 220.0,
+        "final_score": 81.4,
+        "economics_score": 73.2,
+        "estimated_rent_sar_m2_year": 1850.6,
+        "estimated_annual_rent_sar": 407132.0,
+        "top_positives_json": [
+            "Demand potential is strong for this district.",
+            "Economics profile meets target screening band.",
+        ],
+        "top_risks_json": ["Economics score is below preferred threshold."],
+        "decision_summary": "This standard candidate in Al Olaya scores 81.4/100.",
+        "demand_thesis": "Demand is strong (score 81.4).",
+        "cost_thesis": "Estimated rent is 1851 SAR/m²/year.",
+    },
+    "gate_chain": {
+        "candidate_id": "c-gate-1",
+        "parcel_id": "P-1002",
+        "district": "Al Malqa",
+        "area_m2": 140.0,
+        "final_score": 55.0,
+        "gate_status_json": dict(_GATE_STATUS),
+        "gate_reasons_json": dict(_GATE_REASONS),
+        "top_positives_json": [],
+        "top_risks_json": ["Area fit gate failed."],
+        "decision_summary": "Caution advised.",
+        "demand_thesis": "Demand is moderate.",
+        "cost_thesis": "Rent estimate pending.",
+    },
+    "structured_cols_populated": {
+        "candidate_id": "c-struct-1",
+        "parcel_id": "P-1003",
+        "district": "Al Narjis",
+        "area_m2": 300.0,
+        "final_score": 67.0,
+        "economics_score": 60.0,
+        "top_positives_json": ["Demand potential is strong for this district."],
+        "top_risks_json": ["Economics are marginal."],
+        "decision_summary": "Standard candidate.",
+        "demand_thesis": "Demand is moderate.",
+        "cost_thesis": "Estimated rent is 1200 SAR/m²/year.",
+        # PR #2a structured columns — must be DROPPED from the en payload;
+        # en output identical to a candidate without them.
+        "top_positives_structured_json": [{"id": "pos.demand_strong", "params": {}}],
+        "top_risks_structured_json": [{"id": "risk.economics_marginal", "params": {}}],
+        "decision_summary_structured_json": {"id": "decision_summary", "params": {}},
+        "demand_thesis_structured_json": {"id": "demand_thesis", "params": {}},
+        "cost_thesis_structured_json": {"id": "cost_thesis", "params": {}},
+    },
+    "structured_cols_null": {
+        "candidate_id": "c-struct-null",
+        "parcel_id": "P-1004",
+        "district": "Al Narjis",
+        "area_m2": 300.0,
+        "final_score": 67.0,
+        "economics_score": 60.0,
+        "top_positives_json": ["Demand potential is strong for this district."],
+        "top_risks_json": ["Economics are marginal."],
+        "decision_summary": "Standard candidate.",
+        "demand_thesis": "Demand is moderate.",
+        "cost_thesis": "Estimated rent is 1200 SAR/m²/year.",
+        "top_positives_structured_json": None,
+        "top_risks_structured_json": None,
+        "decision_summary_structured_json": None,
+        "demand_thesis_structured_json": None,
+        "cost_thesis_structured_json": None,
+    },
+    "listing_candidate": {
+        "candidate_id": "c-listing-1",
+        "parcel_id": "P-1005",
+        "district": "Hittin",
+        "area_m2": 160.0,
+        "final_score": 70.0,
+        "source_type": "commercial_unit",
+        "commercial_unit_id": "CU-77",
+        "listing_url": "https://example.com/listing/77",
+        "image_url": "https://example.com/img/77.jpg",
+        "unit_price_sar_annual": 250000.0,
+        "unit_area_sqm": 160.0,
+        "unit_street_width_m": 20.0,
+        "unit_neighborhood": "Hittin",
+        "unit_listing_type": "rent",
+        "top_positives_json": ["Newly listed within the last week."],
+        "top_risks_json": [],
+        "decision_summary": "Listing-backed candidate.",
+        "demand_thesis": "Demand is strong.",
+        "cost_thesis": "Rent measured from listing.",
+    },
+    "value_band": {
+        "candidate_id": "c-value-1",
+        "parcel_id": "P-1006",
+        "district": "Al Yasmin",
+        "area_m2": 250.0,
+        "final_score": 75.0,
+        "score_breakdown_json": dict(_SCORE_BREAKDOWN),
+        "top_positives_json": ["Strong economics with favorable rent-to-revenue ratio."],
+        "top_risks_json": [],
+        "decision_summary": "Best value pick.",
+        "demand_thesis": "Demand is strong.",
+        "cost_thesis": "Economics favorable.",
+    },
+    "display_rent": {
+        "candidate_id": "c-rent-1",
+        "parcel_id": "P-1007",
+        "estimated_rent_sar_m2_year": 2000.04,
+        "area_m2": 192.0,
+        "estimated_annual_rent_sar": 2000.04 * 192.0,
+    },
+    "minimal": {
+        "candidate_id": "c-min-1",
+        "parcel_id": "P-1008",
+    },
+    "empty_lists": {
+        "candidate_id": "c-empty-1",
+        "parcel_id": "P-1009",
+        "district": "Al Olaya",
+        "top_positives_json": None,
+        "top_risks_json": None,
+        "decision_summary": None,
+        "demand_thesis": None,
+        "cost_thesis": None,
+    },
+    "district_only": {
+        "candidate_id": "c-dist-1",
+        "parcel_id": "P-1010",
+        "district": "حي العليا",
+        "area_m2": 200.0,
+        "final_score": 60.0,
+        "top_positives_json": ["Demand potential is strong for this district."],
+        "top_risks_json": ["Economics score is below preferred threshold."],
+        "decision_summary": "Standard candidate.",
+        "demand_thesis": "Demand is moderate.",
+        "cost_thesis": "Rent estimate pending.",
+    },
+}
+
+
+def _build_candidate_fixtures() -> None:
+    for fid, candidate in _CANDIDATES.items():
+        expected_en = _strip_structured(_normalize_candidate_payload(dict(candidate)))
+        (OUT / f"cand_{fid}.json").write_text(
+            json.dumps(
+                {
+                    "id": f"cand_{fid}",
+                    "kind": "candidate",
+                    "candidate": candidate,
+                    "expected_en": expected_en,
+                },
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+
+def _build_saved_search_fixtures() -> None:
+    saved = {
+        "id": "ss-1",
+        "title": "Riyadh QSR shortlist",
+        "status": "active",
+        "selected_candidate_ids": ["c-full-1"],
+        "search": {
+            "id": "search-1",
+            "brand_name": "TestBrand",
+            "category": "qsr",
+            "service_model": "qsr",
+            "target_districts": ["Al Olaya"],
+        },
+        "candidates": [dict(_CANDIDATES["full_en_fields"]), dict(_CANDIDATES["gate_chain"])],
+    }
+    expected_en = _strip_structured(_normalize_saved_search_payload(dict(saved)))
+    (OUT / "saved_basic.json").write_text(
+        json.dumps(
+            {
+                "id": "saved_basic",
+                "kind": "saved_search",
+                "saved": saved,
+                "expected_en": expected_en,
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    _build_candidate_fixtures()
+    _build_saved_search_fixtures()
+    print(f"Wrote PR #2b golden fixtures to {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/pr2b_golden/cand_display_rent.json
+++ b/tests/fixtures/pr2b_golden/cand_display_rent.json
@@ -1,0 +1,68 @@
+{
+  "candidate": {
+    "area_m2": 192.0,
+    "candidate_id": "c-rent-1",
+    "estimated_annual_rent_sar": 384007.68,
+    "estimated_rent_sar_m2_year": 2000.04,
+    "parcel_id": "P-1007"
+  },
+  "expected_en": {
+    "area_m2": 192.0,
+    "candidate_id": "c-rent-1",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "",
+    "decision_summary": "",
+    "demand_thesis": "",
+    "display_annual_rent_sar": 384000.0,
+    "district_display": null,
+    "district_key": null,
+    "district_name_ar": null,
+    "district_name_en": null,
+    "estimated_annual_rent_sar": 384007.68,
+    "estimated_rent_sar_m2_year": 2000.04,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1007",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 0.0,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "parcel",
+    "top_positives_json": [],
+    "top_risks_json": [],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_display_rent",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_district_only.json
+++ b/tests/fixtures/pr2b_golden/cand_district_only.json
@@ -1,0 +1,81 @@
+{
+  "candidate": {
+    "area_m2": 200.0,
+    "candidate_id": "c-dist-1",
+    "cost_thesis": "Rent estimate pending.",
+    "decision_summary": "Standard candidate.",
+    "demand_thesis": "Demand is moderate.",
+    "district": "حي العليا",
+    "final_score": 60.0,
+    "parcel_id": "P-1010",
+    "top_positives_json": [
+      "Demand potential is strong for this district."
+    ],
+    "top_risks_json": [
+      "Economics score is below preferred threshold."
+    ]
+  },
+  "expected_en": {
+    "area_m2": 200.0,
+    "candidate_id": "c-dist-1",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "Rent estimate pending.",
+    "decision_summary": "Standard candidate.",
+    "demand_thesis": "Demand is moderate.",
+    "display_annual_rent_sar": null,
+    "district": "حي العليا",
+    "district_display": "حي العليا",
+    "district_key": "العليا",
+    "district_name_ar": "حي العليا",
+    "district_name_en": null,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "final_score": 60.0,
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1010",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 60.0,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "parcel",
+    "top_positives_json": [
+      "Demand potential is strong for this district."
+    ],
+    "top_risks_json": [
+      "Economics score is below preferred threshold."
+    ],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_district_only",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_empty_lists.json
+++ b/tests/fixtures/pr2b_golden/cand_empty_lists.json
@@ -1,0 +1,69 @@
+{
+  "candidate": {
+    "candidate_id": "c-empty-1",
+    "cost_thesis": null,
+    "decision_summary": null,
+    "demand_thesis": null,
+    "district": "Al Olaya",
+    "parcel_id": "P-1009",
+    "top_positives_json": null,
+    "top_risks_json": null
+  },
+  "expected_en": {
+    "candidate_id": "c-empty-1",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "",
+    "decision_summary": "",
+    "demand_thesis": "",
+    "display_annual_rent_sar": null,
+    "district": "Al Olaya",
+    "district_display": "Al Olaya",
+    "district_key": "Al Olaya",
+    "district_name_ar": "Al Olaya",
+    "district_name_en": null,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1009",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 0.0,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "parcel",
+    "top_positives_json": [],
+    "top_risks_json": [],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_empty_lists",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_full_en_fields.json
+++ b/tests/fixtures/pr2b_golden/cand_full_en_fields.json
@@ -1,0 +1,89 @@
+{
+  "candidate": {
+    "area_m2": 220.0,
+    "candidate_id": "c-full-1",
+    "cost_thesis": "Estimated rent is 1851 SAR/m²/year.",
+    "decision_summary": "This standard candidate in Al Olaya scores 81.4/100.",
+    "demand_thesis": "Demand is strong (score 81.4).",
+    "district": "Al Olaya",
+    "economics_score": 73.2,
+    "estimated_annual_rent_sar": 407132.0,
+    "estimated_rent_sar_m2_year": 1850.6,
+    "final_score": 81.4,
+    "parcel_id": "P-1001",
+    "top_positives_json": [
+      "Demand potential is strong for this district.",
+      "Economics profile meets target screening band."
+    ],
+    "top_risks_json": [
+      "Economics score is below preferred threshold."
+    ]
+  },
+  "expected_en": {
+    "area_m2": 220.0,
+    "candidate_id": "c-full-1",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "Estimated rent is 1851 SAR/m²/year.",
+    "decision_summary": "This standard candidate in Al Olaya scores 81.4/100.",
+    "demand_thesis": "Demand is strong (score 81.4).",
+    "display_annual_rent_sar": 407220.0,
+    "district": "Al Olaya",
+    "district_display": "Al Olaya",
+    "district_key": "Al Olaya",
+    "district_name_ar": "Al Olaya",
+    "district_name_en": null,
+    "economics_score": 73.2,
+    "estimated_annual_rent_sar": 407132.0,
+    "estimated_rent_sar_m2_year": 1850.6,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "final_score": 81.4,
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1001",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 81.4,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "parcel",
+    "top_positives_json": [
+      "Demand potential is strong for this district.",
+      "Economics profile meets target screening band."
+    ],
+    "top_risks_json": [
+      "Economics score is below preferred threshold."
+    ],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_full_en_fields",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_gate_chain.json
+++ b/tests/fixtures/pr2b_golden/cand_gate_chain.json
@@ -1,0 +1,123 @@
+{
+  "candidate": {
+    "area_m2": 140.0,
+    "candidate_id": "c-gate-1",
+    "cost_thesis": "Rent estimate pending.",
+    "decision_summary": "Caution advised.",
+    "demand_thesis": "Demand is moderate.",
+    "district": "Al Malqa",
+    "final_score": 55.0,
+    "gate_reasons_json": {
+      "explanations": {
+        "area_fit_pass": "Area below the requested minimum."
+      },
+      "failed": [
+        "area_fit_pass"
+      ],
+      "passed": [
+        "zoning_fit_pass",
+        "economics_pass"
+      ],
+      "thresholds": {
+        "area_fit_pass": {
+          "min": 80
+        }
+      },
+      "unknown": [
+        "parking_pass"
+      ]
+    },
+    "gate_status_json": {
+      "area_fit_pass": false,
+      "economics_pass": true,
+      "overall_pass": false,
+      "parking_pass": null,
+      "zoning_fit_pass": true
+    },
+    "parcel_id": "P-1002",
+    "top_positives_json": [],
+    "top_risks_json": [
+      "Area fit gate failed."
+    ]
+  },
+  "expected_en": {
+    "area_m2": 140.0,
+    "candidate_id": "c-gate-1",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "Rent estimate pending.",
+    "decision_summary": "Caution advised.",
+    "demand_thesis": "Demand is moderate.",
+    "display_annual_rent_sar": null,
+    "district": "Al Malqa",
+    "district_display": "Al Malqa",
+    "district_key": "Al Malqa",
+    "district_name_ar": "Al Malqa",
+    "district_name_en": null,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "final_score": 55.0,
+    "gate_reasons_json": {
+      "explanations": {
+        "area_fit_pass": "Area below the requested minimum."
+      },
+      "failed": [
+        "area fit"
+      ],
+      "passed": [
+        "zoning fit",
+        "economics"
+      ],
+      "thresholds": {
+        "area_fit_pass": {
+          "min": 80
+        }
+      },
+      "unknown": [
+        "parking"
+      ]
+    },
+    "gate_status_json": {
+      "area_fit_pass": false,
+      "economics_pass": true,
+      "overall_pass": false,
+      "parking_pass": null,
+      "zoning_fit_pass": true
+    },
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1002",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 55.0,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "parcel",
+    "top_positives_json": [],
+    "top_risks_json": [
+      "Area fit gate failed."
+    ],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_gate_chain",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_listing_candidate.json
+++ b/tests/fixtures/pr2b_golden/cand_listing_candidate.json
@@ -1,0 +1,86 @@
+{
+  "candidate": {
+    "area_m2": 160.0,
+    "candidate_id": "c-listing-1",
+    "commercial_unit_id": "CU-77",
+    "cost_thesis": "Rent measured from listing.",
+    "decision_summary": "Listing-backed candidate.",
+    "demand_thesis": "Demand is strong.",
+    "district": "Hittin",
+    "final_score": 70.0,
+    "image_url": "https://example.com/img/77.jpg",
+    "listing_url": "https://example.com/listing/77",
+    "parcel_id": "P-1005",
+    "source_type": "commercial_unit",
+    "top_positives_json": [
+      "Newly listed within the last week."
+    ],
+    "top_risks_json": [],
+    "unit_area_sqm": 160.0,
+    "unit_listing_type": "rent",
+    "unit_neighborhood": "Hittin",
+    "unit_price_sar_annual": 250000.0,
+    "unit_street_width_m": 20.0
+  },
+  "expected_en": {
+    "area_m2": 160.0,
+    "candidate_id": "c-listing-1",
+    "commercial_unit_id": "CU-77",
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "Rent measured from listing.",
+    "decision_summary": "Listing-backed candidate.",
+    "demand_thesis": "Demand is strong.",
+    "display_annual_rent_sar": null,
+    "district": "Hittin",
+    "district_display": "Hittin",
+    "district_key": "Hittin",
+    "district_name_ar": "Hittin",
+    "district_name_en": null,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "final_score": 70.0,
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": "https://example.com/img/77.jpg",
+    "listing_url": "https://example.com/listing/77",
+    "parcel_id": "P-1005",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 70.0,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "commercial_unit",
+    "top_positives_json": [
+      "Newly listed within the last week."
+    ],
+    "top_risks_json": [],
+    "unit_area_sqm": 160.0,
+    "unit_listing_type": "rent",
+    "unit_neighborhood": "Hittin",
+    "unit_price_sar_annual": 250000.0,
+    "unit_street_width_m": 20.0,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_listing_candidate",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_minimal.json
+++ b/tests/fixtures/pr2b_golden/cand_minimal.json
@@ -1,0 +1,62 @@
+{
+  "candidate": {
+    "candidate_id": "c-min-1",
+    "parcel_id": "P-1008"
+  },
+  "expected_en": {
+    "candidate_id": "c-min-1",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "",
+    "decision_summary": "",
+    "demand_thesis": "",
+    "display_annual_rent_sar": null,
+    "district_display": null,
+    "district_key": null,
+    "district_name_ar": null,
+    "district_name_en": null,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1008",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 0.0,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "parcel",
+    "top_positives_json": [],
+    "top_risks_json": [],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_minimal",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_structured_cols_null.json
+++ b/tests/fixtures/pr2b_golden/cand_structured_cols_null.json
@@ -1,0 +1,88 @@
+{
+  "candidate": {
+    "area_m2": 300.0,
+    "candidate_id": "c-struct-null",
+    "cost_thesis": "Estimated rent is 1200 SAR/m²/year.",
+    "cost_thesis_structured_json": null,
+    "decision_summary": "Standard candidate.",
+    "decision_summary_structured_json": null,
+    "demand_thesis": "Demand is moderate.",
+    "demand_thesis_structured_json": null,
+    "district": "Al Narjis",
+    "economics_score": 60.0,
+    "final_score": 67.0,
+    "parcel_id": "P-1004",
+    "top_positives_json": [
+      "Demand potential is strong for this district."
+    ],
+    "top_positives_structured_json": null,
+    "top_risks_json": [
+      "Economics are marginal."
+    ],
+    "top_risks_structured_json": null
+  },
+  "expected_en": {
+    "area_m2": 300.0,
+    "candidate_id": "c-struct-null",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "Estimated rent is 1200 SAR/m²/year.",
+    "decision_summary": "Standard candidate.",
+    "demand_thesis": "Demand is moderate.",
+    "display_annual_rent_sar": null,
+    "district": "Al Narjis",
+    "district_display": "Al Narjis",
+    "district_key": "Al Narjis",
+    "district_name_ar": "Al Narjis",
+    "district_name_en": null,
+    "economics_score": 60.0,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "final_score": 67.0,
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1004",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 67.0,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "parcel",
+    "top_positives_json": [
+      "Demand potential is strong for this district."
+    ],
+    "top_risks_json": [
+      "Economics are marginal."
+    ],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_structured_cols_null",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_structured_cols_populated.json
+++ b/tests/fixtures/pr2b_golden/cand_structured_cols_populated.json
@@ -1,0 +1,107 @@
+{
+  "candidate": {
+    "area_m2": 300.0,
+    "candidate_id": "c-struct-1",
+    "cost_thesis": "Estimated rent is 1200 SAR/m²/year.",
+    "cost_thesis_structured_json": {
+      "id": "cost_thesis",
+      "params": {}
+    },
+    "decision_summary": "Standard candidate.",
+    "decision_summary_structured_json": {
+      "id": "decision_summary",
+      "params": {}
+    },
+    "demand_thesis": "Demand is moderate.",
+    "demand_thesis_structured_json": {
+      "id": "demand_thesis",
+      "params": {}
+    },
+    "district": "Al Narjis",
+    "economics_score": 60.0,
+    "final_score": 67.0,
+    "parcel_id": "P-1003",
+    "top_positives_json": [
+      "Demand potential is strong for this district."
+    ],
+    "top_positives_structured_json": [
+      {
+        "id": "pos.demand_strong",
+        "params": {}
+      }
+    ],
+    "top_risks_json": [
+      "Economics are marginal."
+    ],
+    "top_risks_structured_json": [
+      {
+        "id": "risk.economics_marginal",
+        "params": {}
+      }
+    ]
+  },
+  "expected_en": {
+    "area_m2": 300.0,
+    "candidate_id": "c-struct-1",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "Estimated rent is 1200 SAR/m²/year.",
+    "decision_summary": "Standard candidate.",
+    "demand_thesis": "Demand is moderate.",
+    "display_annual_rent_sar": null,
+    "district": "Al Narjis",
+    "district_display": "Al Narjis",
+    "district_key": "Al Narjis",
+    "district_name_ar": "Al Narjis",
+    "district_name_en": null,
+    "economics_score": 60.0,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "final_score": 67.0,
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1003",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {},
+      "final_score": 67.0,
+      "inputs": {},
+      "weighted_components": {},
+      "weights": {}
+    },
+    "source_type": "parcel",
+    "top_positives_json": [
+      "Demand potential is strong for this district."
+    ],
+    "top_risks_json": [
+      "Economics are marginal."
+    ],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": null,
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": null,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_structured_cols_populated",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/cand_value_band.json
+++ b/tests/fixtures/pr2b_golden/cand_value_band.json
@@ -1,0 +1,113 @@
+{
+  "candidate": {
+    "area_m2": 250.0,
+    "candidate_id": "c-value-1",
+    "cost_thesis": "Economics favorable.",
+    "decision_summary": "Best value pick.",
+    "demand_thesis": "Demand is strong.",
+    "district": "Al Yasmin",
+    "final_score": 75.0,
+    "parcel_id": "P-1006",
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {
+        "rent_burden": {
+          "median_monthly_rent_per_m2": 90.0,
+          "mode": "percentile"
+        },
+        "value_band": "best_value",
+        "value_band_low_confidence": false,
+        "value_score": 63.0
+      },
+      "final_score": 72.5,
+      "inputs": {
+        "landlord_signal": 0.7
+      },
+      "weighted_components": {
+        "demand": 21.0
+      },
+      "weights": {
+        "demand": 0.3
+      }
+    },
+    "top_positives_json": [
+      "Strong economics with favorable rent-to-revenue ratio."
+    ],
+    "top_risks_json": []
+  },
+  "expected_en": {
+    "area_m2": 250.0,
+    "candidate_id": "c-value-1",
+    "commercial_unit_id": null,
+    "comparable_competitors_json": [],
+    "confidence_grade": "D",
+    "cost_thesis": "Economics favorable.",
+    "decision_summary": "Best value pick.",
+    "demand_thesis": "Demand is strong.",
+    "display_annual_rent_sar": null,
+    "district": "Al Yasmin",
+    "district_display": "Al Yasmin",
+    "district_key": "Al Yasmin",
+    "district_name_ar": "Al Yasmin",
+    "district_name_en": null,
+    "feature_snapshot_json": {
+      "context_sources": {},
+      "data_completeness_score": 0,
+      "missing_context": []
+    },
+    "final_score": 75.0,
+    "gate_reasons_json": {
+      "explanations": {},
+      "failed": [],
+      "passed": [],
+      "thresholds": {},
+      "unknown": []
+    },
+    "gate_status_json": {},
+    "image_url": null,
+    "listing_url": null,
+    "parcel_id": "P-1006",
+    "rank_position": null,
+    "score_breakdown_json": {
+      "display": {},
+      "economics_detail": {
+        "rent_burden": {
+          "median_monthly_rent_per_m2": 90.0,
+          "mode": "percentile"
+        },
+        "value_band": "best_value",
+        "value_band_low_confidence": false,
+        "value_score": 63.0
+      },
+      "final_score": 72.5,
+      "inputs": {
+        "landlord_signal": 0.7
+      },
+      "weighted_components": {
+        "demand": 21.0
+      },
+      "weights": {
+        "demand": 0.3
+      }
+    },
+    "source_type": "parcel",
+    "top_positives_json": [
+      "Strong economics with favorable rent-to-revenue ratio."
+    ],
+    "top_risks_json": [],
+    "unit_area_sqm": null,
+    "unit_listing_type": null,
+    "unit_neighborhood": null,
+    "unit_price_sar_annual": null,
+    "unit_street_width_m": null,
+    "value_band": "best_value",
+    "value_band_low_confidence": false,
+    "value_downrank_applied": false,
+    "value_downrank_delta": 0,
+    "value_score": 63.0,
+    "value_uprank_applied": false,
+    "value_uprank_delta": 0
+  },
+  "id": "cand_value_band",
+  "kind": "candidate"
+}

--- a/tests/fixtures/pr2b_golden/saved_basic.json
+++ b/tests/fixtures/pr2b_golden/saved_basic.json
@@ -1,0 +1,264 @@
+{
+  "expected_en": {
+    "candidates": [
+      {
+        "area_m2": 220.0,
+        "candidate_id": "c-full-1",
+        "commercial_unit_id": null,
+        "comparable_competitors_json": [],
+        "confidence_grade": "D",
+        "cost_thesis": "Estimated rent is 1851 SAR/m²/year.",
+        "decision_summary": "This standard candidate in Al Olaya scores 81.4/100.",
+        "demand_thesis": "Demand is strong (score 81.4).",
+        "display_annual_rent_sar": 407220.0,
+        "district": "Al Olaya",
+        "district_display": "Al Olaya",
+        "district_key": "Al Olaya",
+        "district_name_ar": "Al Olaya",
+        "district_name_en": null,
+        "economics_score": 73.2,
+        "estimated_annual_rent_sar": 407132.0,
+        "estimated_rent_sar_m2_year": 1850.6,
+        "feature_snapshot_json": {
+          "context_sources": {},
+          "data_completeness_score": 0,
+          "missing_context": []
+        },
+        "final_score": 81.4,
+        "gate_reasons_json": {
+          "explanations": {},
+          "failed": [],
+          "passed": [],
+          "thresholds": {},
+          "unknown": []
+        },
+        "gate_status_json": {},
+        "image_url": null,
+        "listing_url": null,
+        "parcel_id": "P-1001",
+        "rank_position": null,
+        "score_breakdown_json": {
+          "display": {},
+          "economics_detail": {},
+          "final_score": 81.4,
+          "inputs": {},
+          "weighted_components": {},
+          "weights": {}
+        },
+        "source_type": "parcel",
+        "top_positives_json": [
+          "Demand potential is strong for this district.",
+          "Economics profile meets target screening band."
+        ],
+        "top_risks_json": [
+          "Economics score is below preferred threshold."
+        ],
+        "unit_area_sqm": null,
+        "unit_listing_type": null,
+        "unit_neighborhood": null,
+        "unit_price_sar_annual": null,
+        "unit_street_width_m": null,
+        "value_band": null,
+        "value_band_low_confidence": false,
+        "value_downrank_applied": false,
+        "value_downrank_delta": 0,
+        "value_score": null,
+        "value_uprank_applied": false,
+        "value_uprank_delta": 0
+      },
+      {
+        "area_m2": 140.0,
+        "candidate_id": "c-gate-1",
+        "commercial_unit_id": null,
+        "comparable_competitors_json": [],
+        "confidence_grade": "D",
+        "cost_thesis": "Rent estimate pending.",
+        "decision_summary": "Caution advised.",
+        "demand_thesis": "Demand is moderate.",
+        "display_annual_rent_sar": null,
+        "district": "Al Malqa",
+        "district_display": "Al Malqa",
+        "district_key": "Al Malqa",
+        "district_name_ar": "Al Malqa",
+        "district_name_en": null,
+        "feature_snapshot_json": {
+          "context_sources": {},
+          "data_completeness_score": 0,
+          "missing_context": []
+        },
+        "final_score": 55.0,
+        "gate_reasons_json": {
+          "explanations": {
+            "area_fit_pass": "Area below the requested minimum."
+          },
+          "failed": [
+            "area fit"
+          ],
+          "passed": [
+            "zoning fit",
+            "economics"
+          ],
+          "thresholds": {
+            "area_fit_pass": {
+              "min": 80
+            }
+          },
+          "unknown": [
+            "parking"
+          ]
+        },
+        "gate_status_json": {
+          "area_fit_pass": false,
+          "economics_pass": true,
+          "overall_pass": false,
+          "parking_pass": null,
+          "zoning_fit_pass": true
+        },
+        "image_url": null,
+        "listing_url": null,
+        "parcel_id": "P-1002",
+        "rank_position": null,
+        "score_breakdown_json": {
+          "display": {},
+          "economics_detail": {},
+          "final_score": 55.0,
+          "inputs": {},
+          "weighted_components": {},
+          "weights": {}
+        },
+        "source_type": "parcel",
+        "top_positives_json": [],
+        "top_risks_json": [
+          "Area fit gate failed."
+        ],
+        "unit_area_sqm": null,
+        "unit_listing_type": null,
+        "unit_neighborhood": null,
+        "unit_price_sar_annual": null,
+        "unit_street_width_m": null,
+        "value_band": null,
+        "value_band_low_confidence": false,
+        "value_downrank_applied": false,
+        "value_downrank_delta": 0,
+        "value_score": null,
+        "value_uprank_applied": false,
+        "value_uprank_delta": 0
+      }
+    ],
+    "description": null,
+    "filters_json": {},
+    "id": "ss-1",
+    "search": {
+      "bbox": null,
+      "brand_name": "TestBrand",
+      "brand_profile": {},
+      "category": "qsr",
+      "existing_branches": [],
+      "id": "search-1",
+      "meta": {
+        "excluded_sources": [
+          "arcgis_parcels",
+          "hungerstation_poi",
+          "suhail",
+          "inferred_parcels"
+        ],
+        "parcel_source": "listings_only",
+        "version": "expansion_advisor_v7"
+      },
+      "notes": {},
+      "request_json": {},
+      "service_model": "qsr",
+      "target_districts": [
+        "Al Olaya"
+      ]
+    },
+    "selected_candidate_ids": [
+      "c-full-1"
+    ],
+    "status": "active",
+    "title": "Riyadh QSR shortlist",
+    "ui_state_json": {}
+  },
+  "id": "saved_basic",
+  "kind": "saved_search",
+  "saved": {
+    "candidates": [
+      {
+        "area_m2": 220.0,
+        "candidate_id": "c-full-1",
+        "cost_thesis": "Estimated rent is 1851 SAR/m²/year.",
+        "decision_summary": "This standard candidate in Al Olaya scores 81.4/100.",
+        "demand_thesis": "Demand is strong (score 81.4).",
+        "district": "Al Olaya",
+        "economics_score": 73.2,
+        "estimated_annual_rent_sar": 407132.0,
+        "estimated_rent_sar_m2_year": 1850.6,
+        "final_score": 81.4,
+        "parcel_id": "P-1001",
+        "top_positives_json": [
+          "Demand potential is strong for this district.",
+          "Economics profile meets target screening band."
+        ],
+        "top_risks_json": [
+          "Economics score is below preferred threshold."
+        ]
+      },
+      {
+        "area_m2": 140.0,
+        "candidate_id": "c-gate-1",
+        "cost_thesis": "Rent estimate pending.",
+        "decision_summary": "Caution advised.",
+        "demand_thesis": "Demand is moderate.",
+        "district": "Al Malqa",
+        "final_score": 55.0,
+        "gate_reasons_json": {
+          "explanations": {
+            "area_fit_pass": "Area below the requested minimum."
+          },
+          "failed": [
+            "area_fit_pass"
+          ],
+          "passed": [
+            "zoning_fit_pass",
+            "economics_pass"
+          ],
+          "thresholds": {
+            "area_fit_pass": {
+              "min": 80
+            }
+          },
+          "unknown": [
+            "parking_pass"
+          ]
+        },
+        "gate_status_json": {
+          "area_fit_pass": false,
+          "economics_pass": true,
+          "overall_pass": false,
+          "parking_pass": null,
+          "zoning_fit_pass": true
+        },
+        "parcel_id": "P-1002",
+        "top_positives_json": [],
+        "top_risks_json": [
+          "Area fit gate failed."
+        ]
+      }
+    ],
+    "id": "ss-1",
+    "search": {
+      "brand_name": "TestBrand",
+      "category": "qsr",
+      "id": "search-1",
+      "service_model": "qsr",
+      "target_districts": [
+        "Al Olaya"
+      ]
+    },
+    "selected_candidate_ids": [
+      "c-full-1"
+    ],
+    "status": "active",
+    "title": "Riyadh QSR shortlist"
+  }
+}

--- a/tests/test_expansion_advisor_api.py
+++ b/tests/test_expansion_advisor_api.py
@@ -108,7 +108,7 @@ def test_get_expansion_search_detail_includes_versioned_meta(monkeypatch):
     monkeypatch.setattr(
         expansion_api,
         "get_search",
-        lambda _db, _search_id: {
+        lambda _db, _search_id, **_kw: {
             "id": "search-1",
             "created_at": "2026-01-01T00:00:00Z",
             "brand_name": "Brand X",
@@ -143,11 +143,11 @@ def test_get_expansion_search_candidates_shape(monkeypatch):
 
     from app.api import expansion_advisor as expansion_api
 
-    monkeypatch.setattr(expansion_api, "get_search", lambda _db, _search_id: {"id": "search-1"})
+    monkeypatch.setattr(expansion_api, "get_search", lambda _db, _search_id, **_kw: {"id": "search-1"})
     monkeypatch.setattr(
         expansion_api,
         "get_candidates",
-        lambda _db, _search_id: [
+        lambda _db, _search_id, **_kw: [
             {
                 "id": "candidate-1",
                 "search_id": "search-1",
@@ -209,7 +209,7 @@ def test_compare_endpoint_happy_path(monkeypatch):
     monkeypatch.setattr(
         expansion_api,
         "compare_candidates",
-        lambda _db, _search_id, _candidate_ids: {
+        lambda _db, _search_id, _candidate_ids, **_kw: {
             "items": [
                 {"candidate_id": "c1", "economics_score": 70.0, "zoning_fit_score": 82, "frontage_score": 65, "access_score": 66, "parking_score": 61, "access_visibility_score": 64},
                 {"candidate_id": "c2", "economics_score": 62.0},
@@ -266,7 +266,7 @@ def test_compare_endpoint_rejects_foreign_candidate_ids(monkeypatch):
 
     from app.api import expansion_advisor as expansion_api
 
-    def _raise_not_found(_db, _search_id, _candidate_ids):
+    def _raise_not_found(_db, _search_id, _candidate_ids, **_kw):
         raise ValueError("not_found")
 
     monkeypatch.setattr(expansion_api, "compare_candidates", _raise_not_found)
@@ -321,7 +321,7 @@ def test_candidate_memo_endpoint_happy_path(monkeypatch):
     monkeypatch.setattr(
         expansion_api,
         "get_candidate_memo",
-        lambda _db, _candidate_id: {
+        lambda _db, _candidate_id, **_kw: {
             "candidate_id": "c1",
             "search_id": "search-1",
             "brand_profile": {"brand_name": "Brand X", "category": "burger", "service_model": "qsr"},
@@ -392,7 +392,7 @@ def test_candidate_memo_endpoint_404(monkeypatch):
 
     from app.api import expansion_advisor as expansion_api
 
-    monkeypatch.setattr(expansion_api, "get_candidate_memo", lambda _db, _candidate_id: None)
+    monkeypatch.setattr(expansion_api, "get_candidate_memo", lambda _db, _candidate_id, **_kw: None)
 
     client = _client_with_db(db)
     try:
@@ -406,7 +406,7 @@ def test_candidate_memo_endpoint_404(monkeypatch):
 def test_report_endpoint_happy_path(monkeypatch):
     db = DummyDB()
     from app.api import expansion_advisor as expansion_api
-    monkeypatch.setattr(expansion_api, "get_recommendation_report", lambda _db, _search_id: {"search_id": "search-1", "meta": {"version": "expansion_advisor_v7"}, "recommendation": {"best_candidate_id": "c1", "runner_up_candidate_id": "c2", "best_pass_candidate_id": "c1", "best_confidence_candidate_id": "c2", "why_best": "", "main_risk": "", "best_format": "", "summary": "", "report_summary": ""}, "assumptions": {}, "top_candidates": [{"id": "c1", "final_score": 91, "rank_position": 1, "confidence_grade": "A", "gate_verdict": "pass", "top_positives_json": [], "top_risks_json": [], "feature_snapshot_json": {}, "score_breakdown_json": {"weights": {}, "inputs": {}, "weighted_components": {}, "final_score": 91}}]})
+    monkeypatch.setattr(expansion_api, "get_recommendation_report", lambda _db, _search_id, **_kw: {"search_id": "search-1", "meta": {"version": "expansion_advisor_v7"}, "recommendation": {"best_candidate_id": "c1", "runner_up_candidate_id": "c2", "best_pass_candidate_id": "c1", "best_confidence_candidate_id": "c2", "why_best": "", "main_risk": "", "best_format": "", "summary": "", "report_summary": ""}, "assumptions": {}, "top_candidates": [{"id": "c1", "final_score": 91, "rank_position": 1, "confidence_grade": "A", "gate_verdict": "pass", "top_positives_json": [], "top_risks_json": [], "feature_snapshot_json": {}, "score_breakdown_json": {"weights": {}, "inputs": {}, "weighted_components": {}, "final_score": 91}}]})
     client = _client_with_db(db)
     try:
         response = client.get("/v1/expansion-advisor/searches/search-1/report")
@@ -422,7 +422,7 @@ def test_report_endpoint_happy_path(monkeypatch):
 def test_report_endpoint_404(monkeypatch):
     db = DummyDB()
     from app.api import expansion_advisor as expansion_api
-    monkeypatch.setattr(expansion_api, "get_recommendation_report", lambda _db, _search_id: None)
+    monkeypatch.setattr(expansion_api, "get_recommendation_report", lambda _db, _search_id, **_kw: None)
     client = _client_with_db(db)
     try:
         response = client.get("/v1/expansion-advisor/searches/missing/report")
@@ -733,11 +733,11 @@ def test_feature_snapshot_surfaces_listing_age_and_district_momentum(monkeypatch
 
     from app.api import expansion_advisor as expansion_api
 
-    monkeypatch.setattr(expansion_api, "get_search", lambda _db, _search_id: {"id": "search-1"})
+    monkeypatch.setattr(expansion_api, "get_search", lambda _db, _search_id, **_kw: {"id": "search-1"})
     monkeypatch.setattr(
         expansion_api,
         "get_candidates",
-        lambda _db, _search_id: [
+        lambda _db, _search_id, **_kw: [
             {
                 "id": "candidate-1",
                 "search_id": "search-1",
@@ -1174,7 +1174,7 @@ def test_get_search_detail_accepts_lang(monkeypatch):
     monkeypatch.setattr(
         expansion_api,
         "get_search",
-        lambda _db, _search_id: {
+        lambda _db, _search_id, **_kw: {
             "id": "search-1",
             "created_at": "2026-01-01T00:00:00Z",
             "brand_name": "Brand X",
@@ -1209,11 +1209,11 @@ def test_get_search_detail_accepts_lang(monkeypatch):
 def test_get_search_candidates_accepts_lang(monkeypatch):
     from app.api import expansion_advisor as expansion_api
 
-    monkeypatch.setattr(expansion_api, "get_search", lambda _db, _search_id: {"id": "search-1"})
+    monkeypatch.setattr(expansion_api, "get_search", lambda _db, _search_id, **_kw: {"id": "search-1"})
     monkeypatch.setattr(
         expansion_api,
         "get_candidates",
-        lambda _db, _search_id: [
+        lambda _db, _search_id, **_kw: [
             {"id": "candidate-1", "search_id": "search-1", "district": "Olaya"}
         ],
     )
@@ -1237,7 +1237,7 @@ def test_get_search_report_accepts_lang(monkeypatch):
     monkeypatch.setattr(
         expansion_api,
         "get_recommendation_report",
-        lambda _db, _search_id: {
+        lambda _db, _search_id, **_kw: {
             "search_id": "search-1",
             "meta": {"version": "expansion_advisor_v7"},
             "recommendation": {
@@ -1272,7 +1272,7 @@ def test_compare_endpoint_accepts_lang(monkeypatch):
     monkeypatch.setattr(
         expansion_api,
         "compare_candidates",
-        lambda _db, _search_id, _candidate_ids: {
+        lambda _db, _search_id, _candidate_ids, **_kw: {
             "items": [{"candidate_id": "c1"}, {"candidate_id": "c2"}],
             "summary": {"best_overall_candidate_id": "c1"},
         },
@@ -1303,7 +1303,7 @@ def test_candidate_memo_endpoint_accepts_lang(monkeypatch):
     monkeypatch.setattr(
         expansion_api,
         "get_candidate_memo",
-        lambda _db, _candidate_id: {
+        lambda _db, _candidate_id, **_kw: {
             "candidate_id": "c1",
             "search_id": "search-1",
             "brand_profile": {},

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -398,14 +398,14 @@ def test_run_expansion_search_caches_rent_resolution_by_district(monkeypatch, di
     assert len(calls) == 2
 
 
-def test_report_happy_path_returns_best_and_runner_up():
+def test_report_happy_path_returns_best_and_runner_up(monkeypatch):
     db = FakeDB(candidate_rows=[], brand_profile_row={"price_tier": "mid", "preferred_districts_json": [], "excluded_districts_json": []})
     import app.services.expansion_advisor as svc
-    svc.get_search = lambda _db, _sid: {"id": "search-1", "service_model": "qsr", "brand_profile": {"expansion_goal": "balanced"}}
-    svc.get_candidates = lambda _db, _sid, district_lookup=None: [
+    monkeypatch.setattr(svc, "get_search", lambda _db, _sid, **_kw: {"id": "search-1", "service_model": "qsr", "brand_profile": {"expansion_goal": "balanced"}})
+    monkeypatch.setattr(svc, "get_candidates", lambda _db, _sid, district_lookup=None, **_kw: [
         {"id": "c1", "final_score": 90, "brand_fit_score": 82, "economics_score": 70, "area_m2": 170, "district": "Olaya", "key_risks_json": ["risk"]},
         {"id": "c2", "final_score": 86, "brand_fit_score": 79, "economics_score": 68, "area_m2": 180, "district": "Malqa", "key_risks_json": ["risk2"]},
-    ]
+    ])
     report = get_recommendation_report(db, "search-1")
     assert report is not None
     assert report["recommendation"]["best_candidate_id"] == "c1"
@@ -494,14 +494,14 @@ def test_comparable_competitors_payload_shape():
     assert {"id", "name", "category", "district", "rating", "review_count", "distance_m", "source"}.issubset(items[0].keys())
 
 
-def test_report_includes_new_decision_outputs():
+def test_report_includes_new_decision_outputs(monkeypatch):
     db = FakeDB(candidate_rows=[])
     import app.services.expansion_advisor as svc
-    svc.get_search = lambda _db, _sid: {"id": "search-1", "service_model": "qsr", "brand_profile": {"expansion_goal": "balanced"}}
-    svc.get_candidates = lambda _db, _sid, district_lookup=None: [
+    monkeypatch.setattr(svc, "get_search", lambda _db, _sid, **_kw: {"id": "search-1", "service_model": "qsr", "brand_profile": {"expansion_goal": "balanced"}})
+    monkeypatch.setattr(svc, "get_candidates", lambda _db, _sid, district_lookup=None, **_kw: [
         {"id": "c1", "final_score": 90, "brand_fit_score": 82, "economics_score": 70, "area_m2": 170, "district": "Olaya", "key_risks_json": ["risk"], "confidence_grade": "A", "confidence_score": 85, "gate_status_json": {"overall_pass": True}, "demand_thesis": "d", "cost_thesis": "c", "comparable_competitors_json": [{"id": "x"}], "zoning_fit_score": 88, "frontage_score": 65, "access_score": 67, "parking_score": 62, "access_visibility_score": 66, "feature_snapshot_json": {"parcel_area_m2": 170, "data_completeness_score": 90}, "rank_position": 1, "score_breakdown_json": {"final_score": 90}, "top_positives_json": ["pos"], "top_risks_json": ["risk"]},
         {"id": "c2", "final_score": 86, "brand_fit_score": 79, "economics_score": 68, "area_m2": 180, "district": "Malqa", "key_risks_json": ["risk2"], "confidence_grade": "B", "confidence_score": 72, "gate_status_json": {"overall_pass": False}, "demand_thesis": "d2", "cost_thesis": "c2", "comparable_competitors_json": [], "zoning_fit_score": 78, "frontage_score": 61, "access_score": 60, "parking_score": 58, "access_visibility_score": 61, "feature_snapshot_json": {"parcel_area_m2": 180, "data_completeness_score": 80}, "rank_position": 2, "score_breakdown_json": {"final_score": 86}, "top_positives_json": ["pos2"], "top_risks_json": ["risk2"]},
-    ]
+    ])
     report = get_recommendation_report(db, "search-1")
     assert report["recommendation"]["best_pass_candidate_id"] == "c1"
     assert report["recommendation"]["best_confidence_candidate_id"] == "c1"
@@ -1642,7 +1642,7 @@ def test_large_parcel_not_favored_when_target_is_small():
     assert area_fit_250 > area_fit_500, "250 m² should score better than 500 m²"
 
 
-def test_report_best_pass_candidate_id_null_when_no_pass():
+def test_report_best_pass_candidate_id_null_when_no_pass(monkeypatch):
     """get_recommendation_report() must set best_pass_candidate_id = None when
     no candidates pass all gates."""
     import app.services.expansion_advisor as svc
@@ -1652,13 +1652,13 @@ def test_report_best_pass_candidate_id_null_when_no_pass():
         "preferred_districts_json": [],
         "excluded_districts_json": [],
     })
-    svc.get_search = lambda _db, _sid: {
+    monkeypatch.setattr(svc, "get_search", lambda _db, _sid, **_kw: {
         "id": "search-1",
         "service_model": "qsr",
         "brand_profile": {"expansion_goal": "balanced"},
-    }
+    })
     # Both candidates have overall_pass=False
-    svc.get_candidates = lambda _db, _sid, district_lookup=None: [
+    monkeypatch.setattr(svc, "get_candidates", lambda _db, _sid, district_lookup=None, **_kw: [
         {
             "id": "c1", "final_score": 75, "brand_fit_score": 60, "economics_score": 55,
             "area_m2": 200, "district": "Olaya", "key_risks_json": ["risk"],
@@ -1679,7 +1679,7 @@ def test_report_best_pass_candidate_id_null_when_no_pass():
             "top_positives_json": [], "top_risks_json": ["risk2"],
             "feature_snapshot_json": {"parcel_area_m2": 180, "data_completeness_score": 60},
         },
-    ]
+    ])
 
     report = get_recommendation_report(db, "search-1")
 
@@ -1799,7 +1799,7 @@ def test_score_breakdown_has_display_structure():
             f"{name}: weighted_points should differ from weight_percent unless input is 100"
 
 
-def test_report_gate_verdict_uses_tristate():
+def test_report_gate_verdict_uses_tristate(monkeypatch):
     """top_candidates[].gate_verdict in reports must use tri-state mapping,
     not bool()."""
     import app.services.expansion_advisor as svc
@@ -1809,12 +1809,12 @@ def test_report_gate_verdict_uses_tristate():
         "preferred_districts_json": [],
         "excluded_districts_json": [],
     })
-    svc.get_search = lambda _db, _sid: {
+    monkeypatch.setattr(svc, "get_search", lambda _db, _sid, **_kw: {
         "id": "search-1",
         "service_model": "qsr",
         "brand_profile": {"expansion_goal": "balanced"},
-    }
-    svc.get_candidates = lambda _db, _sid, district_lookup=None: [
+    })
+    monkeypatch.setattr(svc, "get_candidates", lambda _db, _sid, district_lookup=None, **_kw: [
         {
             "id": "c1", "final_score": 85, "brand_fit_score": 70, "economics_score": 65,
             "area_m2": 200, "district": "Olaya", "key_risks_json": ["risk"],
@@ -1825,7 +1825,7 @@ def test_report_gate_verdict_uses_tristate():
             "top_positives_json": ["pos"], "top_risks_json": ["risk"],
             "feature_snapshot_json": {"parcel_area_m2": 200, "data_completeness_score": 80},
         },
-    ]
+    ])
 
     report = get_recommendation_report(db, "search-1")
 
@@ -1954,20 +1954,22 @@ def test_derive_site_fit_context_empty_snapshot():
     assert ctx["parking_score_mode"] == "estimated"
 
 
-def test_report_compatible_with_legacy_two_arg_get_candidates():
+def test_report_compatible_with_legacy_two_arg_get_candidates(monkeypatch):
     """get_recommendation_report must work when get_candidates is a 2-arg callable (legacy monkeypatch)."""
     db = FakeDB(candidate_rows=[])
     import app.services.expansion_advisor as svc
-    svc.get_search = lambda _db, _sid: {
+    monkeypatch.setattr(svc, "get_search", lambda _db, _sid, **_kw: {
         "id": "search-1",
         "service_model": "qsr",
         "brand_profile": {"expansion_goal": "balanced"},
-    }
-    # Legacy 2-arg callable — must not raise TypeError
-    svc.get_candidates = lambda _db, _sid: [
+    })
+    # Legacy 2-arg callable — must not raise TypeError. get_recommendation_report
+    # falls back to the 2-arg call form when the lang/district_lookup kwargs
+    # are rejected.
+    monkeypatch.setattr(svc, "get_candidates", lambda _db, _sid: [
         {"id": "c1", "final_score": 80, "brand_fit_score": 70, "economics_score": 60,
          "area_m2": 150, "district": "Olaya", "key_risks_json": []},
-    ]
+    ])
     report = get_recommendation_report(db, "search-1")
     assert report is not None
     assert report["recommendation"]["best_candidate_id"] == "c1"

--- a/tests/test_expansion_saved_search_api.py
+++ b/tests/test_expansion_saved_search_api.py
@@ -117,10 +117,10 @@ def test_saved_search_404_paths(monkeypatch):
     db = DummyDB()
     from app.api import expansion_advisor as api
 
-    monkeypatch.setattr(api, "get_search", lambda *_: None)
-    monkeypatch.setattr(api, "get_saved_search", lambda *_: None)
-    monkeypatch.setattr(api, "update_saved_search", lambda *_: None)
-    monkeypatch.setattr(api, "delete_saved_search", lambda *_: False)
+    monkeypatch.setattr(api, "get_search", lambda *_, **_kw: None)
+    monkeypatch.setattr(api, "get_saved_search", lambda *_, **_kw: None)
+    monkeypatch.setattr(api, "update_saved_search", lambda *_, **_kw: None)
+    monkeypatch.setattr(api, "delete_saved_search", lambda *_, **_kw: False)
 
     client = _client(db)
     try:
@@ -302,14 +302,17 @@ def test_patch_saved_search_accepts_lang(monkeypatch):
 
 
 def test_patch_saved_search_does_not_pass_lang_to_update(monkeypatch):
-    """R3: `lang` must be popped from the payload before it reaches
-    update_saved_search — it is not a persisted saved-search column."""
+    """`lang` must be popped from the persisted payload before it reaches
+    update_saved_search — it is not a saved-search column. PR #2b passes
+    `lang` as a separate keyword argument (the Arabic read path), never
+    inside `payload`."""
     from app.api import expansion_advisor as api
 
     captured = {}
 
-    def _spy_update(_db, _saved_id, payload):
+    def _spy_update(_db, _saved_id, payload, lang="en"):
         captured["payload"] = payload
+        captured["lang"] = lang
         return dict(_SAVED_ROW)
 
     monkeypatch.setattr(api, "update_saved_search", _spy_update)
@@ -327,3 +330,5 @@ def test_patch_saved_search_does_not_pass_lang_to_update(monkeypatch):
     assert "payload" in captured
     assert "lang" not in captured["payload"]
     assert captured["payload"]["title"] == "Renamed"
+    # PR #2b: lang reaches update_saved_search as a separate kwarg.
+    assert captured["lang"] == "ar"

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -752,10 +752,21 @@ class TestRenderPromptFailedGate:
 
     def test_failed_gate_triggers_failure_addendum_and_base_rule_sections(self):
         cand = dict(BASE_STRUCTURED_CANDIDATE)
-        cand["gate_status_json"] = [
-            {"gate": "zoning fit", "verdict": "fail", "reason": "C-2 not allowed on this parcel"},
-            {"gate": "rent_reasonable", "verdict": "pass", "reason": "ok"},
-        ]
+        # Realistic production shape: gate_status_json is the flat
+        # raw-keyed bool/None map; gate_reasons_json is the bucketed
+        # humanized view. PR #2b's blocking/advisory split resolves the
+        # raw key (zoning_fit_pass) from gate_status_json.
+        cand["gate_status_json"] = {
+            "overall_pass": False,
+            "zoning_fit_pass": False,
+            "economics_pass": True,
+        }
+        cand["gate_reasons_json"] = {
+            "passed": ["economics"],
+            "failed": ["zoning fit"],
+            "unknown": [],
+            "explanations": {"zoning fit": "C-2 not allowed on this parcel"},
+        }
 
         ctx = build_memo_context(candidate=cand, brief=BASE_STRUCTURED_BRIEF, lang="en")
         messages = render_structured_memo_prompt(ctx)

--- a/tests/test_pr2b_arabic_render.py
+++ b/tests/test_pr2b_arabic_render.py
@@ -1,0 +1,292 @@
+"""PR #2b — Arabic read-path render tests.
+
+Covers the new ``expansion_advisor_i18n`` module and the ``lang="ar"``
+branch of ``_normalize_candidate_payload``:
+
+  - structured records render to Arabic;
+  - NULL structured columns fall back to the English persisted column
+    (discipline rule #4);
+  - ``humanize_gate(key, "en")`` reproduces ``_gate_key_to_label`` for
+    every gate key (the 12 ``gate_*`` golden fixtures pin this);
+  - the third lockstep leg — re-rendering a structured record through
+    the i18n module's ``en`` template equals the producer's English
+    string — for every PR #2a golden fixture;
+  - ``render`` degrades gracefully (returns "") on unknown ids /
+    missing params.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.expansion_advisor import (
+    _gate_key_to_label,
+    _normalize_candidate_payload,
+)
+from app.services.expansion_advisor_i18n import (
+    GATE_LABELS,
+    TEMPLATES,
+    humanize_gate,
+    render,
+)
+
+PR2_GOLDEN = Path(__file__).parent / "fixtures" / "pr2_golden"
+
+
+# Minimal params per template id so render() produces a non-empty string.
+_MINIMAL_PARAMS: dict[str, dict] = {
+    "pos.well_separated_branch": {"nearest_km": 5.5},
+    "risk.gate_failed": {"gate_key": "parking_pass"},
+    "risk.gate_unknown": {"gate_key": "parking_pass"},
+    "risk.area_near_min": {"area_m2": 90.0},
+    "risk.area_near_max": {"area_m2": 480.0},
+    "risk.nearest_branch_close": {"nearest_km": 1.2},
+    "risk.high_competitor_density": {"count": 9},
+    "demand_thesis": {
+        "demand_score": 80.0,
+        "population_reach": 12000.0,
+        "demand_label": "strong",
+        "provider_label": "dense",
+        "whitespace_label": "attractive",
+        "competition_label": "intense",
+    },
+    "cost_thesis": {
+        "estimated_rent_sar_m2_year": 1200.0,
+        "estimated_annual_rent_sar": 240000.0,
+        "estimated_fitout_cost_sar": 300000.0,
+    },
+    "decision_summary": {
+        "area_label": "compact",
+        "district_label": "Al Olaya",
+        "final_score": 70.0,
+        "economics_score": 60.0,
+        "use_case": "neighborhood_qsr",
+        "risk_kind": "execution",
+        "risk_text_en": "",
+    },
+}
+
+
+# ── i18n module: structural completeness ────────────────────────────
+
+@pytest.mark.parametrize("tid", sorted(TEMPLATES.keys()))
+def test_every_template_renders_non_empty_en(tid: str) -> None:
+    """Every TEMPLATES id renders a non-empty English string with its
+    producer-shaped params — proves there are no template typos."""
+    params = _MINIMAL_PARAMS.get(tid, {})
+    assert render({"id": tid, "params": params}, "en"), f"empty en render for {tid}"
+
+
+@pytest.mark.parametrize("tid", sorted(TEMPLATES.keys()))
+def test_every_template_renders_non_empty_ar(tid: str) -> None:
+    """Every TEMPLATES id renders a non-empty Arabic string."""
+    params = _MINIMAL_PARAMS.get(tid, {})
+    assert render({"id": tid, "params": params}, "ar"), f"empty ar render for {tid}"
+
+
+def test_templates_count() -> None:
+    """15 pos.* + 13 risk.* (incl. the defensive K7 entry) + 3 theses."""
+    pos = [k for k in TEMPLATES if k.startswith("pos.")]
+    risk = [k for k in TEMPLATES if k.startswith("risk.")]
+    assert len(pos) == 15
+    assert len(risk) == 13
+    assert {"demand_thesis", "cost_thesis", "decision_summary"} <= set(TEMPLATES)
+    assert "risk.delivery_district_estimates" in risk  # K7, defensive
+
+
+# ── humanize_gate: en byte-identity with _gate_key_to_label ─────────
+
+def test_humanize_gate_en_matches_gate_key_to_label() -> None:
+    for key in GATE_LABELS["en"]:
+        assert humanize_gate(key, "en") == _gate_key_to_label(key)
+
+
+def test_humanize_gate_en_matches_gate_golden_fixtures() -> None:
+    """The 12 gate_* PR #2a golden fixtures pin every English label."""
+    checked = 0
+    for path in sorted(PR2_GOLDEN.glob("gate_*.json")):
+        fx = json.loads(path.read_text(encoding="utf-8"))
+        key = fx["kwargs"]["gate_key"]
+        assert humanize_gate(key, "en") == fx["expected_english"]
+        checked += 1
+    assert checked == 12
+
+
+def test_humanize_gate_ar_translates_all_12_keys() -> None:
+    for key in GATE_LABELS["en"]:
+        ar = humanize_gate(key, "ar")
+        assert ar and ar != humanize_gate(key, "en")
+
+
+def test_humanize_gate_unknown_key_fallback() -> None:
+    assert humanize_gate("some_new_gate_pass", "en") == "some new gate"
+    assert humanize_gate("some_new_gate_pass", "ar") == "some new gate"
+
+
+# ── Third lockstep leg: en render == producer English ───────────────
+
+def test_en_render_matches_pr2a_golden_producer_output() -> None:
+    """Re-rendering each PR #2a structured record through the i18n en
+    template reproduces the producer's English string byte-for-byte."""
+    failures: list[str] = []
+    checked = 0
+    for path in sorted(PR2_GOLDEN.glob("*.json")):
+        fx = json.loads(path.read_text(encoding="utf-8"))
+        structured = fx.get("expected_structured")
+        english = fx.get("expected_english")
+        if structured is None:
+            continue
+        if isinstance(structured, dict) and "id" in structured and isinstance(english, str):
+            checked += 1
+            if render(structured, "en") != english:
+                failures.append(fx["id"])
+        elif isinstance(structured, dict) and isinstance(english, dict):
+            for bucket in ("positives", "risks"):
+                for rec, eng in zip(structured.get(bucket, []), english.get(bucket, [])):
+                    checked += 1
+                    if render(rec, "en") != eng:
+                        failures.append(f"{fx['id']}:{bucket}")
+    assert not failures, f"en lockstep mismatch: {failures}"
+    assert checked > 0
+
+
+# ── Graceful degradation ────────────────────────────────────────────
+
+def test_render_unknown_id_returns_empty() -> None:
+    assert render({"id": "does.not.exist", "params": {}}, "ar") == ""
+
+
+def test_render_malformed_record_returns_empty() -> None:
+    assert render(None, "ar") == ""  # type: ignore[arg-type]
+    assert render({}, "ar") == ""
+    assert render({"params": {}}, "ar") == ""
+
+
+def test_render_missing_params_returns_empty() -> None:
+    """A thesis template missing its params can't format → "" (caller
+    falls back to the English persisted column)."""
+    assert render({"id": "demand_thesis", "params": {}}, "en") == ""
+    assert render({"id": "cost_thesis", "params": {}}, "ar") == ""
+
+
+# ── Arabic content / formatting conventions ─────────────────────────
+
+def test_demand_thesis_ar_uses_parenthetical_english_jargon() -> None:
+    rendered = render({"id": "demand_thesis", "params": _MINIMAL_PARAMS["demand_thesis"]}, "ar")
+    assert "الطلب" in rendered
+    assert "providers" in rendered      # parenthetical English jargon
+    assert "whitespace" in rendered
+    assert "12000" in rendered          # Latin digits
+
+
+def test_decision_summary_ar_suffix_for_each_risk_kind() -> None:
+    for risk_kind in ("from_key_risks", "tight_economics", "execution"):
+        params = dict(_MINIMAL_PARAMS["decision_summary"])
+        params["risk_kind"] = risk_kind
+        params["risk_text_en"] = "cannibalization risk is elevated"
+        rendered = render({"id": "decision_summary", "params": params}, "ar")
+        assert "أبرز مخاطر تجارية" in rendered, risk_kind
+
+
+def test_pos_template_ar_distinct_from_en() -> None:
+    en = render({"id": "pos.demand_strong", "params": {}}, "en")
+    ar = render({"id": "pos.demand_strong", "params": {}}, "ar")
+    assert en == "Demand potential is strong for this district."
+    assert ar == "إمكانية الطلب قوية في هذا الحي."
+
+
+# ── _normalize_candidate_payload ar branch ──────────────────────────
+
+def test_normalize_candidate_ar_renders_structured() -> None:
+    candidate = {
+        "candidate_id": "c-ar-1",
+        "parcel_id": "P-AR-1",
+        "district": "Al Olaya",
+        "top_positives_json": ["English fallback positive."],
+        "top_risks_json": ["English fallback risk."],
+        "decision_summary": "English decision summary.",
+        "demand_thesis": "English demand thesis.",
+        "cost_thesis": "English cost thesis.",
+        "top_positives_structured_json": [{"id": "pos.demand_strong", "params": {}}],
+        "top_risks_structured_json": [{"id": "risk.economics_marginal", "params": {}}],
+        "decision_summary_structured_json": {
+            "id": "decision_summary",
+            "params": {
+                "area_label": "compact",
+                "district_label": "Al Olaya",
+                "final_score": 70.0,
+                "economics_score": 60.0,
+                "use_case": "neighborhood_qsr",
+                "risk_kind": "execution",
+                "risk_text_en": "",
+            },
+        },
+        "demand_thesis_structured_json": {
+            "id": "demand_thesis",
+            "params": _MINIMAL_PARAMS["demand_thesis"],
+        },
+        "cost_thesis_structured_json": {
+            "id": "cost_thesis",
+            "params": _MINIMAL_PARAMS["cost_thesis"],
+        },
+    }
+    result = _normalize_candidate_payload(dict(candidate), lang="ar")
+    assert result["top_positives_json"] == ["إمكانية الطلب قوية في هذا الحي."]
+    assert result["top_risks_json"][0].startswith("الجدوى الاقتصادية حدّية")
+    assert "الجدوى الاقتصادية" in result["decision_summary"]
+    assert "الطلب" in result["demand_thesis"]
+    assert "الإيجار التقديري" in result["cost_thesis"]
+    # Internal structured columns never leak into the payload.
+    for col in (
+        "top_positives_structured_json",
+        "top_risks_structured_json",
+        "decision_summary_structured_json",
+        "demand_thesis_structured_json",
+        "cost_thesis_structured_json",
+    ):
+        assert col not in result
+
+
+def test_normalize_candidate_ar_falls_back_to_english_when_structured_null() -> None:
+    """Pre-PR-2a rows have NULL structured columns — the ar read path
+    must serve the English persisted column unchanged (rule #4)."""
+    candidate = {
+        "candidate_id": "c-ar-2",
+        "parcel_id": "P-AR-2",
+        "district": "Al Olaya",
+        "top_positives_json": ["English fallback positive."],
+        "top_risks_json": ["English fallback risk."],
+        "decision_summary": "English decision summary.",
+        "demand_thesis": "English demand thesis.",
+        "cost_thesis": "English cost thesis.",
+        "top_positives_structured_json": None,
+        "top_risks_structured_json": None,
+        "decision_summary_structured_json": None,
+        "demand_thesis_structured_json": None,
+        "cost_thesis_structured_json": None,
+    }
+    result = _normalize_candidate_payload(dict(candidate), lang="ar")
+    assert result["top_positives_json"] == ["English fallback positive."]
+    assert result["top_risks_json"] == ["English fallback risk."]
+    assert result["decision_summary"] == "English decision summary."
+    assert result["demand_thesis"] == "English demand thesis."
+    assert result["cost_thesis"] == "English cost thesis."
+
+
+def test_normalize_candidate_ar_partial_failure_falls_back_whole_list() -> None:
+    """If any structured positive fails to render, the whole English
+    list is served (no mixed-language list)."""
+    candidate = {
+        "candidate_id": "c-ar-3",
+        "parcel_id": "P-AR-3",
+        "top_positives_json": ["English A.", "English B."],
+        "top_positives_structured_json": [
+            {"id": "pos.demand_strong", "params": {}},
+            {"id": "does.not.exist", "params": {}},
+        ],
+    }
+    result = _normalize_candidate_payload(dict(candidate), lang="ar")
+    assert result["top_positives_json"] == ["English A.", "English B."]

--- a/tests/test_pr2b_lang_en_byte_identity.py
+++ b/tests/test_pr2b_lang_en_byte_identity.py
@@ -1,0 +1,76 @@
+"""PR #2b — read-path English byte-identity guard (discipline rule #2).
+
+PR #2b adds a ``lang`` parameter to ``_normalize_candidate_payload`` /
+``_normalize_saved_search_payload`` and the Expansion Advisor read-path
+service functions. With ``lang="en"`` or omitted, the normalized payload
+must stay byte-identical to HEAD.
+
+The golden fixtures in ``tests/fixtures/pr2b_golden/`` were captured
+against HEAD before the PR #2b edits (see ``scripts/gen_pr2b_golden.py``).
+The five internal ``*_structured_json`` columns — which PR #2b drops from
+the outgoing payload — are stripped from the captured ``expected_en`` so
+the comparison reflects the intended post-edit response shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.expansion_advisor import (
+    _normalize_candidate_payload,
+    _normalize_saved_search_payload,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "pr2b_golden"
+
+
+def _load_fixtures() -> list[dict]:
+    return [
+        json.loads(p.read_text(encoding="utf-8"))
+        for p in sorted(FIXTURE_DIR.glob("*.json"))
+    ]
+
+
+FIXTURES = _load_fixtures()
+FIXTURE_IDS = [fx["id"] for fx in FIXTURES]
+
+
+def _normalize(fx: dict, lang: str | None) -> dict:
+    if fx["kind"] == "candidate":
+        if lang is None:
+            return _normalize_candidate_payload(dict(fx["candidate"]))
+        return _normalize_candidate_payload(dict(fx["candidate"]), lang=lang)
+    if lang is None:
+        return _normalize_saved_search_payload(dict(fx["saved"]))
+    return _normalize_saved_search_payload(dict(fx["saved"]), lang=lang)
+
+
+def _jsonable(obj: object) -> object:
+    """Round-trip through JSON so the comparison matches the fixture,
+    which was itself captured via json.dumps."""
+    return json.loads(json.dumps(obj, ensure_ascii=False, default=str))
+
+
+def test_fixtures_present() -> None:
+    assert FIXTURES, "pr2b_golden fixtures missing — run scripts/gen_pr2b_golden.py"
+
+
+@pytest.mark.parametrize("fx", FIXTURES, ids=FIXTURE_IDS)
+def test_omitted_lang_byte_identical(fx: dict) -> None:
+    """Omitted lang reproduces the HEAD English payload byte-for-byte."""
+    assert _jsonable(_normalize(fx, None)) == fx["expected_en"]
+
+
+@pytest.mark.parametrize("fx", FIXTURES, ids=FIXTURE_IDS)
+def test_explicit_en_byte_identical(fx: dict) -> None:
+    """Explicit lang="en" reproduces the HEAD English payload byte-for-byte."""
+    assert _jsonable(_normalize(fx, "en")) == fx["expected_en"]
+
+
+@pytest.mark.parametrize("fx", FIXTURES, ids=FIXTURE_IDS)
+def test_omitted_equals_explicit_en(fx: dict) -> None:
+    """Omitted lang and explicit "en" are identical."""
+    assert _jsonable(_normalize(fx, None)) == _jsonable(_normalize(fx, "en"))


### PR DESCRIPTION
## Summary

Implements the read-path (PR #2b) for locale-invariant structured records persisted by PR #2a. Adds a new `expansion_advisor_i18n` module that renders structured candidate records (positives, risks, theses, decision summary) into the requested language at read time, with graceful fallback to English persisted columns when structured data is missing or malformed.

## Key Changes

- **New module `app/services/expansion_advisor_i18n.py`**: 
  - Defines `TEMPLATES` dict with 31 template IDs (15 pos.*, 13 risk.*, 3 theses) in English and Arabic
  - Implements `render(record, lang)` to format structured records with parameters into localized strings
  - Implements `humanize_gate(key, lang)` to translate gate keys into human-readable labels
  - Includes `GATE_LABELS` dict mapping all 12 gate keys to English and Arabic labels
  - Arabic translations follow documented conventions: Latin digits, English units inline, em-dashes preserved, domain-specific terminology ("معيار" for "gate")

- **Updated `app/services/expansion_advisor.py`**:
  - Added `lang` parameter to `_normalize_candidate_payload()` and `_normalize_saved_search_payload()` (defaults to "en" for backward compatibility)
  - Refactored `_gate_key_to_label()` to delegate to `humanize_gate()` from i18n module for single source of truth
  - Added `_render_structured_list()` and `_render_structured_field()` helpers to render structured records with fallback to English persisted columns
  - Strips five internal `*_structured_json` columns from outgoing payloads (rule §2.1)
  - Gate humanization now respects the requested language throughout the normalization pipeline

- **Updated `app/services/llm_decision_memo.py`**:
  - Changed `_hard_fail_gate_labels()` to `_hard_fail_gate_keys()` to compare on raw gate keys instead of humanized labels
  - Ensures gate blocking/advisory split is language-independent

- **Updated `app/api/expansion_advisor.py`**:
  - Passes `lang` parameter through to service functions

- **Comprehensive test coverage**:
  - `tests/test_pr2b_arabic_render.py`: Tests Arabic rendering, gate humanization, fallback behavior, and graceful degradation
  - `tests/test_pr2b_lang_en_byte_identity.py`: Enforces English read-path byte-identity with HEAD (discipline rule #2)
  - Golden fixtures in `tests/fixtures/pr2b_golden/`: Captures expected output for 10 candidate scenarios and 1 saved search scenario
  - `scripts/gen_pr2b_golden.py`: Script to regenerate golden fixtures against HEAD

- **Updated existing tests**:
  - Modified `test_expansion_advisor_service.py`, `test_expansion_advisor_api.py`, `test_expansion_saved_search_api.py`, `test_llm_decision_memo.py` to pass `lang` parameter where needed

## Implementation Details

- **Fallback strategy**: When a structured record is NULL or fails to render, the English persisted column is used (rule #4 spirit — never degrade below English baseline)
- **Template composition**: `decision_summary` uses non-standard dict keys (`en_main`, `en_suffix_*`, `ar_main`, `ar_suffix_*`) to support conditional suffix logic; `render()` handles this in a dedicated branch
- **Gate label consistency**: `humanize_gate(key, "en")` reproduces legacy `_GATE_HUMAN_LABELS` lookup + fallback byte-for-byte; all 12 gate keys have explicit Arabic translations
- **Graceful degradation**: `render()` returns empty string on unknown template IDs or missing required params (never raises)
- **Backward compatibility**: All service functions default to `lang="en"` when not specified; English output is byte-identical to HEAD

## Testing & Validation

- Every template ID renders non

https://claude.ai/code/session_01JtB86LgLAidxodtzU2y3Pp