### PR TITLE
ci: smoke-pr2b validator — accept empty lists, dump E bare-field contents

### DIFF
--- a/.github/workflows/smoke-pr2b.yml
+++ b/.github/workflows/smoke-pr2b.yml
@@ -165,22 +165,31 @@ jobs:
               return [c for c in LEAK_COLS if c in cand]
 
           def check_populated(cand):
-              """Return (populated_count, total, problems)."""
+              """Return (populated_count, total, problems).
+
+              LIST_FIELDS: a list (including []) counts as populated — an
+              empty list is a valid output for a candidate with no
+              recorded positives/risks. None / absent key is a real miss;
+              any other type is a type error.
+              STR_FIELDS: only a non-empty string counts as populated.
+              """
               total = len(LIST_FIELDS) + len(STR_FIELDS)
               ok = 0
               problems = []
               for f in LIST_FIELDS:
                   v = cand.get(f)
-                  if isinstance(v, list) and len(v) >= 1:
+                  if isinstance(v, list):
                       ok += 1
+                  elif v is None:
+                      problems.append(f"'{f}' (None)")
                   else:
-                      problems.append(f)
+                      problems.append(f"'{f}' (wrong type)")
               for f in STR_FIELDS:
                   v = cand.get(f)
                   if isinstance(v, str) and len(v) >= 1:
                       ok += 1
                   else:
-                      problems.append(f)
+                      problems.append(f"'{f}'")
               return ok, total, problems
 
           def has_arabic(cand):
@@ -189,6 +198,19 @@ jobs:
                   if isinstance(v, str) and ARABIC.search(v):
                       return True
               return False
+
+          _API_KEY = os.environ.get("PROD_API_KEY") or ""
+
+          def preview(v):
+              """200-char masked preview of a bare field for the E dump."""
+              if v is None:
+                  return "<NULL>"
+              if isinstance(v, str) and len(v) == 0:
+                  return "<EMPTY>"
+              s = str(v)
+              if _API_KEY:
+                  s = s.replace(_API_KEY, "***")
+              return s[:200]
 
           details = []
           fail_reasons = []
@@ -218,7 +240,7 @@ jobs:
                   details.append(
                       f"  - B cand[{i}] {cand.get('candidate_id', cand.get('id', '?'))}: "
                       f"{ok}/{total} fields"
-                      + (f", MISSING {problems}" if problems else "")
+                      + (f", MISSING [{', '.join(problems)}]" if problems else "")
                       + (f", LEAK {leaks}" if leaks else ", no leak")
                   )
               if pop_ok != len(b_cands):
@@ -283,7 +305,7 @@ jobs:
                       f"  - D cand[{i}] {cand.get('candidate_id', cand.get('id', '?'))}: "
                       f"{ok}/{total} fields, "
                       + ("Arabic present" if arabic else "NO Arabic")
-                      + (f", MISSING {problems}" if problems else "")
+                      + (f", MISSING [{', '.join(problems)}]" if problems else "")
                       + (f", LEAK {leaks}" if leaks else ", no leak")
                   )
               if pop_ok != len(d_cands):
@@ -327,11 +349,35 @@ jobs:
                   stayed_en = bare_present and not arabic
                   if stayed_en:
                       en_ok += 1
