### PR TITLE
feat(expansion_advisor): PR #3 — structured strengths/risks + Arabic read-path for secondary leaks

### DIFF
--- a/alembic/versions/20260518_ea_strengths_risks_structured.py
+++ b/alembic/versions/20260518_ea_strengths_risks_structured.py
@@ -1,0 +1,43 @@
+"""Expansion advisor structured strengths/risks columns (PR #3)
+
+Adds two nullable JSONB columns on expansion_candidate so the
+_build_strengths_and_risks producer can persist locale-invariant
+structured records alongside its existing English string lists. The
+Arabic read path renders them in _normalize_candidate_payload. Purely
+additive — no existing column is modified, renamed, or dropped, and no
+rows are backfilled (pre-PR-3 rows keep these columns NULL and the
+Arabic read path falls back to the persisted English text).
+
+Revision ID: 20260518_ea_strengths_risks
+Revises: 20260516_ea_structured_inputs
+Create Date: 2026-05-18 00:00:00.000000
+
+NOTE: the revision id is kept <= 32 chars to fit alembic_version.version_num.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "20260518_ea_strengths_risks"
+down_revision = "20260516_ea_structured_inputs"
+branch_labels = None
+depends_on = None
+
+
+_COLS = (
+    "key_strengths_structured_json",
+    "key_risks_structured_json",
+)
+
+
+def upgrade() -> None:
+    for col in _COLS:
+        op.add_column("expansion_candidate", sa.Column(col, JSONB, nullable=True))
+
+
+def downgrade() -> None:
+    for col in reversed(_COLS):
+        op.drop_column("expansion_candidate", col)

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -1237,6 +1237,9 @@ _STRUCTURED_CANDIDATE_COLS: tuple[str, ...] = (
     "decision_summary_structured_json",
     "demand_thesis_structured_json",
     "cost_thesis_structured_json",
+    # PR #3 structured strengths/risks.
+    "key_strengths_structured_json",
+    "key_risks_structured_json",
 )
 
 
@@ -1313,6 +1316,20 @@ def _normalize_candidate_payload(
         payload["cost_thesis"] = _render_structured_one(
             candidate.get("cost_thesis_structured_json"),
             payload.get("cost_thesis"), lang)
+        # PR #3: localize the strengths/risks string lists. These columns
+        # feed the four secondary leak paths (candidate.key_strengths /
+        # key_risks / main_watchout / main_risk) downstream. Guarded on
+        # presence so compare_candidates — which passes neither column
+        # (Q2 deferral) — is untouched. NULL structured columns (pre-PR-3
+        # rows) fall back to the persisted English list (rule #4).
+        if "key_strengths_json" in payload:
+            payload["key_strengths_json"] = _render_structured_list(
+                candidate.get("key_strengths_structured_json"),
+                payload.get("key_strengths_json"), lang)
+        if "key_risks_json" in payload:
+            payload["key_risks_json"] = _render_structured_list(
+                candidate.get("key_risks_structured_json"),
+                payload.get("key_risks_json"), lang)
     else:
         # byte-identical to HEAD
         payload["top_positives_json"] = payload.get("top_positives_json") or []
@@ -5494,22 +5511,36 @@ def _build_strengths_and_risks(
     fit_score: float,
     cannibalization_score: float,
     rent_source: str,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], list[dict[str, Any]], list[dict[str, Any]]]:
     strengths: list[str] = []
     risks: list[str] = []
+    # PR #3: parallel locale-invariant structured records. The English
+    # append literals below are byte-untouched; the structured side
+    # mirrors the same six firing conditions in the same order
+    # (deliberately NOT DRY'd — same convention as
+    # _recommended_use_case / _recommended_use_case_token). All six
+    # conditions are zero-param, so params is always {}.
+    strengths_structured: list[dict[str, Any]] = []
+    risks_structured: list[dict[str, Any]] = []
     if demand_score >= 70:
         strengths.append("High demand index supports branch throughput")
+        strengths_structured.append({"id": "S1", "params": {}})
     if whitespace_score >= 65:
         strengths.append("Competitive whitespace remains attractive")
+        strengths_structured.append({"id": "S2", "params": {}})
     if fit_score >= 70:
         strengths.append("Parcel characteristics align with target format")
+        strengths_structured.append({"id": "S3", "params": {}})
     if rent_source == "conservative_default":
         risks.append("Rent benchmark fell back to conservative city default (lower confidence)")
+        risks_structured.append({"id": "R1", "params": {}})
     if cannibalization_score >= 70:
         risks.append("High overlap risk with existing branches")
+        risks_structured.append({"id": "R2", "params": {}})
     if whitespace_score <= 45:
         risks.append("Competitive density may pressure launch economics")
-    return strengths[:4], risks[:4]
+        risks_structured.append({"id": "R3", "params": {}})
+    return strengths[:4], risks[:4], strengths_structured[:4], risks_structured[:4]
 
 
 def _recommended_use_case(service_model: str, area_m2: float) -> str:
@@ -5546,6 +5577,7 @@ def _decision_summary(
     key_risks: list[str],
     service_model: str,
     area_m2: float,
+    key_risks_structured: list[dict[str, Any]] | None = None,
 ) -> tuple[str, dict[str, Any]]:
     area_label = "compact" if area_m2 < 180 else "standard"
     district_label = district or "the target district"
@@ -5577,9 +5609,10 @@ def _decision_summary(
         risk_kind = "tight_economics"
     else:
         risk_kind = "execution"
-    # risk_text_en is the deferred parity bridge for _build_strengths_and_risks
-    # (out of scope for PR #2; tracked for PR #3). When PR #3 brings strengths/risks
-    # into structured inputs, this field becomes redundant and should be removed.
+    # risk_text_en is retained as the dual-read bridge: post-PR-2a-pre-PR-3
+    # rows carry only risk_text_en, and the ar renderer falls back to it
+    # when no risk_id is present (PR #3 Q3). PR #3 adds the sibling
+    # risk_id below so post-PR-3 rows render a localized Arabic clause.
     structured = {
         "id": "decision_summary",
         "params": {
@@ -5592,6 +5625,14 @@ def _decision_summary(
             "risk_text_en": risk_text,
         },
     }
+    # PR #3: when the risk clause is spliced from key_risks, persist the
+    # structured risk id (index-aligned with key_risks — both lists are
+    # built from the same six firing conditions in _build_strengths_and_risks)
+    # so the Arabic read path can render a localized clause.
+    if risk_kind == "from_key_risks" and key_risks_structured:
+        _first_risk = key_risks_structured[0]
+        if isinstance(_first_risk, dict) and _first_risk.get("id"):
+            structured["params"]["risk_id"] = _first_risk["id"]
     return summary, structured
 
 
@@ -8975,7 +9016,12 @@ def run_expansion_search(
         if isinstance(score_breakdown_json, dict):
             score_breakdown_json.setdefault("economics_detail", {}).update(economics_meta)
         final_score = _safe_float(score_breakdown_json.get("final_score"))
-        key_strengths_json, key_risks_json = _build_strengths_and_risks(
+        (
+            key_strengths_json,
+            key_risks_json,
+            key_strengths_structured,
+            key_risks_structured,
+        ) = _build_strengths_and_risks(
             demand_score=demand_score,
             whitespace_score=whitespace_score,
             fit_score=fit_score,
@@ -9095,6 +9141,7 @@ def run_expansion_search(
             key_risks=key_risks_json,
             service_model=service_model,
             area_m2=area_m2,
+            key_risks_structured=key_risks_structured,
         )
 
         # ── Advisory-grade snapshot plumbing (PR #1) ──
@@ -9276,6 +9323,9 @@ def run_expansion_search(
                 "decision_summary": decision_summary,
                 "key_risks_json": key_risks_json,
                 "key_strengths_json": key_strengths_json,
+                # PR #3: parallel structured records for the Arabic read path.
+                "key_strengths_structured_json": key_strengths_structured,
+                "key_risks_structured_json": key_risks_structured,
                 "final_score": round(final_score, 2),
                 "explanation": explanation,
                 "zoning_signal_source": zoning_source,
@@ -9508,6 +9558,8 @@ def run_expansion_search(
             decision_summary,
             key_risks_json,
             key_strengths_json,
+            key_strengths_structured_json,
+            key_risks_structured_json,
             compare_rank,
             rank_position,
             explanation,
@@ -9579,6 +9631,8 @@ def run_expansion_search(
             :decision_summary,
             CAST(:key_risks_json AS jsonb),
             CAST(:key_strengths_json AS jsonb),
+            CAST(:key_strengths_structured_json AS jsonb),
+            CAST(:key_risks_structured_json AS jsonb),
             :compare_rank,
             :rank_position,
             CAST(:explanation AS jsonb),
@@ -9608,6 +9662,8 @@ def run_expansion_search(
             "explanation": json.dumps(_sanitize_for_json(candidate["explanation"]), ensure_ascii=False),
             "key_risks_json": json.dumps(_sanitize_for_json(candidate["key_risks_json"]), ensure_ascii=False),
             "key_strengths_json": json.dumps(_sanitize_for_json(candidate["key_strengths_json"]), ensure_ascii=False),
+            "key_strengths_structured_json": json.dumps(_sanitize_for_json(candidate["key_strengths_structured_json"]), ensure_ascii=False),
+            "key_risks_structured_json": json.dumps(_sanitize_for_json(candidate["key_risks_structured_json"]), ensure_ascii=False),
             "gate_status_json": json.dumps(_sanitize_for_json(candidate["gate_status_json"]), ensure_ascii=False),
             "gate_reasons_json": json.dumps(_sanitize_for_json(candidate["gate_reasons_json"]), ensure_ascii=False),
             "feature_snapshot_json": json.dumps(_sanitize_for_json(candidate["feature_snapshot_json"]), ensure_ascii=False),
@@ -9876,6 +9932,8 @@ def get_candidates(db: Session, search_id: str, district_lookup: dict[str, dict[
                 decision_summary,
                 key_risks_json,
                 key_strengths_json,
+                key_strengths_structured_json,
+                key_risks_structured_json,
                 final_score,
                 compare_rank,
                 rank_position,
@@ -10426,6 +10484,8 @@ def get_candidate_memo(db: Session, candidate_id: str, lang: str = "en") -> dict
                 c.estimated_revenue_index,
                 c.key_strengths_json,
                 c.key_risks_json,
+                c.key_strengths_structured_json,
+                c.key_risks_structured_json,
                 c.decision_summary,
                 c.rank_position,
                 c.source_type,

--- a/app/services/expansion_advisor_i18n.py
+++ b/app/services/expansion_advisor_i18n.py
@@ -1,8 +1,9 @@
 """Locale-invariant rendering for Expansion Advisor structured records.
 
 PR #2a persists structured records of the form {"id": ..., "params": ...}