-                  details.append(
+                  header = (
                       f"  - E cand[{i}] {cand.get('candidate_id', cand.get('id', '?'))}: "
                       + ("3/3 bare fields, English" if stayed_en else "did NOT stay English")
                       + (f", LEAK {leaks}" if leaks else ", no leak")
                   )
+                  details.append(header)
+                  if not stayed_en:
+                      # Dump the raw bare-field content so AR_FALLBACK_TO_EN
+                      # misses are diagnosable: distinguishes genuine Arabic
+                      # rendering from has_arabic catching Arabic proper
+                      # nouns embedded in otherwise-English text.
+                      print(header)
+                      arabic_chars = 0
+                      total_chars = 0
+                      for f in STR_FIELDS:
+                          v = cand.get(f)
+                          if isinstance(v, str):
+                              arabic_chars += len(ARABIC.findall(v))
+                              total_chars += len(v)
+                      dump = [
+                          f"      decision_summary: {preview(cand.get('decision_summary'))}",
+                          f"      demand_thesis:    {preview(cand.get('demand_thesis'))}",
+                          f"      cost_thesis:      {preview(cand.get('cost_thesis'))}",
+                          f"      arabic_chars: {arabic_chars} / total_chars: {total_chars}"
+                          "  (so we can see the ratio)",
+                      ]
+                      for line in dump:
+                          details.append(line)
+                          print(line)
               if e_leak:
                   fail_reasons.append("E structured-column leak")
               ar_fallback = "pass" if en_ok == len(e_cands) and e_cands else "fail"


### PR DESCRIPTION
## Validator-only change

This PR touches **only** `.github/workflows/smoke-pr2b.yml`, "Validate and summarize" step. **Application code is untouched.** The contract for inputs, secrets, curls, URLs, and summary structure is unchanged. No new curls were added; `has_arabic`, `BEARER_PARITY`, leak-check, masking, secrets, inputs, concurrency, and permissions are all unchanged. Verdict logic changes only where Change 1's relaxed populate check requires it.

### Why

Run #4 shows PR-2b working: B/D 14/15 candidates at 5/5, AR_RENDER 15/15, BEARER_PARITY pass, zero leaks. Two false-positive-looking results remain:

1. `cand[11]` is flagged for a missing `top_risks_json` in **both** English and Arabic — that's a data characteristic of that candidate (no recorded risks), not a regression. An empty list is a valid output; the validator was treating it as a miss.
2. E AR fallback returned 1/12 "stayed English". Likely a false positive from `has_arabic`'s naive `[؀-ۿ]` regex catching Arabic proper nouns (Riyadh district names, brand names) embedded in otherwise-English text. We need the raw field content to confirm before touching `has_arabic`.

### Change 1 — accept empty lists in LIST_FIELDS

`check_populated` now distinguishes:

- `cand.get(f)` is `None` or key absent → not populated (real miss)
- `cand.get(f)` is a `list` (including `[]`) → populated
- `cand.get(f)` is anything else → not populated (type error)

`STR_FIELDS` is unchanged — empty/null strings still count as not populated. `MISSING` labels now show the reason: `MISSING ['top_risks_json' (None)]` vs `MISSING ['top_risks_json' (wrong type)]`.

```diff
           def check_populated(cand):
-              """Return (populated_count, total, problems)."""
+              """Return (populated_count, total, problems).
+
+              LIST_FIELDS: a list (including []) counts as populated — an
+              empty list is a valid output for a candidate with no
+              recorded positives/risks. None / absent key is a real miss;
+              any other type is a type error.
+              STR_FIELDS: only a non-empty string counts as populated.
+              """
               total = len(LIST_FIELDS) + len(STR_FIELDS)
               ok = 0
               problems = []
               for f in LIST_FIELDS:
                   v = cand.get(f)
-                  if isinstance(v, list) and len(v) >= 1:
+                  if isinstance(v, list):
                       ok += 1
-                  else:
-                      problems.append(f)
+                  elif v is None:
+                      problems.append(f"'{f}' (None)")
+                  else:
+                      problems.append(f"'{f}' (wrong type)")
               for f in STR_FIELDS:
                   v = cand.get(f)
                   if isinstance(v, str) and len(v) >= 1:
                       ok += 1
                   else:
-                      problems.append(f)
+                      problems.append(f"'{f}'")
               return ok, total, problems
```

B/D detail lines now render `MISSING [{', '.join(problems)}]`.

### Change 2 — dump E bare fields when "did NOT stay English" fires

For each E candidate that fails `stayed_en`, follow-up detail lines are appended with the raw `decision_summary`, `demand_thesis`, `cost_thesis` content (truncated to 200 chars, `<NULL>`/`<EMPTY>` markers), plus arabic/total char counts. `${PROD_API_KEY}` is masked to `***` in field content as defence in depth. Lines go to both `$GITHUB_STEP_SUMMARY` and stdout.

```diff
+          _API_KEY = os.environ.get("PROD_API_KEY") or ""
+
+          def preview(v):
+              """200-char masked preview of a bare field for the E dump."""
+              if v is None:
+                  return "<NULL>"
+              if isinstance(v, str) and len(v) == 0:
+                  return "<EMPTY>"
+              s = str(v)
+              if _API_KEY:
+                  s = s.replace(_API_KEY, "***")
+              return s[:200]
```

```diff
+                  header = (
                       f"  - E cand[{i}] {cand.get('candidate_id', cand.get('id', '?'))}: "
                       + ("3/3 bare fields, English" if stayed_en else "did NOT stay English")
                       + (f", LEAK {leaks}" if leaks else ", no leak")
                   )
+                  details.append(header)
+                  if not stayed_en:
+                      print(header)
+                      arabic_chars = 0
+                      total_chars = 0
+                      for f in STR_FIELDS:
+                          v = cand.get(f)
+                          if isinstance(v, str):
+                              arabic_chars += len(ARABIC.findall(v))
+                              total_chars += len(v)
+                      dump = [
+                          f"      decision_summary: {preview(cand.get('decision_summary'))}",
+                          f"      demand_thesis:    {preview(cand.get('demand_thesis'))}",
+                          f"      cost_thesis:      {preview(cand.get('cost_thesis'))}",
+                          f"      arabic_chars: {arabic_chars} / total_chars: {total_chars}"
+                          "  (so we can see the ratio)",
+                      ]
+                      for line in dump:
+                          details.append(line)
+                          print(line)
```

### Effect

- **Change 1** moves `B fields not fully populated` from fail → pass for `cand[11]` (legitimately empty `top_risks_json`). B and D should report 15/15.
- **Change 2** makes `AR_FALLBACK_TO_EN` diagnosable on the next run: if dumped content is English with Arabic proper nouns, `has_arabic` is the bug; if genuinely Arabic-rendered, that's a real PR-2b finding.

No follow-up PR will be opened until the next run's output is read.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WdGt4TjhGPFEuhTaNPFm3r)_