-in five JSONB columns on expansion_candidate. PR #2b renders them
-into the requested language at read time. The en-side templates are
+in JSONB columns on expansion_candidate (five columns at PR #2a, plus
+two structured strengths/risks columns at PR #3). PR #2b and PR #3
+render them into the requested language at read time. The en-side templates are
 byte-identical to the producer's English f-strings/append literals
 at HEAD; the ar-side templates are Arabic anchor translations
 following these formatting conventions:
@@ -139,6 +140,48 @@ TEMPLATES: dict[str, dict[str, str]] = {
     "risk.high_competitor_density": {
         "en": "High competitor density ({count} nearby) — market may be saturated.",
         "ar": "كثافة المنافسين مرتفعة ({count} في المحيط القريب) — السوق قد يكون مشبعاً.",
+    },
+    # ── PR #3: _build_strengths_and_risks structured records ──
+    # Six zero-param templates. The en side is byte-identical to the
+    # producer's append literals in _build_strengths_and_risks (no
+    # trailing period — matches the producer). The ar side follows the
+    # PR #2b conventions: Latin digits, inline English units, and
+    # parenthetical English for jargon that is ambiguous in F&B context.
+    # S1 en: "High demand index supports branch throughput"
+    #   — a strong demand index supports the branch's customer throughput.
+    "S1": {
+        "en": "High demand index supports branch throughput",
+        "ar": "مؤشر طلب مرتفع يدعم معدّل تدفق الفرع (throughput)",
+    },
+    # S2 en: "Competitive whitespace remains attractive"
+    #   — competitor whitespace (market gap) is still attractive.
+    "S2": {
+        "en": "Competitive whitespace remains attractive",
+        "ar": "الفجوة السوقية التنافسية (whitespace) لا تزال جذابة",
+    },
+    # S3 en: "Parcel characteristics align with target format"
+    #   — the parcel's characteristics fit the target branch format.
+    "S3": {
+        "en": "Parcel characteristics align with target format",
+        "ar": "خصائص قطعة الأرض تتوافق مع الصيغة المستهدفة",
+    },
+    # R1 en: "Rent benchmark fell back to conservative city default (lower confidence)"
+    #   — the rent benchmark used the conservative city-wide default.
+    "R1": {
+        "en": "Rent benchmark fell back to conservative city default (lower confidence)",
+        "ar": "تراجع مرجع الإيجار إلى القيمة الافتراضية المحافظة على مستوى المدينة (ثقة أقل)",
+    },
+    # R2 en: "High overlap risk with existing branches"
+    #   — high cannibalization/overlap risk against the branch network.
+    "R2": {
+        "en": "High overlap risk with existing branches",
+        "ar": "مخاطر تداخل مرتفعة مع الفروع الحالية",
+    },
+    # R3 en: "Competitive density may pressure launch economics"
+    #   — competitor density could pressure the launch economics.
+    "R3": {
+        "en": "Competitive density may pressure launch economics",
+        "ar": "كثافة المنافسة قد تضغط على اقتصاديات الإطلاق",
     },
     "demand_thesis": {
         "en": ("Demand is {_demand_label} (score {demand_score:.1f}) with "
@@ -353,6 +396,18 @@ def _render_decision_summary(
     risk_kind = resolved.get("risk_kind")
     if risk_kind == "from_key_risks":
         suffix_key = f"{lang}_suffix_from_key_risks" if lang == "ar" else "en_suffix_from_key_risks"
+        # PR #3 dual-read (Q3): prefer the structured risk_id — rendered
+        # from the localized R-template — over the persisted English
+        # risk_text_en. risk_text_en is retained as the fallback for
+        # post-PR-2a-pre-PR-3 rows, which carry no risk_id. The
+        # en/omitted path never enters this branch, so it stays
+        # byte-identical to HEAD (discipline rule #2).
+        if lang == "ar":
+            risk_id = resolved.get("risk_id")
+            if isinstance(risk_id, str) and risk_id in TEMPLATES:
+                ar_clause = render({"id": risk_id, "params": {}}, "ar")
+                if ar_clause:
+                    resolved = {**resolved, "_risk_text_en": ar_clause}
     elif risk_kind == "tight_economics":
         suffix_key = f"{lang}_suffix_tight_economics" if lang == "ar" else "en_suffix_tight_economics"
     elif risk_kind == "execution":

--- a/tests/services/test_expansion_advisor_strengths_risks.py
+++ b/tests/services/test_expansion_advisor_strengths_risks.py
@@ -1,0 +1,226 @@
+"""PR #3 — _build_strengths_and_risks structured-inputs tests.
+
+Covers the producer's new 4-tuple return shape and the six zero-param
+S1-R3 templates that PR #3 adds to ``expansion_advisor_i18n``:
+
+  - each of the six firing conditions emits its English literal AND the
+    matching structured record (deliberately NOT DRY'd);
+  - the English literal is byte-identical to the i18n ``en`` template
+    (discipline rule #1 — lockstep);
+  - the ``ar`` template renders a non-empty, distinct Arabic string;
+  - the producer is locale-invariant — it only emits English strings
+    and structured ids, never Arabic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.expansion_advisor import _build_strengths_and_risks, _decision_summary
+from app.services.expansion_advisor_i18n import TEMPLATES, render
+
+# Baseline scalars that fire NONE of the six conditions:
+#   demand 50 < 70, whitespace 55 (not >=65, not <=45), fit 50 < 70,
+#   cannibalization 50 < 70, rent_source != "conservative_default".
+_NEUTRAL = dict(
+    demand_score=50.0,
+    whitespace_score=55.0,
+    fit_score=50.0,
+    cannibalization_score=50.0,
+    rent_source="market",
+)
+
+# (id, override kwargs that fire exactly one condition, English literal,
+#  whether it lands in strengths)
+_CONDITIONS = [
+    (
+        "S1",
+        {"demand_score": 80.0},
+        "High demand index supports branch throughput",
+        True,
+    ),
+    (
+        "S2",
+        {"whitespace_score": 70.0},
+        "Competitive whitespace remains attractive",
+        True,
+    ),
+    (
+        "S3",
+        {"fit_score": 80.0},
+        "Parcel characteristics align with target format",
+        True,
+    ),
+    (
+        "R1",
+        {"rent_source": "conservative_default"},
+        "Rent benchmark fell back to conservative city default (lower confidence)",
+        False,
+    ),
+    (
+        "R2",
+        {"cannibalization_score": 80.0},
+        "High overlap risk with existing branches",
+        False,
+    ),
+    (
+        "R3",
+        {"whitespace_score": 40.0},
+        "Competitive density may pressure launch economics",
+        False,
+    ),
+]
+_CONDITION_IDS = [c[0] for c in _CONDITIONS]
+
+
+# ── Producer: return shape ──────────────────────────────────────────
+
+
+def test_producer_returns_four_tuple() -> None:
+    out = _build_strengths_and_risks(**_NEUTRAL)
+    assert isinstance(out, tuple) and len(out) == 4
+    strengths, risks, strengths_structured, risks_structured = out
+    assert strengths == []
+    assert risks == []
+    assert strengths_structured == []
+    assert risks_structured == []
+
+
+def test_producer_all_six_fire_together() -> None:
+    """All six conditions firing — English + structured stay parallel."""
+    strengths, risks, s_struct, r_struct = _build_strengths_and_risks(
+        demand_score=80.0,
+        whitespace_score=70.0,  # >=65 fires S2; not <=45 so R3 stays off
+        fit_score=80.0,
+        cannibalization_score=80.0,
+        rent_source="conservative_default",
+    )
+    assert len(strengths) == 3 and len(s_struct) == 3
+    assert len(risks) == 2 and len(r_struct) == 2  # R1 + R2 (R3 needs ws<=45)
+    assert [r["id"] for r in s_struct] == ["S1", "S2", "S3"]
+    assert [r["id"] for r in r_struct] == ["R1", "R2"]
+    assert all(r["params"] == {} for r in s_struct + r_struct)
+
+
+# ── Producer: each firing condition in isolation (6 conditions) ─────
+
+
+@pytest.mark.parametrize(
+    "tid,override,literal,is_strength", _CONDITIONS, ids=_CONDITION_IDS
+)
+def test_producer_condition_emits_literal_and_structured(
+    tid: str, override: dict, literal: str, is_strength: bool
+) -> None:
+    kwargs = {**_NEUTRAL, **override}
+    strengths, risks, s_struct, r_struct = _build_strengths_and_risks(**kwargs)
+    if is_strength:
+        assert strengths == [literal]
+        assert s_struct == [{"id": tid, "params": {}}]
+        assert risks == [] and r_struct == []
+    else:
+        assert risks == [literal]
+        assert r_struct == [{"id": tid, "params": {}}]
+        assert strengths == [] and s_struct == []
+
+
+# ── Lockstep: en template byte-identical to producer literal ────────
+# (6 conditions × en = the first 6 of the 12 producer fixtures)
+
+
+@pytest.mark.parametrize(
+    "tid,override,literal,is_strength", _CONDITIONS, ids=_CONDITION_IDS
+)
+def test_en_template_byte_identical_to_producer_literal(
+    tid: str, override: dict, literal: str, is_strength: bool
+) -> None:
+    """render(record, "en") reproduces the producer's English literal
+    byte-for-byte (discipline rule #1)."""
+    assert render({"id": tid, "params": {}}, "en") == literal
+
+
+# ── Arabic render: non-empty and distinct (6 conditions × ar) ───────
+
+
+@pytest.mark.parametrize(
+    "tid,override,literal,is_strength", _CONDITIONS, ids=_CONDITION_IDS
+)
+def test_ar_template_renders_non_empty_distinct(
+    tid: str, override: dict, literal: str, is_strength: bool
+) -> None:
+    ar = render({"id": tid, "params": {}}, "ar")
+    assert ar
+    assert ar != literal
+
+
+# ── i18n: structural completeness of the six new templates ─────────
+
+
+def test_six_new_templates_present() -> None:
+    for tid in ("S1", "S2", "S3", "R1", "R2", "R3"):
+        assert tid in TEMPLATES
+        assert set(TEMPLATES[tid]) == {"en", "ar"}
+
+
+def test_ar_templates_use_latin_digits_only() -> None:
+    """No Arabic-Indic digits in any of the six ar strings."""
+    arabic_indic = "٠١٢٣٤٥٦٧٨٩"
+    for tid in ("S1", "S2", "S3", "R1", "R2", "R3"):
+        ar = TEMPLATES[tid]["ar"]
+        assert not any(ch in arabic_indic for ch in ar), tid
+
+
+# ── _decision_summary: risk_id sibling field (PR #3 §4) ─────────────
+
+
+def test_decision_summary_emits_risk_id_from_structured() -> None:
+    """When the risk clause is spliced from key_risks, the structured
+    record carries the index-aligned risk_id alongside risk_text_en."""
+    _, structured = _decision_summary(
+        district="Al Olaya",
+        final_score=70.0,
+        economics_score=60.0,
+        key_risks=["High overlap risk with existing branches"],
+        service_model="qsr",
+        area_m2=200.0,
+        key_risks_structured=[{"id": "R2", "params": {}}],
+    )
+    assert structured["params"]["risk_kind"] == "from_key_risks"
+    assert structured["params"]["risk_id"] == "R2"
+    # risk_text_en is retained for dual-read of pre-PR-3 rows (Q3).
+    assert (
+        structured["params"]["risk_text_en"]
+        == "High overlap risk with existing branches"
+    )
+
+
+def test_decision_summary_no_risk_id_when_no_key_risks() -> None:
+    """No key_risks → risk_kind is tight_economics/execution and no
+    risk_id is emitted."""
+    _, structured = _decision_summary(
+        district="Al Olaya",
+        final_score=70.0,
+        economics_score=40.0,
+        key_risks=[],
+        service_model="qsr",
+        area_m2=200.0,
+        key_risks_structured=[],
+    )
+    assert structured["params"]["risk_kind"] == "tight_economics"
+    assert "risk_id" not in structured["params"]
+
+
+def test_decision_summary_english_clause_unchanged() -> None:
+    """The English summary string is byte-untouched by the risk_id
+    addition (rule #1)."""
+    summary, _ = _decision_summary(
+        district="Al Olaya",
+        final_score=70.0,
+        economics_score=60.0,
+        key_risks=["High overlap risk with existing branches"],
+        service_model="qsr",
+        area_m2=200.0,
+        key_risks_structured=[{"id": "R2", "params": {}}],
+    )
+    assert (
+        "Biggest commercial risk: High overlap risk with existing branches." in summary
+    )

--- a/tests/test_pr2b_arabic_render.py
+++ b/tests/test_pr2b_arabic_render.py
@@ -290,3 +290,137 @@ def test_normalize_candidate_ar_partial_failure_falls_back_whole_list() -> None:
     }
     result = _normalize_candidate_payload(dict(candidate), lang="ar")
     assert result["top_positives_json"] == ["English A.", "English B."]
+
+
+# ── PR #3: strengths/risks structured read path ─────────────────────
+
+def _pr3_candidate(**overrides: object) -> dict:
+    base = {
+        "candidate_id": "c-pr3",
+        "parcel_id": "P-PR3",
+        "district": "Al Olaya",
+        "key_strengths_json": ["High demand index supports branch throughput"],
+        "key_risks_json": ["High overlap risk with existing branches"],
+        "key_strengths_structured_json": [{"id": "S1", "params": {}}],
+        "key_risks_structured_json": [{"id": "R2", "params": {}}],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_normalize_ar_localizes_key_strengths() -> None:
+    """AR branch renders key_strengths_json from the structured column."""
+    result = _normalize_candidate_payload(_pr3_candidate(), lang="ar")
+    assert result["key_strengths_json"] == [TEMPLATES["S1"]["ar"]]
+
+
+def test_normalize_ar_localizes_key_risks() -> None:
+    """AR branch renders key_risks_json from the structured column."""
+    result = _normalize_candidate_payload(_pr3_candidate(), lang="ar")
+    assert result["key_risks_json"] == [TEMPLATES["R2"]["ar"]]
+
+
+def test_normalize_ar_main_watchout_path_is_localized() -> None:
+    """get_candidate_memo derives main_watchout as key_risks_json[0];
+    after the AR normalize that element is Arabic."""
+    result = _normalize_candidate_payload(_pr3_candidate(), lang="ar")
+    main_watchout = result["key_risks_json"][0]
+    assert main_watchout == TEMPLATES["R2"]["ar"]
+
+
+def test_normalize_ar_main_risk_path_is_localized() -> None:
+    """get_recommendation_report derives main_risk as key_risks_json[0]
+    of the best candidate; the same column overwrite localizes it."""
+    result = _normalize_candidate_payload(_pr3_candidate(), lang="ar")
+    main_risk = (result["key_risks_json"] or ["x"])[0]
+    assert main_risk == TEMPLATES["R2"]["ar"]
+
+
+@pytest.mark.parametrize("lang", ["en", None])
+def test_normalize_en_key_strengths_risks_byte_identical(lang) -> None:
+    """en/omitted branch leaves the English persisted lists untouched
+    even when the PR #3 structured columns are populated (rule #2)."""
+    cand = _pr3_candidate()
+    kwargs = {} if lang is None else {"lang": lang}
+    result = _normalize_candidate_payload(dict(cand), **kwargs)
+    assert result["key_strengths_json"] == [
+        "High demand index supports branch throughput"
+    ]
+    assert result["key_risks_json"] == ["High overlap risk with existing branches"]
+
+
+def test_normalize_ar_falls_back_when_structured_null() -> None:
+    """Pre-PR-3 rows (NULL structured columns) serve the English
+    persisted lists unchanged on the AR path (rule #4)."""
+    cand = _pr3_candidate(
+        key_strengths_structured_json=None,
+        key_risks_structured_json=None,
+    )
+    result = _normalize_candidate_payload(cand, lang="ar")
+    assert result["key_strengths_json"] == [
+        "High demand index supports branch throughput"
+    ]
+    assert result["key_risks_json"] == ["High overlap risk with existing branches"]
+
+
+def test_normalize_drops_pr3_structured_columns() -> None:
+    """The two PR #3 structured columns are internal — never in the
+    outgoing payload, on either language branch."""
+    for lang in ("en", "ar"):
+        result = _normalize_candidate_payload(_pr3_candidate(), lang=lang)
+        assert "key_strengths_structured_json" not in result
+        assert "key_risks_structured_json" not in result
+
+
+def test_normalize_compare_style_dict_without_columns_untouched() -> None:
+    """compare_candidates passes a dict carrying neither key_*_json nor
+    the structured columns (Q2 deferral). The AR overwrite is guarded
+    on column presence, so no key_strengths_json/key_risks_json key is
+    introduced."""
+    compare_like = {
+        "candidate_id": "c-cmp",
+        "parcel_id": "P-CMP",
+        "district": "Al Olaya",
+    }
+    result = _normalize_candidate_payload(compare_like, lang="ar")
+    assert "key_strengths_json" not in result
+    assert "key_risks_json" not in result
+
+
+# ── PR #3: _render_decision_summary dual-read (Q3) ──────────────────
+
+def _decision_summary_record(**param_overrides: object) -> dict:
+    params = {
+        "area_label": "compact",
+        "district_label": "Al Olaya",
+        "final_score": 70.0,
+        "economics_score": 60.0,
+        "use_case": "neighborhood_qsr",
+        "risk_kind": "from_key_risks",
+        "risk_text_en": "High overlap risk with existing branches",
+    }
+    params.update(param_overrides)
+    return {"id": "decision_summary", "params": params}
+
+
+def test_decision_summary_ar_dual_read_uses_risk_id() -> None:
+    """Post-PR-3 row: both risk_text_en and risk_id present — the AR
+    render uses the localized R-template clause."""
+    rendered = render(_decision_summary_record(risk_id="R2"), "ar")
+    assert TEMPLATES["R2"]["ar"] in rendered
+    assert "High overlap risk with existing branches" not in rendered
+
+
+def test_decision_summary_ar_dual_read_falls_back_to_risk_text_en() -> None:
+    """Post-PR-2a-pre-PR-3 row: only risk_text_en present (no risk_id)
+    — the AR render falls back to the persisted English clause (Q3)."""
+    rendered = render(_decision_summary_record(), "ar")
+    assert "High overlap risk with existing branches" in rendered
+
+
+def test_decision_summary_en_dual_read_ignores_risk_id() -> None:
+    """The en path never consults risk_id — byte-identical to HEAD
+    (rule #2). risk_id is present but the en clause stays English."""
+    rendered = render(_decision_summary_record(risk_id="R2"), "en")
+    assert "High overlap risk with existing branches" in rendered
+    assert TEMPLATES["R2"]["ar"] not in rendered


### PR DESCRIPTION
## Summary

Extends the PR #2a/#2b structured-inputs pattern to `_build_strengths_and_risks` and closes the four documented English-leak paths under `lang=ar`, plus the `decision_summary` `from_key_risks` splice.

## Four confirmed decisions (verbatim)

- **Q1 wide scope.** Localize all four leak paths: `decision_summary` `from_key_risks` splice, `candidate.key_strengths`, `candidate.key_risks`, `main_watchout`, `main_risk`. (The framing called these "three other paths" + the splice; treat as four endpoints with one root producer.)
- **Q2 `compare_candidates` out.** Same deferral as PR #2b. Don't touch its SELECT or its pros/cons builder.
- **Q3 dual-read in `_render_decision_summary`.** Renderer accepts both `risk_text_en` (old, post-PR-2a-pre-PR-3 rows) and `risk_id` (new). Same column.
- **Q4 keep the unreachable `[:4]` slices.** Defensively included in templates, no fixture rows.

## Seven-rule discipline walkthrough

1. **English persisted strings byte-identical.** `_build_strengths_and_risks` keeps all six append literals unchanged; only parallel `*_structured.append(...)` lines were added (NOT DRY'd). `_decision_summary` leaves the English `summary`/`risk_text` branches untouched. The six new i18n `en` templates are byte-identical to the producer literals — pinned by `test_en_template_byte_identical_to_producer_literal`.
2. **`_normalize_candidate_payload(lang="en"|omitted)` byte-identical.** The new overwrite lives only inside the `if lang == "ar":` block; the new structured columns are added to `_STRUCTURED_CANDIDATE_COLS` so they are dropped on both branches. Pinned by the existing `pr2b_golden` suite + `test_normalize_en_key_strengths_risks_byte_identical`.
3. **Migrations add only new nullable columns, no backfill.** `20260518_ea_strengths_risks` = two `op.add_column(..., JSONB, nullable=True)`, no defaults, no `UPDATE`.
4. **No backfill / NULL fallback.** Pre-PR-3 rows keep both columns NULL; `_render_structured_list` falls back to the persisted English list. The dual-read falls back to `risk_text_en` when no `risk_id` is present.
5. **`_humanize_gate_list` en/omitted byte-identical.** Not touched — zero diff.
6. **Gate blocking/advisory split on raw keys.** Not touched — no gate label/status code changed.
7. **No frontend / no handler-signature / no `_prewarm` / no LLM prompt-text changes.** Verified `MemoContext` has no strengths/risks field and no LLM prompt path consumes `_build_strengths_and_risks` output, so no prompt-strip was needed.

## File-by-file change inventory

| File | Status | +/- |
|------|--------|-----|
| `alembic/versions/20260518_ea_strengths_risks_structured.py` | new | +43 |
| `app/services/expansion_advisor.py` | edit | +66 / -6 |
| `app/services/expansion_advisor_i18n.py` | edit | +57 / -2 |
| `tests/test_pr2b_arabic_render.py` | edit | +134 |
| `tests/services/test_expansion_advisor_strengths_risks.py` | new | +226 |

5 files, 526 insertions / 8 deletions.

## Test counts

- Baseline (HEAD): **1700 passed**, 20 skipped.
- After PR #3: **1749 passed**, 20 skipped. (One pre-existing flaky concurrency test, `test_prewarm_concurrency.py::test_prewarm_per_candidate_exception_does_not_crash_batch`, intermittently fails under full-suite load and passes in isolation — unrelated to PR #3.)
- New tests: **50** (25 producer, 13 normalizer/dual-read, 12 auto-collected template renders).

## Migration

- `revision = "20260518_ea_strengths_risks"` (27 chars).
- `down_revision = "20260516_ea_structured_inputs"` — chain: `20260518_ea_strengths_risks` → `20260516_ea_structured_inputs` → `20260501b_drop_osm_districts`. Single head.
- Validated on a live PostgreSQL 16: `upgrade head` → `downgrade -1` → `upgrade head`, all three steps green.

## Known follow-ups

- The four side findings from earlier investigations (`.strip()` fragility, fail-open `AUTH_MODE`, non-constant-time compare).
- Intermittent 401; API-key rotation.
- `compare_candidates` AR strengths/risks deferral (Q2) — a future PR could localize its pros/cons builder with the same pattern.
- `risk_text_en` is now redundant on post-PR-3 rows (dual-read prefers `risk_id`); droppable once no pre-PR-3 rows remain.

## Test plan

- [x] Full suite: 1749 passed (baseline 1700)
- [x] `pr2b_golden` en/omitted byte-identity unchanged
- [x] Alembic upgrade/downgrade/upgrade on live Postgres
- [ ] Ahmed's diff review before merge

## Reference docs

`/tmp/pr3_investigation.md` and `/tmp/pr3_validation.md` are CC-side artifacts (not in the repo). The investigation report was re-derived from live source per the task's re-verification step; no drift was found.

https://claude.ai/code/session_01Y2FqZiyohgzx315154PfS3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2FqZiyohgzx315154PfS3)_