### PR TITLE
feat(expansion_advisor): PR #4a — structured-memo Arabic end-to-end (validator/retry/rewrite/persistence/GET)

### DIFF
--- a/alembic/versions/20260519_decision_memo_lang.py
+++ b/alembic/versions/20260519_decision_memo_lang.py
@@ -1,0 +1,39 @@
+"""Expansion advisor decision_memo_lang column (PR #4a)
+
+Adds a single nullable column on expansion_candidate recording the locale
+the persisted decision memo was generated in. GET /candidates/{id}/memo
+uses it to regenerate a memo when the requested ``lang`` does not match
+the persisted memo's locale.
+
+Purely additive — no existing column is modified, renamed, or dropped,
+and no rows are backfilled. Pre-PR-4a rows keep decision_memo_lang NULL;
+the read path treats NULL as "unknown locale" and regenerates only when
+the requested lang is not English.
+
+Revision ID: 20260519_decision_memo_lang
+Revises: 20260518_ea_strengths_risks
+Create Date: 2026-05-19 00:00:00.000000
+
+NOTE: the revision id is kept <= 32 chars to fit alembic_version.version_num.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260519_decision_memo_lang"
+down_revision = "20260518_ea_strengths_risks"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "expansion_candidate",
+        sa.Column("decision_memo_lang", sa.String(8), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("expansion_candidate", "decision_memo_lang")

--- a/app/api/expansion_advisor.py
+++ b/app/api/expansion_advisor.py
@@ -1517,9 +1517,15 @@ def _decision_memo_cache_write(
     parcel_id: str,
     memo_text: str | None,
     memo_json: dict[str, Any] | None,
+    lang: str = "en",
 ) -> None:
     """Persist the memo to expansion_candidate. Swallows errors — a persist
     failure must not break the endpoint response.
+
+    ``lang`` is the locale the memo was generated in; it is persisted to
+    ``decision_memo_lang`` (PR #4a) so GET /candidates/{id}/memo can detect
+    a locale mismatch and regenerate. The default "en" keeps the pre-PR-4a
+    pre-warm call site (which only ever generates English memos) unchanged.
 
     Phase 3 chunk 1 verification: this UPDATE is bound to the request session
     via :func:`get_db` and committed inline. The 0-memos-in-prod observation
@@ -1534,7 +1540,8 @@ def _decision_memo_cache_write(
                 "UPDATE expansion_candidate "
                 "SET decision_memo = :txt, "
                 "    decision_memo_json = CAST(:j AS JSONB), "
-                "    decision_memo_prompt_version = :ver "
+                "    decision_memo_prompt_version = :ver, "
+                "    decision_memo_lang = :lang "
                 "WHERE search_id = :sid AND parcel_id = :pid"
             ),
             {
@@ -1543,6 +1550,7 @@ def _decision_memo_cache_write(
                 "txt": memo_text,
                 "j": json.dumps(memo_json, ensure_ascii=False) if memo_json is not None else None,
                 "ver": MEMO_PROMPT_VERSION,
+                "lang": lang,
             },
         )
         db.commit()
@@ -1684,7 +1692,8 @@ def post_decision_memo(
     # 4) Persist when keyed
     if cache_keyed:
         _decision_memo_cache_write(
-            db, search_id, parcel_id, memo_text, response_payload["memo_json"]
+            db, search_id, parcel_id, memo_text,
+            response_payload["memo_json"], lang,
         )
 
     return response_payload

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -10430,6 +10430,71 @@ def compare_candidates(db: Session, search_id: str, candidate_ids: list[str], la
     return {"items": items, "summary": summary}
 
 
+def _regenerate_candidate_memo_in_locale(
+    db: Session,
+    raw_candidate: dict[str, Any],
+    brand_profile: dict[str, Any] | None,
+    lang: str,
+) -> tuple[str | None, dict[str, Any]] | None:
+    """Regenerate and persist a structured decision memo in ``lang``.
+
+    Returns ``(memo_text, memo_json)`` on success, or None when structured
+    generation is unavailable (flag off, LLM error, renderer failure) — the
+    caller then serves the existing persisted memo unchanged.
+
+    PR #4a: invoked by :func:`get_candidate_memo` on a locale mismatch.
+    """
+    from app.services.llm_decision_memo import (
+        MEMO_PROMPT_VERSION,
+        build_memo_context,
+        generate_structured_memo,
+        render_structured_memo_as_text,
+    )
+
+    cid = raw_candidate.get("candidate_id") or raw_candidate.get("id")
+    try:
+        ctx = build_memo_context(
+            candidate=raw_candidate,
+            brief={"brand_profile": brand_profile or {}},
+            lang=lang,
+        )
+        memo_json = generate_structured_memo(ctx)
+        if memo_json is None:
+            return None
+        memo_text = render_structured_memo_as_text(memo_json, lang)
+    except Exception as exc:
+        logger.warning("decision memo regenerate failed for %s: %s", cid, exc)
+        return None
+
+    try:
+        db.execute(
+            text(
+                "UPDATE expansion_candidate "
+                "SET decision_memo = :txt, "
+                "    decision_memo_json = CAST(:j AS JSONB), "
+                "    decision_memo_prompt_version = :ver, "
+                "    decision_memo_lang = :lang "
+                "WHERE id = :cid"
+            ),
+            {
+                "txt": memo_text,
+                "j": json.dumps(memo_json, ensure_ascii=False),
+                "ver": MEMO_PROMPT_VERSION,
+                "lang": lang,
+                "cid": cid,
+            },
+        )
+        db.commit()
+    except Exception as exc:
+        logger.warning("decision memo regenerate persist failed for %s: %s", cid, exc)
+        try:
+            db.rollback()
+        except Exception:
+            pass
+
+    return memo_text, memo_json
+
+
 def get_candidate_memo(db: Session, candidate_id: str, lang: str = "en") -> dict[str, Any] | None:
     t_start = time.monotonic()
     row = db.execute(
@@ -10504,7 +10569,8 @@ def get_candidate_memo(db: Session, candidate_id: str, lang: str = "en") -> dict
                 c.rerank_delta,
                 c.rerank_status,
                 c.decision_memo,
-                c.decision_memo_json
+                c.decision_memo_json,
+                c.decision_memo_lang
             FROM expansion_candidate c
             JOIN expansion_search s ON s.id = c.search_id
             WHERE c.id = :candidate_id
@@ -10552,7 +10618,7 @@ def get_candidate_memo(db: Session, candidate_id: str, lang: str = "en") -> dict
         candidate.get("search_id"), verdict,
     )
 
-    return {
+    result = {
         "candidate_id": candidate["candidate_id"],
         "search_id": candidate["search_id"],
         "brand_profile": {
@@ -10663,6 +10729,32 @@ def get_candidate_memo(db: Session, candidate_id: str, lang: str = "en") -> dict
         "decision_memo": candidate.get("decision_memo"),
         "decision_memo_json": candidate.get("decision_memo_json"),
     }
+
+    # PR #4a (Q3 (b)): regenerate-on-mismatch. The persisted memo carries
+    # the locale it was generated in (decision_memo_lang — read from the row
+    # internally; intentionally NOT surfaced on the response since
+    # CandidateMemoResponse forbids extra fields and the frontend contract
+    # must not drift). When the requested ``lang`` does not match — treating
+    # a NULL column on pre-PR-4a rows as English — the memo is regenerated
+    # in the requested locale and persisted.
+    # COST NOTE: this fires a synchronous model call from a GET handler.
+    # Pre-warm hardcodes lang="en" (Q4 defer), so the first AR view of a
+    # candidate not yet POSTed in Arabic pays this regeneration cost once.
+    stored_lang = candidate.get("decision_memo_lang")
+    has_memo = (
+        candidate.get("decision_memo_json") is not None
+        or candidate.get("decision_memo") is not None
+    )
+    if has_memo and lang != (stored_lang or "en"):
+        regenerated = _regenerate_candidate_memo_in_locale(
+            db, dict(row), brand_profile, lang,
+        )
+        if regenerated is not None:
+            regen_text, regen_json = regenerated
+            result["decision_memo"] = regen_text
+            result["decision_memo_json"] = regen_json
+
+    return result
 
 
 def get_recommendation_report(db: Session, search_id: str, lang: str = "en") -> dict[str, Any] | None:

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -1291,7 +1291,7 @@ def build_memo_advisory_sections(ctx: MemoContext) -> dict[str, Any]:
 # ── Prompt ──────────────────────────────────────────────────────────
 
 
-STRUCTURED_MEMO_SYSTEM_PROMPT = """You are a senior real-estate advisor in Riyadh writing an investment memo for a restaurant operator's principal. The reader is the person making the capital call on this specific listing — they want a clear, persuasive, numerically-grounded answer to one question: is this site worth the capital?
+_STRUCTURED_MEMO_PREAMBLE = """You are a senior real-estate advisor in Riyadh writing an investment memo for a restaurant operator's principal. The reader is the person making the capital call on this specific listing — they want a clear, persuasive, numerically-grounded answer to one question: is this site worth the capital?
 
 Write like an advisor, not a junior analyst. Lead with the strongest investment argument grounded in a specific number. Synthesize the score breakdown into a thesis — never restate the breakdown back at the reader as a list of percentages. Be direct. Be specific to this candidate, this listing, this catchment. Density beats length.
 
@@ -1621,9 +1621,12 @@ count, nearest distance, and district. Anything beyond those four facts —
 rent, pricing, AOV, throughput, margin, commission, positioning, success
 metrics — is fabrication and is banned in every prose field.
 
-Now write the memo for the candidate JSON the user provides. Match the voice in the examples. Be specific to this site, not generic.
+Now write the memo for the candidate JSON the user provides. Match the voice in the examples. Be specific to this site, not generic."""
 
-══════════════════════════════════════════════════════════════════════
+
+# CRITICAL block — English variant. Byte-identical to the pre-PR-4a tail
+# of STRUCTURED_MEMO_SYSTEM_PROMPT (Q2 (a): the EN branch must not drift).
+_CRITICAL_BLOCK_EN = """══════════════════════════════════════════════════════════════════════
 CRITICAL OUTPUT FORMAT RULES — these are the most important rules in
 this prompt. Other instructions are subordinate to these.
 
@@ -1712,6 +1715,125 @@ EXAMPLES of incorrect headlines that violate these rules:
 ══════════════════════════════════════════════════════════════════════"""
 
 
+# CRITICAL block — Arabic variant (PR #4a, Q2 (a)). Mandates the Arabic
+# headline triad نوصي / نوصي مع تحفظات / نرفض instead of the English
+# triad; every other structural rule is preserved. Inline ``#`` comments
+# carry an English gloss of each translated line for review (PR #3
+# convention). JSON keys stay English in every locale.
+_CRITICAL_BLOCK_AR = """══════════════════════════════════════════════════════════════════════
+# "CRITICAL OUTPUT FORMAT RULES — the most important rules in this prompt."
+قواعد تنسيق المخرجات الحاسمة — هذه أهم القواعد في هذا التوجيه.
+# "Other instructions are subordinate to these critical rules."
+كل التعليمات الأخرى تابعة لهذه القواعد الحاسمة.
+
+# "JSON keys remain in English; only the string values are in Arabic."
+مفاتيح JSON تبقى بالإنجليزية؛ القيم النصية فقط تُكتب بالعربية.
+
+# Rule 1: "headline_recommendation MUST begin with one of the three Arabic prefixes."
+1. يجب أن يبدأ حقل `headline_recommendation` بأحد العناوين التالية حصراً:
+   - "نوصي"
+   - "نوصي مع تحفظات"
+   - "نرفض"
+
+# "Never begin with a non-decision word (Consider/Caution) or a descriptive adjective; you MUST pick one of the three prefixes."
+   لا تبدأ أبداً بكلمة لا تمثل قراراً مثل "ربما" أو "احذر"، ولا بأي
+   صفة وصفية مثل "قوي" أو "جيد". حتى عندما تكون إشارات الموقع ضعيفة
+   أو الأدلة متباينة، يجب أن تختار أحد العناوين الثلاثة المسموح بها.
+
+# Rule 2: "Map deterministic_verdict to the headline prefix; mappings are MANDATORY when overall_pass == true."
+2. اربط `deterministic_verdict` بعنوان التوصية كما يلي. هذه الروابط
+   إلزامية عندما تكون `overall_pass == true`. الحكم الحتمي
+   (deterministic verdict) هو مصدر الحقيقة لفعل العنوان؛ لا تُعِد
+   التقييم من الدرجات الخام أو من عتبات الطلب.
+# "deterministic_verdict == go → نوصي (default); نوصي مع تحفظات only if blocking gates failed; NEVER نرفض."
+   - deterministic_verdict == "go"
+       → "نوصي" (الافتراضي)
+       → "نوصي مع تحفظات" فقط إذا فشلت بوابات حاجبة
+       → "نرفض" ممنوع أبداً
+# "deterministic_verdict == consider → نوصي مع تحفظات (mandatory when overall_pass == true); NEVER نرفض."
+   - deterministic_verdict == "consider"
+       → "نوصي مع تحفظات" (إلزامي عندما يكون overall_pass == true)
+       → "نرفض" ممنوع أبداً عندما يكون overall_pass == true
+# "deterministic_verdict == caution → نرفض (default); نوصي مع تحفظات only with a strong specific positive case."
+   - deterministic_verdict == "caution"
+       → "نرفض" (الافتراضي)
+       → "نوصي مع تحفظات" فقط عند وجود حجة إيجابية قوية ومحددة
+         ترجِّح كفة التوصية رغم الحذر الحتمي
+
+# Rule 3: "rank 1 + score >= 70 + no blocking gates failed → headline MUST be نوصي."
+3. إذا كان `final_rank == 1` و `final_score >= 70` ولم تفشل أي بوابة
+   حاجبة: يجب أن يكون العنوان "نوصي". هذا غير قابل للتفاوض. لا
+   تستخدم الدرجات اللينة (موقف السيارات، الواجهة، الوضوح) سبباً
+   لرفض مرشح من المرتبة الأولى يستوفي هذه المعايير. درجات المكونات
+   اللينة دون 50 هي مدخلات للترتيب الحتمي، وليست مُسقِطات مستقلة.
+
+# Rule 4: "overall_pass == false → headline MUST be نرفض."
+4. إذا كان `overall_pass == false`: يجب أن يكون العنوان "نرفض".
+
+# Rule 5: "Never confabulate gate failures; if gates.failed is empty do not write نرفض بسبب فشل …"
+5. لا تختلق فشل البوابات أبداً. قائمة البوابات الفاشلة موجودة في
+   حقل `gates.failed`. إذا كان `gates.failed` فارغاً، فلا تكتب
+   "نرفض بسبب فشل [أي شيء]". انخفاض درجة مكوّن لين ليس فشلاً لبوابة.
+
+# Rule 6: "No claims about a named competitor's rent/pricing/margin/AOV/throughput or any economic data."
+6. لا تُطلق أي ادعاءات حول إيجار منافس مذكور بالاسم أو تسعيره أو
+   هامشه أو متوسط قيمة طلبه (AOV) أو معدل تدفقه (throughput) أو
+   مقاييس نجاحه أو أي بيانات اقتصادية أو تشغيلية. استجابة مذكرة
+   المرشح تحمل فقط اسم المنافس وعدد فروعه وأقرب مسافة إليه والحي.
+   يمكن للمقارنات أن تشير إلى هذه الحقائق المكانية وحقائق الحضور
+   وأن تفسّر دلالتها على السوق المحلي. المقارنات مقابل وسيط الحي
+   (النسبة المئوية للإيجار، الإيجار الوسيط) صحيحة فقط إذا تضمّنتها
+   الحمولة المُصنّفة. لا تؤكد أبداً ما يدفعه منافس بعينه أو يتقاضاه
+   أو يربحه أو يحققه. تنطبق هذه القاعدة على كل حقل نصي.
+
+# "EXAMPLES of correct headlines:"
+أمثلة على عناوين صحيحة:
+
+# rank=1, score=80.5, gates.failed=[]:
+  "نوصي — اقتصاديات قوية في حي مستقر مع منافسة يمكن إدارتها."
+
+# rank=1, score=80.5, gates.failed=[radiance_growth_pass] (advisory):
+  "نوصي — اقتصاديات قوية؛ إشارة نمو السوق ضعيفة لكنها لا تحجب القرار."
+
+# rank=2, score=72.0, gates.failed=[economics_pass] (blocking):
+  "نرفض — تفشل بوابة الاقتصاديات؛ عبء الإيجار يتجاوز عتبة الجدوى لهذه العلامة."
+
+# rank=4, score=65.0, gates.failed=[]:
+  "نوصي مع تحفظات — اقتصاديات معتدلة مع كثافة منافسين عالية؛ قابل للتطبيق لكنه ليس الخيار الأقوى."
+
+# "EXAMPLES of incorrect headlines that violate these rules:"
+أمثلة على عناوين خاطئة تنتهك هذه القواعد:
+
+# WRONG: begins with a banned non-decision word.
+  خطأ: "ربما بسبب إشارات طلب قوية رغم المنافسة العالية"
+       (يبدأ بكلمة "ربما" — ممنوع)
+# WRONG: confabulated gate failure when gates.failed is empty.
+  خطأ: "نرفض بسبب فشل الوصول لموقف السيارات"
+       (عندما تكون gates.failed=[] — فشل بوابة مختلق)
+# WRONG: Decline when overall_pass=true and rank-1 with score>=70.
+  خطأ: "نرفض — تفشل إشارة نمو السوق"
+       (عندما يكون overall_pass=true و final_rank=1 بدرجة >= 70)
+══════════════════════════════════════════════════════════════════════"""
+
+
+def _compose_structured_system_prompt(locale: str) -> str:
+    """Compose the structured-memo system prompt for ``locale``.
+
+    The prompt is the locale-invariant preamble followed by a CRITICAL
+    block. The EN branch returns bytes identical to the pre-PR-4a
+    ``STRUCTURED_MEMO_SYSTEM_PROMPT`` constant (rule #1 byte-identity).
+    The AR branch swaps in ``_CRITICAL_BLOCK_AR`` so the headline-prefix
+    mandate matches the Arabic triad the LOCALE addendum already asks for.
+    """
+    block = _CRITICAL_BLOCK_AR if locale == "ar" else _CRITICAL_BLOCK_EN
+    return _STRUCTURED_MEMO_PREAMBLE + "\n\n" + block
+
+
+# Back-compat module constant — the EN composition. Any importer of the
+# old name keeps working; equals _compose_structured_system_prompt("en").
+STRUCTURED_MEMO_SYSTEM_PROMPT = _compose_structured_system_prompt("en")
+
+
 _MAX_USER_PAYLOAD_CHARS = 12000
 _FEATURE_SNAPSHOT_SOFT_LIMIT = 4000
 
@@ -1798,6 +1920,7 @@ def render_structured_memo_prompt(ctx: MemoContext) -> list[dict]:
     failed.
     """
     addenda: list[str] = []
+    # Reinforces the AR CRITICAL block — see _CRITICAL_BLOCK_AR.
     if ctx.locale == "ar":
         addenda.append(
             "LOCALE: Produce every string value in Modern Standard Arabic "
@@ -1878,7 +2001,7 @@ def render_structured_memo_prompt(ctx: MemoContext) -> list[dict]:
             "negative recommendation."
         )
 
-    system_content = STRUCTURED_MEMO_SYSTEM_PROMPT
+    system_content = _compose_structured_system_prompt(ctx.locale)
     if addenda:
         system_content = (
             system_content
@@ -1904,6 +2027,16 @@ _ALLOWED_HEADLINE_PREFIXES: tuple[str, ...] = (
     "Decline",
 )
 
+# PR #4a: Arabic prefix canon (Q1 (a)). Mirrors the triad the LOCALE
+# addendum and _CRITICAL_BLOCK_AR already instruct the model to produce.
+# Longest-first, like the EN tuple, so "نوصي مع تحفظات" is matched before
+# the "نوصي" substring it begins with.
+_ALLOWED_HEADLINE_PREFIXES_AR: tuple[str, ...] = (
+    "نوصي مع تحفظات",
+    "نوصي",
+    "نرفض",
+)
+
 
 def _headline_validity_reason(
     headline: str | None,
@@ -1913,6 +2046,7 @@ def _headline_validity_reason(
     overall_pass: bool | None,
     blocking_failed: list,
     deterministic_verdict: str | None = None,
+    locale: str = "en",
 ) -> str | None:
     """Return None when ``headline`` satisfies the format rules; otherwise
     a short reason string suitable for logging and retry-prompt context.
@@ -1927,6 +2061,10 @@ def _headline_validity_reason(
          (mutually exclusive with #3 by construction).
       5. Confabulated gate failures (Decline citing "failed [X]" when
          ``gates.failed`` is empty).
+
+    ``locale`` selects the prefix canon: "en" (default) keeps the exact
+    pre-PR-4a English code path byte-for-byte; "ar" validates against the
+    Arabic triad نوصي / نوصي مع تحفظات / نرفض (PR #4a, Q1 (a)).
     """
     if not isinstance(headline, str) or not headline.strip():
         return "headline missing or empty"
@@ -1934,17 +2072,31 @@ def _headline_validity_reason(
     stripped = headline.strip()
     lowered = stripped.lower()
 
+    # Locale-keyed prefix canon and diagnostic markers. The EN values below
+    # reproduce the original literals exactly, so locale="en" is a no-op.
+    is_ar = locale == "ar"
+    prefixes = _ALLOWED_HEADLINE_PREFIXES_AR if is_ar else _ALLOWED_HEADLINE_PREFIXES
+    decline_prefix = "نرفض" if is_ar else "decline"
+    recommend_prefix = "نوصي" if is_ar else "recommend"
+    recommend_reservations_prefix = (
+        "نوصي مع تحفظات" if is_ar else "recommend with reservations"
+    )
+    # Confabulation-guard heuristics — Arabic equivalents of "failed"/"fails on".
+    # "فشل" = "failure/failed"; "لم يجتز" = "did not pass".
+    fail_markers = ("فشل", "لم يجتز") if is_ar else ("failed ", "fails on")
+
     if not any(
-        lowered.startswith(prefix.lower()) for prefix in _ALLOWED_HEADLINE_PREFIXES
+        lowered.startswith(prefix.lower()) for prefix in prefixes
     ):
         return f"headline does not start with an allowed prefix: {stripped[:60]!r}"
 
-    starts_with_decline = lowered.startswith("decline")
+    starts_with_decline = lowered.startswith(decline_prefix)
     starts_with_recommend_with_reservations = lowered.startswith(
-        "recommend with reservations"
+        recommend_reservations_prefix
     )
     starts_with_recommend_only = (
-        lowered.startswith("recommend") and not starts_with_recommend_with_reservations
+        lowered.startswith(recommend_prefix)
+        and not starts_with_recommend_with_reservations
     )
 
     # Rank-1 high-score guarantee.
@@ -1987,7 +2139,7 @@ def _headline_validity_reason(
     # Confabulation guard: a Decline headline citing failed gates when
     # no blocking gate actually failed is a fabrication.
     if starts_with_decline and not blocking_failed:
-        if "failed " in lowered or "fails on" in lowered:
+        if any(marker in lowered for marker in fail_markers):
             return "headline cites failed gates but no blocking gates failed"
 
     return None
@@ -2000,12 +2152,31 @@ def _rewrite_headline_locally(
     final_score: float | None,
     overall_pass: bool | None,
     blocking_failed: list,
+    locale: str = "en",
 ) -> str:
     """Safety-net rewrite when both LLM attempts fail validation.
 
     Produces an awkward but format-compliant headline so a
     contradicting recommendation never reaches the user.
+
+    ``locale`` selects the headline-prefix vocabulary: "en" (default)
+    keeps the exact pre-PR-4a English literals; "ar" stamps the Arabic
+    triad نوصي / نوصي مع تحفظات / نرفض (PR #4a, Q1 (a)). ``original``'s
+    ``ranking_explanation`` is a Python ``str``, so the ``[:80]`` slice is
+    by codepoint — safe for multi-byte Arabic text.
     """
+    is_ar = locale == "ar"
+    recommend_prefix = "نوصي" if is_ar else "Recommend"
+    decline_prefix = "نرفض" if is_ar else "Decline"
+    reservations_prefix = (
+        "نوصي مع تحفظات" if is_ar else "Recommend with reservations"
+    )
+    # "بسبب" = "due to" — the Arabic connector the AR prompt produces.
+    connectors = (
+        (" بسبب ", " — ", " - ", ": ") if is_ar
+        else (" due to ", " — ", " - ", ": ")
+    )
+
     body = ""
     raw_explanation = original.get("ranking_explanation")
     if isinstance(raw_explanation, str):
@@ -2017,9 +2188,9 @@ def _rewrite_headline_locally(
         and final_score >= 70
         and not blocking_failed
     ):
-        return f"Recommend — {body}" if body else "Recommend"
+        return f"{recommend_prefix} — {body}" if body else recommend_prefix
     if overall_pass is False:
-        return f"Decline — {body}" if body else "Decline"
+        return f"{decline_prefix} — {body}" if body else decline_prefix
     # Fallback: strip any leading banned word and prepend the soft-yes prefix.
     raw_headline = original.get("headline_recommendation")
     tail = body
@@ -2028,7 +2199,7 @@ def _rewrite_headline_locally(
         # Prefer dropping a connector phrase (e.g., "consider due to ...");
         # otherwise drop just the leading banned word so the rest reads.
         connector_split = None
-        for connector in (" due to ", " — ", " - ", ": "):
+        for connector in connectors:
             if connector in cleaned:
                 connector_split = cleaned.split(connector, 1)[1]
                 break
@@ -2039,7 +2210,7 @@ def _rewrite_headline_locally(
             if len(parts) == 2:
                 cleaned = parts[1]
         tail = cleaned[:80].rstrip(" ,.;:—-") or body
-    return f"Recommend with reservations — {tail}" if tail else "Recommend with reservations"
+    return f"{reservations_prefix} — {tail}" if tail else reservations_prefix
 
 
 _STRUCTURED_REQUIRED_KEYS: tuple[str, ...] = (
@@ -2175,6 +2346,52 @@ def _blocking_failed_from_buckets(buckets: dict | None) -> list[dict]:
     ]
 
 
+# Corrective retry preamble. The EN template reproduces the pre-PR-4a
+# inline text byte-for-byte (rule #1). ``{reason}`` is substituted with
+# the validity-failure reason; only the template is parsed by .format(),
+# so a reason containing braces is inserted verbatim.
+_CORRECTIVE_RETRY_PREAMBLE_EN = (
+    "PREVIOUS RESPONSE WAS REJECTED. Reason: {reason}.\n\n"
+    "The headline_recommendation field must follow the format "
+    "rules exactly. Do not begin with \"Consider\" or any "
+    "other word outside the three allowed prefixes "
+    "(\"Recommend\", \"Recommend with reservations\", "
+    "\"Decline\"). Do not cite gate failures unless they "
+    "appear in gates.failed. Re-emit the full structured "
+    "memo with a corrected headline."
+)
+
+# Arabic corrective preamble (PR #4a, §3.2). Same length/tone as the EN
+# template; reasserts the Arabic prefix canon. Inline ``#`` glosses give
+# the English meaning of each line for review.
+_CORRECTIVE_RETRY_PREAMBLE_AR = (
+    # "PREVIOUS RESPONSE WAS REJECTED. Reason: {reason}."
+    "تم رفض الاستجابة السابقة. السبب: {reason}.\n\n"
+    # "The headline_recommendation field must follow the format rules exactly."
+    "يجب أن يلتزم حقل headline_recommendation بقواعد التنسيق بدقة. "
+    # "Do not begin with a banned word outside the three allowed Arabic prefixes."
+    "لا تبدأ بكلمة ممنوعة خارج العناوين الثلاثة المسموح بها "
+    "(\"نوصي\"، \"نوصي مع تحفظات\"، \"نرفض\"). "
+    # "Do not cite gate failures unless they appear in gates.failed."
+    "لا تذكر فشل بوابات إلا إذا ظهرت في gates.failed. "
+    # "Re-emit the full structured memo with a corrected headline."
+    "أعد إصدار المذكرة المنظمة كاملة بعنوان مُصحَّح."
+)
+
+
+def _corrective_retry_preamble(locale: str, reason: str) -> str:
+    """Build the retry user-turn preamble for ``locale``.
+
+    locale="en" returns text byte-identical to the pre-PR-4a inline
+    preamble; locale="ar" returns the Arabic variant (PR #4a, §3).
+    """
+    template = (
+        _CORRECTIVE_RETRY_PREAMBLE_AR if locale == "ar"
+        else _CORRECTIVE_RETRY_PREAMBLE_EN
+    )
+    return template.format(reason=reason)
+
+
 def generate_structured_memo(ctx: MemoContext) -> dict | None:
     """Call the LLM for a structured memo, or return None on any failure.
 
@@ -2247,6 +2464,7 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
         overall_pass=ctx.overall_pass,
         blocking_failed=blocking_failed,
         deterministic_verdict=ctx.deterministic_verdict,
+        locale=ctx.locale,
     )
 
     usage = getattr(response, "usage", None)
@@ -2264,16 +2482,8 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
             messages[0],
             {
                 "role": "user",
-                "content": (
-                    "PREVIOUS RESPONSE WAS REJECTED. Reason: "
-                    f"{headline_reason}.\n\n"
-                    "The headline_recommendation field must follow the format "
-                    "rules exactly. Do not begin with \"Consider\" or any "
-                    "other word outside the three allowed prefixes "
-                    "(\"Recommend\", \"Recommend with reservations\", "
-                    "\"Decline\"). Do not cite gate failures unless they "
-                    "appear in gates.failed. Re-emit the full structured "
-                    "memo with a corrected headline."
+                "content": _corrective_retry_preamble(
+                    ctx.locale, headline_reason
                 ),
             },
             messages[1],
@@ -2306,6 +2516,7 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
                     overall_pass=ctx.overall_pass,
                     blocking_failed=blocking_failed,
                     deterministic_verdict=ctx.deterministic_verdict,
+                    locale=ctx.locale,
                 )
                 retry_usage = getattr(retry_response, "usage", None)
                 input_tokens += int(
@@ -2335,6 +2546,7 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
                 final_score=ctx.final_score,
                 overall_pass=ctx.overall_pass,
                 blocking_failed=blocking_failed,
+                locale=ctx.locale,
             )
             logger.error(
                 "Structured memo headline locally rewritten for %s: "

--- a/tests/data/pr4a_structured_memo_system_prompt_en_head.txt
+++ b/tests/data/pr4a_structured_memo_system_prompt_en_head.txt
@@ -1,0 +1,419 @@
+You are a senior real-estate advisor in Riyadh writing an investment memo for a restaurant operator's principal. The reader is the person making the capital call on this specific listing — they want a clear, persuasive, numerically-grounded answer to one question: is this site worth the capital?
+
+Write like an advisor, not a junior analyst. Lead with the strongest investment argument grounded in a specific number. Synthesize the score breakdown into a thesis — never restate the breakdown back at the reader as a list of percentages. Be direct. Be specific to this candidate, this listing, this catchment. Density beats length.
+
+You will receive a JSON object describing the brand profile, the candidate's feature snapshot, the score_breakdown (9 components with weights and contributions), the gate buckets (gates.passed / gates.failed / gates.unknown — tri-state), deterministic anchors (overall_pass, final_rank, final_score, deterministic_verdict), comparable competitors, the rank-2 alternative (next_candidate_summary), and optionally a realized_demand block.
+
+Return ONLY a single JSON object — no markdown fences, no commentary before or after. The object must contain EXACTLY these ten top-level keys:
+
+{
+  "headline_recommendation": "string — one short sentence. MUST start with 'Recommend', 'Recommend with reservations', or 'Decline'. Never start with 'Consider' — that is a non-decision. Never start with 'consider due to'.",
+  "ranking_explanation": "string — 3 to 5 sentences. Lead with the strongest investment argument grounded in a specific number (rent vs comparable median, foot traffic, brand saturation, demand signal). MUST cite at least one number with units. Mention one real trade-off. Do NOT recite the score breakdown back at the reader; synthesize it into an investment thesis.",
+  "key_evidence": [
+    {"signal": "string", "value": "string — MUST include a unit (SAR/yr, SAR/m²/yr, ratings/30d, /100, m, count, %, etc.); never a bare number", "implication": "string — one clause naming the investment consequence (not a description of what the number is)", "polarity": "positive | negative | neutral"}
+  ],
+  "risks": [
+    {"risk": "string", "mitigation": "string or null — specific tactics only; see rule below"}
+  ],
+  "comparison": "string — 2 to 3 sentences. MUST reference (a) at least one named competitor from comparable_competitors AND (b) the rank-2 alternative from next_candidate_summary, by rank ('rank 2 in this search...'). Be specific about what beats what.",
+  "bottom_line": "string — one sentence. The 'tell over coffee' closer. MUST NOT repeat the headline.",
+  "property_overview": {
+    "summary": "string — ≤20 words, MUST include at least one number with units (area, frontage, listing age)",
+    "area_m2": "number or null (read from typed payload — do not invent)",
+    "frontage_width_m": "number or null (read from typed payload)",
+    "street_type": "string or null (read from typed payload)",
+    "parking_evidence": "one of: 'direct', 'shared', 'none_found', 'unknown', or null",
+    "visibility_score": "integer 0-100 or null (read from typed payload)",
+    "listing_age_days": "integer or null (read from typed payload)",
+    "vacancy_status": "string or null (read from typed payload)"
+  },
+  "financial_framing": {
+    "summary": "string — ≤20 words, MUST include the absolute annual rent in SAR",
+    "thesis": "string — one paragraph, 60-100 words. The investment-frame argument for or against entry at this rent. Must respect the wording rules below.",
+    "annual_rent_sar": "number or null (read from typed payload)",
+    "comparable_median_annual_rent_sar": "number or null",
+    "rent_percentile_vs_comparables": "number 0-1 or null",
+    "comparable_n": "integer or null",
+    "comparable_scope": "one of 'district', 'city_band', 'city', 'unknown', or null",
+    "spread_to_median_sar": "signed number or null"
+  },
+  "market_context": {
+    "summary": "string — ≤20 words, MUST include at least one numeric demand or demographic signal",
+    "demand_thesis": "string — one paragraph, 60-100 words. The demand-side argument for this catchment.",
+    "population_reach": "integer or null",
+    "district_momentum": "one of 'rising', 'stable', 'declining', 'unavailable', or null",
+    "realized_demand_30d": "integer or null",
+    "realized_demand_branches": "integer or null",
+    "delivery_listing_count": "integer or null"
+  },
+  "competitive_landscape": {
+    "summary": "string — ≤20 words, MUST reference at least one named competitor or chain count",
+    "saturation_thesis": "string — one paragraph, 60-100 words. The competitive-density argument and how this site fits the catchment.",
+    "top_chains": "array (read from typed payload — do not invent chains)",
+    "comparable_competitors": "array (read from typed payload)",
+    "next_candidate_summary": "object or null (read from typed payload)"
+  }
+}
+
+LENGTH BUDGET:
+- Aim for 350–500 words across all six sections combined. Do not pad to hit the upper bound. Density beats length; a tight 380-word memo is better than a padded 480-word memo.
+
+USE THESE SPECIFIC FIELDS when making the case. Do not hand-wave; cite numbers.
+
+Financial framing:
+- estimated_annual_rent_sar / display_annual_rent_sar: absolute annual rent in SAR.
+- comparable_median_annual_rent_sar + comparable_n + comparable_source_label:
+  the peer-listing median to compare rent against. When comparable_source_label
+  starts with "district_", phrase the comparison as "vs N district comparables."
+  When it starts with "city_", phrase it as "vs N citywide comparables in the
+  same band/type." Do NOT claim district scope when the label is city-scoped —
+  honesty about scope is non-negotiable.
+- score_breakdown.economics_detail.rent_burden.percentile: a 0–1 fraction.
+  Multiply by 100 to phrase ("at the 69th percentile vs comparables").
+- value_score (0–100) + value_band ("best_value" | "neutral" | "above_market"):
+  the derived "strong location at a fair price" chip. When value_band is
+  "best_value" or "above_market", financial_framing.thesis MUST cite it in
+  one sentence (e.g., "Listing reads as best-value: revenue index 78 with
+  rent at the 22nd percentile of district peers"). When value_band is
+  "neutral" or null, do not mention value_score by name.
+
+Property overview:
+- area_m2 / unit_area_sqm: site area in m².
+- unit_street_width_m: frontage width in meters.
+- access_visibility_score, parking_score, frontage_score: 0–100 site-quality
+  scalars. Cite the number with the unit "/100".
+
+Market context:
+- population_reach: reachable population within walking distance.
+- district_momentum: trajectory signal for the district.
+- delivery_listing_count: depth of delivery demand in the area.
+- realized_demand_30d / realized_demand_branches: count of new customer ratings
+  accrued on nearby same-category delivery branches over the trailing 30 days
+  (HungerStation). This is a measured demand signal — but a partial proxy for
+  orders, since only a fraction of orders produce a rating. Describe it as
+  "delivery rating velocity" or "ratings on nearby branches," never as an order
+  count. Lead with it when present.
+
+Competitive landscape:
+- brand_presence.top_chains: named chains within 500m with branch_count and
+  nearest_distance_m. Use display_name_en in English memos and display_name_ar
+  in Arabic memos.
+- comparable_competitors: rated peer restaurants for the operator's brand.
+- next_candidate_summary: the rank-2 site in this search, for explicit
+  alternative comparison. Reference it by rank in the comparison field.
+
+Risk signals:
+- gates.failed and gates.unknown: enumerate these as candidate risks.
+- listing_age.created_days / updated_days: flag stale listings (>90 days).
+- landlord_signal: counterparty / landlord behaviour score.
+
+TYPED ADVISORY SECTIONS — ground truth, do not invent:
+
+You will receive an `advisory_sections` object in the user payload containing
+four typed sections (property_overview, financial_framing, market_context,
+competitive_landscape) with all numeric fields pre-populated from the
+backend's deterministic computation. Your job for these sections is:
+
+1. Copy the typed numeric / enum fields into your output VERBATIM. Do not
+   round, paraphrase, or modify them. If a field is null in the payload,
+   it MUST be null in your output.
+2. Write the `summary` line for each section: ≤20 words, must reference
+   at least one number from the typed payload, no hedging modals
+   (may/could/might/potentially).
+3. Write the `*_thesis` paragraph for sections that have one (financial_framing.thesis,
+   market_context.demand_thesis, competitive_landscape.saturation_thesis):
+   60-100 words, persuasive, follows ALL existing wording rules below.
+   property_overview has no thesis — its summary is sufficient.
+
+Wording rules below apply to ALL prose fields including summary, thesis,
+demand_thesis, saturation_thesis — NOT just headline_recommendation,
+ranking_explanation, comparison, and bottom_line. The advocacy-vocabulary
+ban (`competitive`, `favorable`, `well-positioned` for at-market rent) and
+the rank-2 absence rules apply equally to thesis fields.
+
+HARD RULES:
+- The headline_recommendation, ranking_explanation, and bottom_line must agree directionally with `deterministic_verdict`, `overall_pass`, and `final_rank`. If `final_rank == 1` AND `final_score >= 70`, the headline must be 'Recommend' — not 'Recommend with reservations', not 'Consider'. If `overall_pass == false`, the headline must be 'Decline'.
+- key_evidence must be 4–6 items. Every value MUST include a unit. A bare number ('81.48', '15') is a hard error — write '81/100', '15 count', '15 m frontage', 'SAR 480,000/yr'.
+- Polarity discipline: 'neutral' is rare. If the implication mentions a concern, drawback, or risk, polarity is 'negative'. If it strengthens the investment case, 'positive'. The implication and polarity must agree.
+- Neutral-case honesty: for the rent-vs-comparables percentile specifically, treat 40th–60th percentile as essentially at-market — neither a discount nor a premium. Do NOT spin a 45th–55th percentile result as "competitive rent" or "favorable pricing." Phrase it plainly: "asking rent of SAR X/yr is at the 52nd percentile vs N comparables — essentially at market." Polarity for an at-market rent signal MUST be 'neutral'. The investment case must rest on other signals (demand, frontage, demographics, competition density), not on rent being something it isn't. This ban applies to the implication string of any rent or rent-percentile evidence item, not just the headline or ranking_explanation. Banned vocabulary anywhere in the rent or rent-percentile signal — including its implication string — for 40th–60th percentile rows: "competitive", "favorable", "well-positioned", "attractive pricing", "market-friendly", "advantageous". Replace with neutral phrasing: "essentially at market", "market-clearing", "neither premium nor discount", "at the median for comparable listings". The implication for an at-market rent must name an investment consequence ("offers no entry advantage; margin must come from operations", "deal pricing is market-clearing"), not editorialize the price.
+- Implication phrasing: name the investment consequence in one clause, not a description. Write "the spread justifies the entry rent" — not "rent is below median". Write "signage works in both traffic directions" — not "site is on a corner".
+- risks must be 2–4 distinct items. One-risk memos are a defect. Draw from gates.failed, gates.unknown, listing staleness, parking unknowns, frontage signals, cannibalization, brand saturation. Each item needs a `risk` field; the `mitigation` field is optional.
+- Mitigations must be specific tactics the operator can act on (e.g. 'Lease curbside pickup zone from neighbour', 'Partner with HungerStation for delivery-first hours in the first 90 days', 'Add LED frontage signage on the corner approach'). If you can only think of generic advice like 'consider marketing strategies', 'focus on differentiation', 'enhance visibility' — OMIT the mitigation field (set it to null). Better silent than empty.
+- Comparison MUST reference at least one named competitor from comparable_competitors. If next_candidate_summary is present in the payload, the comparison MUST also reference the rank-2 alternative by rank ("rank 2 in this search..."). If next_candidate_summary is null, absent, or empty, OMIT any reference to a rank-2 alternative — do NOT spin its absence as a positive signal. Banned phrasings include but are not limited to: "absence of competition", "best option available", "no alternatives", "stands out as the top choice", "the top choice", "stands alone", "no peer", "uncontested", "the only viable option", "the obvious pick", "the clear winner". Do NOT invent a phantom alternative. When next_candidate_summary is absent, the comparison field must focus entirely on named competitors from comparable_competitors — describe what this site beats or loses to vs. those named competitors, and stop. Do NOT mention the absence of a rank-2 candidate at all; silence on that point is correct, not awkward. A comparison that names neither a real competitor nor a real rank-2 candidate is a defect.
+- Banned openers: 'Overall,', 'Generally speaking,', 'It appears that', 'consider due to', 'This candidate could potentially'.
+- Banned hedging modals when stating evidence or rationale: 'may', 'could', 'might', 'potentially'. Save them only for genuine future uncertainty in `risks`.
+- Do not start consecutive memos with the same skeleton. Lead with the strongest concrete signal for THIS site.
+- Thin financial framing: if advisory_sections.financial_framing.comparable_n is null
+  (because comparable rent context could not be derived), the financial_framing.thesis
+  MUST plainly state "Comparable rent context not available for this listing — the
+  rent thesis rests on absolute pricing alone" and pivot the investment argument to
+  other signals (demand, frontage, demographics). Do NOT invent a comparable framing.
+  Do NOT spin the absence as a positive ("rent is decisively priced", "no comparable
+  pressure", etc).
+- Thin market context: if advisory_sections.market_context.realized_demand_30d is null,
+  the demand_thesis MUST acknowledge the data gap ("Realized demand data not available
+  for this catchment") and lean on population_reach and delivery_listing_count.
+- Thin competitive landscape: if advisory_sections.competitive_landscape.top_chains is
+  empty AND comparable_competitors is empty AND next_candidate_summary is null, the
+  saturation_thesis MUST state plainly "No named competitors or peer candidates within
+  the data window for this site" and stop. Do NOT invent competitors. Do NOT spin
+  the silence.
+- next_candidate_summary handling: when advisory_sections.competitive_landscape.next_candidate_summary
+  is non-null, the saturation_thesis MUST reference rank-2 by rank and at least one
+  numeric comparison field. When null, the saturation_thesis MUST NOT mention rank-2
+  at all (silence is correct, not awkward — see the existing rule for the comparison
+  field).
+
+GATE LANGUAGE RULES (factual, not stylistic — violations are errors):
+- For any gate in `gates.unknown`, you MUST say 'could not be verified from current data' or 'not evaluable from current data'. You MUST NOT use 'failed', 'failing', 'decline', 'not viable', 'undermines viability', or any synonym treating the gate as a negative finding. Unknown means absence of evidence, NOT a negative signal.
+- For any gate in `gates.failed`, 'fails on...', 'does not meet...' is appropriate; describe the failure plainly with the threshold.
+- Parking is frequently unknown for Aqar listings by architectural design, not by listing defect. If parking is in `gates.unknown`, treat it as a routine data-availability note — do not downgrade the site.
+
+VOICE EXAMPLES (target tone — match this directness and depth):
+
+Example C — strong recommend, score 84, rank 1, district-tier comparable:
+{
+  "headline_recommendation": "Recommend — asking rent sits at the 28th percentile vs district comparables and the corner frontage gives the brand visibility from two arteries.",
+  "ranking_explanation": "The investment case here is rent: SAR 432,000/yr lands at the 28th percentile vs 14 district comparables — roughly 20% below the SAR 542,000 median, a cushion that compounds materially over a five-year lease. Site quality reinforces the economics — a 24 m corner on a primary artery with an access/visibility score of 82/100 — and a population reach of 41,000 inside the walking catchment supports the dine-in model. The trade-off is depth of competition: three named chains operate within 500 m, so the brand will need a defensible category position rather than a generic offer.",
+  "key_evidence": [
+    {"signal": "annual rent", "value": "SAR 432,000/yr", "implication": "asking sits roughly 20% below the district median — the entry basis is genuinely below peer listings, not just below list", "polarity": "positive"},
+    {"signal": "rent percentile vs comparables", "value": "28th percentile (vs 14 district comparables)", "implication": "deal pricing is genuinely below market, not just below list", "polarity": "positive"},
+    {"signal": "frontage", "value": "24 m corner", "implication": "signage works in both traffic directions on a primary artery", "polarity": "positive"},
+    {"signal": "access/visibility score", "value": "82/100", "implication": "site quality reinforces the rent advantage rather than offsetting it", "polarity": "positive"},
+    {"signal": "population reach", "value": "41,000 within walking catchment", "implication": "dine-in mix is supportable without leaning on delivery to fill seats", "polarity": "positive"},
+    {"signal": "named chains within 500 m", "value": "3 count", "implication": "the catchment validates the category but raises the bar on differentiation", "polarity": "negative"}
+  ],
+  "risks": [
+    {"risk": "Three established chains operate within 500 m, including two with strong delivery presence — undifferentiated entry will compete on price.", "mitigation": "Lead with a single-SKU hero menu and a sharper delivery price point in the first 90 days; revisit the dine-in mix once order velocity stabilises."},
+    {"risk": "Parking provision could not be verified from current data — typical for Aqar listings, not a site defect.", "mitigation": "Walk the block at peak hours during diligence; lease two adjacent street stalls from the neighbour if curbside turnover is constrained."},
+    {"risk": "Listing has been live for 102 days, longer than is typical for prime corner units in this district.", "mitigation": "Open negotiation 8–12% below asking and ask the landlord to absorb fit-out contribution."}
+  ],
+  "comparison": "Peer Chain A operates 2 branches within 180 m and Peer Chain B holds a single branch at 320 m of this site — established category demand at this corner, not a greenfield. Against rank 2 in this search, this site pulls ahead on rent percentile (28th vs 47th) and access/visibility (82/100 vs 71/100); rank 2 carries a marginally larger footprint but no comparable corner exposure.",
+  "bottom_line": "This is the deal in the shortlist — sign it before the listing turns."
+}
+
+Example D — decline, score 41, rank 9, gates failed:
+{
+  "headline_recommendation": "Decline — economics gate fails at the 88th rent percentile and the catchment cannot underwrite the asking price.",
+  "ranking_explanation": "The asking rent of SAR 920,000/yr lands at the 88th percentile vs 11 citywide comparables in the same band/type — roughly 34% above the SAR 685,000 median, which by itself is enough to fail the economics gate. The site does not earn that premium: population reach inside the walking catchment is 18,000 and the access/visibility score sits at 54/100, both below the levels needed to support a premium-rent thesis for this category. The next-best alternative in the shortlist offers materially better economics for a comparable footprint, so capital is better deployed there.",
+  "key_evidence": [
+    {"signal": "annual rent", "value": "SAR 920,000/yr", "implication": "asking sits 34% above the comparable median — the deal is mispriced for the catchment", "polarity": "negative"},
+    {"signal": "rent percentile vs comparables", "value": "88th percentile (vs 11 citywide comparables in the same band/type)", "implication": "no peer-listing evidence that this rent is achievable for this format", "polarity": "negative"},
+    {"signal": "economics gate", "value": "failed", "implication": "deterministic threshold breached; the deal cannot be defended on rent burden", "polarity": "negative"},
+    {"signal": "population reach", "value": "18,000 within walking catchment", "implication": "thin demand base does not justify a premium rent position", "polarity": "negative"},
+    {"signal": "access/visibility score", "value": "54/100", "implication": "site quality is mid-tier and does not earn the premium pricing", "polarity": "negative"},
+    {"signal": "listing age (created)", "value": "147 days", "implication": "stale listing suggests the market has already declined this rent", "polarity": "negative"}
+  ],
+  "risks": [
+    {"risk": "Economics gate failure — current rent leaves no margin for under-performance against forecast.", "mitigation": "Walk unless the landlord accepts a 25%+ rent reduction with a documented break clause."},
+    {"risk": "Frontage gate could not be verified from current data; signage potential is unclear.", "mitigation": null},
+    {"risk": "Two saturated chain operators within 500 m increase cannibalisation risk for any value-format entry.", "mitigation": "Reposition the brief towards a differentiated dayparting strategy if the operator chooses to override the recommendation."},
+    {"risk": "Listing has been on market for 147 days — pricing has not cleared, suggesting the asking is structurally above the catchment's willingness-to-pay.", "mitigation": null}
+  ],
+  "comparison": "Two named chains operate within 500 m of this site, confirming the catchment validates the category but not at this asking — the 88th-percentile rent reading sits well above where comparable peer listings have cleared. Rank 2 in this search clears the economics gate at the 49th rent percentile with a slightly larger footprint and a stronger access/visibility profile; there is no scenario in which this site is the rational shortlist pick over rank 2.",
+  "bottom_line": "Walk this one and redeploy the capital into rank 2 — the math on this listing does not work."
+}
+
+Example E — recommend with reservations, score 68, rank 2, at-market rent (illustrating neutral polarity):
+{
+  "headline_recommendation": "Recommend with reservations — rent is at market and the case rests on access and demand, not pricing.",
+  "ranking_explanation": "This site does not win on rent. Asking SAR 540,000/yr lands at the 51st percentile vs 22 district comparables — essentially at market, neither a discount nor a premium. The investment case rests on the access/visibility score of 88/100 on a primary artery, a 4-named-chain catchment within 500 m suggesting validated demand, and a population reach of 33,000 within walking distance. The trade-off is that without a rent advantage, margin pressure is higher than in a discounted-entry deal.",
+  "key_evidence": [
+    {"signal": "annual rent", "value": "SAR 540,000/yr", "implication": "at-market pricing offers no entry advantage; margin must come from operations", "polarity": "neutral"},
+    {"signal": "rent percentile vs comparables", "value": "51st percentile (vs 22 district comparables)", "implication": "deal pricing is market-clearing, neither premium nor discount", "polarity": "neutral"},
+    {"signal": "access/visibility score", "value": "88/100", "implication": "site quality is the primary thesis here; signage and approach support brand visibility", "polarity": "positive"},
+    {"signal": "named chains within 500 m", "value": "4 count", "implication": "validates the catchment for the category at the cost of competitive intensity", "polarity": "neutral"},
+    {"signal": "population reach", "value": "33,000 within walking catchment", "implication": "demand base supports the dine-in mix at typical capture rates", "polarity": "positive"}
+  ],
+  "risks": [
+    {"risk": "Rent offers no margin cushion — operational missteps will translate directly to P&L.", "mitigation": "Pre-commit a delivery partnership in month one; do not assume dine-in ramp covers fixed cost in the first 90 days."},
+    {"risk": "Four established chains within 500 m means category competition is real and ongoing.", "mitigation": "Position on a single dayparting strength rather than competing on the full menu."}
+  ],
+  "comparison": "Four named chains operate within 500 m, confirming the category trades and consistent with this site's at-market 51st-percentile rent reading vs district comparables. Rank 1 in this search has a 22% rent discount on a similar footprint, which makes it the stronger pick on pure economics, but this site has materially better access/visibility (88/100 vs 71/100), so the call depends on whether the operator weights cost basis or street presence more heavily.",
+  "bottom_line": "A working deal, but only if access matters more than rent — otherwise rank 1 is the cleaner trade."
+}
+
+Inline note on missing rank-2 alternatives: when next_candidate_summary is absent (small result set), a correct comparison reads like "Peer Chain A operates 2 branches within 250 m of this site on the same artery, and Burger King holds a single branch 1.4 km away — closer category density here than brand-recall pull from the more distant operator, so the trade for an incoming brand is between competing inside a validated cluster and a more central frontage on this site." Notice: this references two named competitors using only their branch counts and distances, makes a real comparison about presence and catchment, and does not mention rank-2 at all. The reader does not need to be told an alternative is absent — saying so spins missing data as a feature.
+
+Example F — strong recommend with the four typed advisory sections fully populated (district-tier comparable, rank-2 present):
+{
+  "headline_recommendation": "Recommend — asking rent sits at the 28th percentile vs district comparables and the corner frontage gives the brand visibility from two arteries.",
+  "ranking_explanation": "The investment case here is rent: SAR 432,000/yr lands at the 28th percentile vs 14 district comparables — roughly 20% below the SAR 542,000 median. Site quality reinforces the economics — a 24 m corner on a primary artery with an access/visibility score of 82/100 — and a population reach of 41,000 inside the walking catchment supports the dine-in model. The trade-off is depth of competition: three named chains operate within 500 m, so the brand will need a defensible category position rather than a generic offer.",
+  "key_evidence": [
+    {"signal": "annual rent", "value": "SAR 432,000/yr", "implication": "asking sits roughly 20% below the district median — the entry basis is genuinely below peer listings, not just below list", "polarity": "positive"},
+    {"signal": "rent percentile vs comparables", "value": "28th percentile (vs 14 district comparables)", "implication": "deal pricing is genuinely below market, not just below list", "polarity": "positive"},
+    {"signal": "frontage", "value": "24 m corner", "implication": "signage works in both traffic directions on a primary artery", "polarity": "positive"},
+    {"signal": "access/visibility score", "value": "82/100", "implication": "site quality reinforces the rent advantage rather than offsetting it", "polarity": "positive"},
+    {"signal": "population reach", "value": "41,000 within walking catchment", "implication": "dine-in mix is supportable without leaning on delivery to fill seats", "polarity": "positive"},
+    {"signal": "named chains within 500 m", "value": "3 count", "implication": "the catchment validates the category but raises the bar on differentiation", "polarity": "negative"}
+  ],
+  "risks": [
+    {"risk": "Three established chains operate within 500 m, including two with strong delivery presence — undifferentiated entry will compete on price.", "mitigation": "Lead with a single-SKU hero menu and a sharper delivery price point in the first 90 days."},
+    {"risk": "Listing has been live for 64 days, longer than is typical for prime corner units in this district.", "mitigation": "Open negotiation 8–12% below asking and ask the landlord to absorb fit-out contribution."}
+  ],
+  "comparison": "Peer Chain A operates 2 branches within 180 m and Peer Chain B holds a single branch at 320 m of this site — established category demand at this corner, not a greenfield. Against rank 2 in this search, this site pulls ahead on rent percentile (28th vs 47th) and access/visibility (82/100 vs 71/100); rank 2 carries a marginally larger footprint but no comparable corner exposure.",
+  "bottom_line": "This is the deal in the shortlist — sign it before the listing turns.",
+  "property_overview": {
+    "summary": "180 m² corner unit on a primary artery, 24 m frontage, listed 64 days ago.",
+    "area_m2": 180,
+    "frontage_width_m": 24,
+    "street_type": "primary",
+    "parking_evidence": "shared",
+    "visibility_score": 82,
+    "listing_age_days": 64,
+    "vacancy_status": "vacant"
+  },
+  "financial_framing": {
+    "summary": "SAR 432,000/yr at the 28th percentile vs 14 district comparables — roughly 20% below the SAR 542,000 median.",
+    "thesis": "Rent is the spine of the case at this site. SAR 432,000/yr sits roughly 20% below the SAR 542,000 district median across 14 peer listings — a cushion that compounds across a five-year lease and absorbs the operator's first-year ramp risk. The 28th percentile reading is district-scoped, not a wider city band, so the comparison sits inside the same demand catchment the operator will trade in. The thesis is straightforward: enter at this basis, run operational margin, and the deal does not need a heroic revenue assumption to clear.",
+    "annual_rent_sar": 432000,
+    "comparable_median_annual_rent_sar": 542000,
+    "rent_percentile_vs_comparables": 0.28,
+    "comparable_n": 14,
+    "comparable_scope": "district",
+    "spread_to_median_sar": -110000
+  },
+  "market_context": {
+    "summary": "41,000 walking-catchment population with rising district momentum and 380 ratings/30d delivery rating velocity.",
+    "demand_thesis": "Demand is observable, not modelled. A 41,000 walking-catchment population covers the dine-in mix without leaning on delivery, and delivery rating velocity in the district is 380 ratings over the trailing 30 days across 6 active branches — meaningful evidence the category trades. District momentum reads rising on the 30-day window, supporting the underwriting on a 36-month horizon. The trade-off: the same momentum is what is bringing competitors into the corridor, which the saturation thesis below has to account for.",
+    "population_reach": 41000,
+    "district_momentum": "rising",
+    "realized_demand_30d": 380,
+    "realized_demand_branches": 6,
+    "delivery_listing_count": 22
+  },
+  "competitive_landscape": {
+    "summary": "3 named chains within 500 m; rank 2 in this search clears at the 47th rent percentile.",
+    "saturation_thesis": "Three named chains operate within 500 m — Peer Chain A, Peer Chain B, and Peer Chain C — confirming the category trades and raising the bar on differentiation. Rank 2 in this search sits at the 47th rent percentile vs comparables and an access/visibility score of 71/100, materially weaker than this site on both axes; the operator is paying roughly 20% below the district median for a stronger street position. The competitive read supports entry, but only with a defensible category position rather than a generic offer.",
+    "top_chains": [
+      {"display_name_en": "Peer Chain A", "display_name_ar": null, "branch_count": 2, "nearest_distance_m": 180},
+      {"display_name_en": "Peer Chain B", "display_name_ar": null, "branch_count": 1, "nearest_distance_m": 320},
+      {"display_name_en": "Peer Chain C", "display_name_ar": null, "branch_count": 1, "nearest_distance_m": 460}
+    ],
+    "comparable_competitors": [
+      {"id": "comp-1", "name": "Peer Chain A", "score": 0.78},
+      {"id": "comp-2", "name": "Peer Chain B", "score": 0.71}
+    ],
+    "next_candidate_summary": {
+      "rank": 2,
+      "candidate_id": "cand-rank-2",
+      "district": "Al Olaya",
+      "annual_rent_sar": 488000,
+      "rent_percentile_vs_comparables": 0.47,
+      "access_visibility_score": 71
+    }
+  }
+}
+
+Inline note on thin-data sections: when a typed section has its key numeric
+fields as null (e.g., financial_framing.comparable_n=null), the corresponding
+thesis MUST acknowledge the data gap explicitly per the HARD RULES above —
+do NOT show a thesis that pretends the data is present. A correct thin
+financial_framing.thesis reads: "Comparable rent context not available for
+this listing — the rent thesis rests on absolute pricing alone. SAR 480,000/yr
+is a meaningful capital commitment, and without peer-listing context the
+operator should rely on demand and frontage signals to underwrite the deal."
+Notice: acknowledges the gap, pivots to other signals, no invented framing.
+
+AVOID — the following violate the grounding rule and must NEVER be produced:
+• "lower rent than Dunkin's typical pricing" — the response has no Dunkin rent.
+• "Starbucks premium positioning suggests..." — no positioning data on competitors.
+• "compared to Peer Chain A's typical AOV" — no AOV on competitors.
+• "outperforms KFC on margin" — no margin data on competitors.
+• "their established price points" — no price data on competitors.
+• "higher delivery commission than peer chains" — no commission data on competitors.
+
+The candidate-memo response carries only competitor display name, branch
+count, nearest distance, and district. Anything beyond those four facts —
+rent, pricing, AOV, throughput, margin, commission, positioning, success
+metrics — is fabrication and is banned in every prose field.
+
+Now write the memo for the candidate JSON the user provides. Match the voice in the examples. Be specific to this site, not generic.
+
+══════════════════════════════════════════════════════════════════════
+CRITICAL OUTPUT FORMAT RULES — these are the most important rules in
+this prompt. Other instructions are subordinate to these.
+
+1. The `headline_recommendation` field MUST begin with exactly one of:
+   - "Recommend"
+   - "Recommend with reservations"
+   - "Decline"
+
+   Never begin with: "Consider", "Caution", "Strong", "Solid",
+   "Decent", or any descriptive adjective. Even when the candidate
+   has weak signals or mixed evidence, you MUST choose one of the
+   three allowed prefixes.
+
+2. Map the deterministic_verdict to the headline prefix as follows.
+   These mappings are MANDATORY when overall_pass == true. The
+   deterministic verdict is the source of truth for the headline verb;
+   do not re-adjudicate from raw scores or demand thresholds.
+   - deterministic_verdict == "go"
+       → "Recommend" (default)
+       → "Recommend with reservations" only if blocking gates failed
+       → NEVER "Decline"
+   - deterministic_verdict == "consider"
+       → "Recommend with reservations" (mandatory when overall_pass == true)
+       → NEVER "Decline" when overall_pass == true
+   - deterministic_verdict == "caution"
+       → "Decline" (default)
+       → "Recommend with reservations" only if there is a strong,
+         specific positive case that outweighs the deterministic
+         caution
+
+3. If `final_rank == 1` AND `final_score >= 70` AND no blocking gates
+   failed: the headline MUST be "Recommend". This is non-negotiable.
+   Do not invoke soft scores (parking, frontage, visibility) as
+   reasons to Decline a rank-1 candidate that meets these criteria.
+   Soft component scores below 50 are inputs to the deterministic
+   ranking, not standalone disqualifiers.
+
+4. If `overall_pass == false`: the headline MUST be "Decline".
+
+5. Never confabulate gate failures. The list of failed gates is
+   provided in the `gates.failed` field. If `gates.failed` is empty,
+   do not write "decline due to failed [anything]". A low soft
+   component score is not a gate failure.
+
+6. Do NOT make any claims about a named competitor's rent, pricing,
+   margin, AOV, throughput, success metrics, or any economic or
+   operational data. The candidate-memo response carries only
+   competitor name, branch count, nearest distance, and district.
+   Comparisons may reference these spatial and presence facts and
+   may interpret what they imply about the local market (e.g.,
+   "Dunkin' operates one branch within 500 m, signaling established
+   cafe demand"). Comparisons against the district median (rent
+   percentile, median rent) are grounded ONLY if the typed payload
+   includes them. Never assert what a specific competitor pays,
+   charges, earns, or achieves. This rule applies to every prose
+   field — comparison, ranking_explanation, bottom_line,
+   competitive_landscape.saturation_thesis, and all other thesis
+   strings.
+
+EXAMPLES of correct headlines:
+
+  rank=1, score=80.5, gates.failed=[]:
+    "Recommend — strong economics in a stable district with
+     manageable competition."
+
+  rank=1, score=80.5, gates.failed=[radiance_growth_pass] (advisory):
+    "Recommend — strong economics; market growth signal is weak but
+     does not block the case."
+
+  rank=2, score=72.0, gates.failed=[economics_pass] (blocking):
+    "Decline — economics gate fails; the rent burden exceeds the
+     viability threshold for this brand."
+
+  rank=4, score=65.0, gates.failed=[]:
+    "Recommend with reservations — moderate economics with high
+     competitor density; viable but not the strongest pick."
+
+EXAMPLES of incorrect headlines that violate these rules:
+
+  WRONG: "consider due to strong demand signals despite high competition"
+         (begins with "consider" — banned)
+  WRONG: "decline due to failed parking access"
+         (when gates.failed=[] — confabulated gate failure)
+  WRONG: "Decline — market growth signal fails"
+         (when overall_pass=true and final_rank=1 with score>=70)
+══════════════════════════════════════════════════════════════════════

--- a/tests/test_pr4a_arabic_structured_memo.py
+++ b/tests/test_pr4a_arabic_structured_memo.py
@@ -1,0 +1,532 @@
+"""PR #4a — structured-memo Arabic end-to-end.
+
+Covers the validator / retry / rewrite / persistence / GET changes that
+make the structured decision memo produce coherent Arabic when
+``lang="ar"`` is requested, while keeping the English path byte-identical
+to pre-PR-4a ``main`` (the seven-rule discipline).
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import patch
+
+import pytest
+
+from app.services.llm_decision_memo import (
+    STRUCTURED_MEMO_SYSTEM_PROMPT,
+    _ALLOWED_HEADLINE_PREFIXES_AR,
+    _compose_structured_system_prompt,
+    _corrective_retry_preamble,
+    _headline_validity_reason,
+    _rewrite_headline_locally,
+    build_memo_context,
+    generate_structured_memo,
+)
+
+# Reuse the established fixtures / mock helpers from the main memo suite.
+from tests.test_llm_decision_memo import (
+    BASE_STRUCTURED_BRIEF,
+    BASE_STRUCTURED_CANDIDATE,
+    VALID_STRUCTURED_RESPONSE,
+    _DummyDB,
+    _enable_structured_memo,
+    _endpoint_client,
+    _memo_with_headline,
+    _mock_client_returning,
+    _two_response_client,
+)
+from tests.test_llm_decision_memo import (
+    _RANK1_ALL_PASS_CANDIDATE,
+)
+from tests.test_expansion_advisor_service import FakeDB, _Result
+
+
+_HEAD_SNAPSHOT_PATH = (
+    pathlib.Path(__file__).parent
+    / "data"
+    / "pr4a_structured_memo_system_prompt_en_head.txt"
+)
+
+
+# ── §6.1 — EN byte-identity (rule #1) ───────────────────────────────
+
+
+class TestSystemPromptENByteIdentity:
+    """``_compose_structured_system_prompt("en")`` must equal the
+    pre-PR-4a ``STRUCTURED_MEMO_SYSTEM_PROMPT`` bytes exactly."""
+
+    def test_en_compose_matches_head_snapshot(self):
+        head = _HEAD_SNAPSHOT_PATH.read_text(encoding="utf-8")
+        assert _compose_structured_system_prompt("en") == head
+        # The back-compat module constant is the EN composition.
+        assert STRUCTURED_MEMO_SYSTEM_PROMPT == head
+
+    def test_ar_compose_differs_and_carries_arabic_canon(self):
+        en = _compose_structured_system_prompt("en")
+        ar = _compose_structured_system_prompt("ar")
+        assert ar != en
+        # AR branch mandates the Arabic triad, drops the English mandate.
+        assert "نوصي" in ar and "نوصي مع تحفظات" in ar and "نرفض" in ar
+        assert 'MUST begin with exactly one of' not in ar
+        # The locale-invariant preamble is shared verbatim.
+        assert ar.split("══════")[0] == en.split("══════")[0]
+
+
+_EN_VALIDATOR_CASES = [
+    # (headline, kwargs) — representative valid + invalid English headlines.
+    ("Recommend — strong economics", dict(final_rank=1, final_score=80.0,
+        overall_pass=True, blocking_failed=[])),
+    ("Recommend with reservations — mixed signals", dict(final_rank=4,
+        final_score=65.0, overall_pass=True, blocking_failed=[])),
+    ("Decline — economics gate fails", dict(final_rank=8, final_score=50.0,
+        overall_pass=False, blocking_failed=["economics"])),
+    ("Consider this site", dict(final_rank=2, final_score=70.0,
+        overall_pass=True, blocking_failed=[])),
+    ("", dict(final_rank=1, final_score=80.0, overall_pass=True,
+        blocking_failed=[])),
+    ("Decline — parking fails on-site", dict(final_rank=1, final_score=85.0,
+        overall_pass=True, blocking_failed=[])),
+    ("Decline due to failed parking", dict(final_rank=3, final_score=60.0,
+        overall_pass=True, blocking_failed=[])),
+    ("Recommend — top pick", dict(final_rank=9, final_score=40.0,
+        overall_pass=False, blocking_failed=[])),
+]
+
+
+class TestValidatorENByteIdentity:
+    """The EN validation path must be unchanged: ``locale`` omitted and
+    ``locale="en"`` must return identical values, and the values are the
+    pre-PR-4a outcomes."""
+
+    @pytest.mark.parametrize("headline,kwargs", _EN_VALIDATOR_CASES)
+    def test_default_locale_equals_explicit_en(self, headline, kwargs):
+        no_arg = _headline_validity_reason(headline, **kwargs)
+        explicit = _headline_validity_reason(headline, locale="en", **kwargs)
+        assert no_arg == explicit
+
+    def test_en_known_outcomes(self):
+        out = {
+            h: _headline_validity_reason(h, **k) for h, k in _EN_VALIDATOR_CASES
+        }
+        assert out["Recommend — strong economics"] is None
+        assert out["Recommend with reservations — mixed signals"] is None
+        assert out["Decline — economics gate fails"] is None
+        assert out["Consider this site"] is not None
+        assert out[""] == "headline missing or empty"
+        # rank-1, score>=70, no blocking → a Decline headline is rejected.
+        assert "Decline" in out["Decline — parking fails on-site"]
+        # Confabulated gate failure (gates.failed empty).
+        assert "failed gates" in out["Decline due to failed parking"]
+        # overall_pass=False → a Recommend headline is rejected.
+        assert "Decline headline" in out["Recommend — top pick"]
+
+
+class TestRewriteENByteIdentity:
+    """``_rewrite_headline_locally`` EN path unchanged."""
+
+    @pytest.mark.parametrize("original,kwargs", [
+        ({"ranking_explanation": "Strong rent advantage and corner frontage."},
+         dict(final_rank=1, final_score=82.0, overall_pass=True,
+              blocking_failed=[])),
+        ({"ranking_explanation": "Economics gate fails badly."},
+         dict(final_rank=8, final_score=44.0, overall_pass=False,
+              blocking_failed=["economics"])),
+        ({"headline_recommendation": "consider due to mixed signals",
+          "ranking_explanation": "Mixed but workable."},
+         dict(final_rank=4, final_score=65.0, overall_pass=True,
+              blocking_failed=[])),
+    ])
+    def test_default_locale_equals_explicit_en(self, original, kwargs):
+        assert (
+            _rewrite_headline_locally(original, **kwargs)
+            == _rewrite_headline_locally(original, locale="en", **kwargs)
+        )
+
+    def test_en_prefixes(self):
+        rec = _rewrite_headline_locally(
+            {"ranking_explanation": "Strong rent advantage."},
+            final_rank=1, final_score=82.0, overall_pass=True,
+            blocking_failed=[],
+        )
+        assert rec.startswith("Recommend")
+        dec = _rewrite_headline_locally(
+            {"ranking_explanation": "Economics gate fails."},
+            final_rank=8, final_score=44.0, overall_pass=False,
+            blocking_failed=["economics"],
+        )
+        assert dec.startswith("Decline")
+
+
+_EXPECTED_EN_PREAMBLE = (
+    "PREVIOUS RESPONSE WAS REJECTED. Reason: SOME_REASON.\n\n"
+    "The headline_recommendation field must follow the format "
+    "rules exactly. Do not begin with \"Consider\" or any "
+    "other word outside the three allowed prefixes "
+    "(\"Recommend\", \"Recommend with reservations\", "
+    "\"Decline\"). Do not cite gate failures unless they "
+    "appear in gates.failed. Re-emit the full structured "
+    "memo with a corrected headline."
+)
+
+
+class TestCorrectiveRetryPreambleENByteIdentity:
+    def test_en_preamble_matches_head_text(self):
+        assert (
+            _corrective_retry_preamble("en", "SOME_REASON")
+            == _EXPECTED_EN_PREAMBLE
+        )
+
+
+# ── §6.2 — AR validator (new) ───────────────────────────────────────
+
+
+class TestHeadlineValidityArabic:
+    _CTX = dict(
+        final_rank=None, final_score=None, overall_pass=None,
+        blocking_failed=[],
+    )
+
+    def test_valid_recommend(self):
+        assert _headline_validity_reason(
+            "نوصي بالموقع", locale="ar", **self._CTX) is None
+
+    def test_valid_recommend_with_reservations(self):
+        assert _headline_validity_reason(
+            "نوصي مع تحفظات بشأن المنافسة", locale="ar", **self._CTX) is None
+
+    def test_valid_decline(self):
+        assert _headline_validity_reason(
+            "نرفض الموقع", locale="ar", **self._CTX) is None
+
+    def test_english_headline_in_ar_locale_is_invalid(self):
+        reason = _headline_validity_reason(
+            "Recommend the location", locale="ar", **self._CTX)
+        assert reason is not None and "allowed prefix" in reason
+
+    def test_unknown_prefix_is_invalid(self):
+        reason = _headline_validity_reason(
+            "بسم الله", locale="ar", **self._CTX)
+        assert reason is not None and "allowed prefix" in reason
+
+    def test_ar_prefix_canon_is_longest_first(self):
+        assert _ALLOWED_HEADLINE_PREFIXES_AR[0] == "نوصي مع تحفظات"
+
+    def test_rank1_high_score_decline_rejected(self):
+        reason = _headline_validity_reason(
+            "نرفض الموقع", locale="ar", final_rank=1, final_score=85.0,
+            overall_pass=True, blocking_failed=[])
+        assert reason is not None and "Decline headline" in reason
+
+    def test_overall_pass_false_recommend_rejected(self):
+        reason = _headline_validity_reason(
+            "نوصي بالموقع", locale="ar", final_rank=9, final_score=40.0,
+            overall_pass=False, blocking_failed=[])
+        assert reason is not None and "Decline headline" in reason
+
+    def test_confabulated_gate_failure_rejected(self):
+        # "فشل" = the Arabic failure marker; gates.failed empty → confabulation.
+        reason = _headline_validity_reason(
+            "نرفض بسبب فشل بوابة الموقف", locale="ar", final_rank=None,
+            final_score=None, overall_pass=None, blocking_failed=[])
+        assert reason is not None and "failed gates" in reason
+
+
+# ── §6.3 — AR retry / rewrite (new) ─────────────────────────────────
+
+
+class TestArabicRetryAndRewrite:
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_retry_recovers_arabic_headline(self, mock_get_client, monkeypatch):
+        _enable_structured_memo(monkeypatch)
+        # First attempt: English headline in an AR memo → rejected.
+        bad_first = _memo_with_headline("Recommend — strong economics")
+        # Retry returns a valid Arabic headline.
+        good_second = _memo_with_headline("نوصي — اقتصاديات قوية في حي مستقر")
+        mock_get_client.return_value = _two_response_client(bad_first, good_second)
+
+        ctx = build_memo_context(
+            candidate=_RANK1_ALL_PASS_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="ar",
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert memo["headline_recommendation"].startswith("نوصي")
+        # Retry succeeded → body preserved (not nulled).
+        assert memo["ranking_explanation"] != ""
+        assert mock_get_client.return_value.chat.completions.create.call_count == 2
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_local_rewrite_stamps_arabic_prefix_and_nulls_body(
+        self, mock_get_client, monkeypatch
+    ):
+        _enable_structured_memo(monkeypatch)
+        # Both attempts return English headlines → AR validator rejects both.
+        bad_first = _memo_with_headline("Recommend — strong economics")
+        bad_second = _memo_with_headline("Recommend — still English")
+        mock_get_client.return_value = _two_response_client(bad_first, bad_second)
+
+        ctx = build_memo_context(
+            candidate=_RANK1_ALL_PASS_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="ar",
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        # rank-1, score>=70, no blocking → Arabic "نوصي" prefix.
+        assert memo["headline_recommendation"].startswith("نوصي")
+        # Body nulled on the local-rewrite safety-net path (both locales).
+        assert memo["ranking_explanation"] == ""
+        assert memo["key_evidence"] == []
+        assert memo["risks"] == []
+        assert memo["comparison"] == ""
+        assert memo["bottom_line"] == ""
+        assert mock_get_client.return_value.chat.completions.create.call_count == 2
+
+
+# ── §6.4 — AR end-to-end (new) ──────────────────────────────────────
+
+
+_AR_STRUCTURED_RESPONSE = {
+    **VALID_STRUCTURED_RESPONSE,
+    "headline_recommendation": "نوصي بالموقع — اقتصاديات قوية تدعم القرار",
+}
+
+
+class TestArabicEndToEnd:
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_post_decision_memo_ar_persists_arabic(self, mock_get_client):
+        mock_get_client.return_value = _mock_client_returning(
+            _AR_STRUCTURED_RESPONSE
+        )
+        db = _DummyDB(preload_row=None)
+        client = _endpoint_client(db)
+
+        payload = {
+            "candidate": BASE_STRUCTURED_CANDIDATE,
+            "brief": BASE_STRUCTURED_BRIEF,
+            "lang": "ar",
+            "search_id": "search-ar",
+            "parcel_id": "parcel-ar",
+        }
+        resp = client.post("/v1/expansion-advisor/decision-memo", json=payload)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert body["memo_json"] is not None
+        assert body["memo_json"]["headline_recommendation"].startswith(
+            ("نوصي", "نرفض")
+        )
+        # Rendered text carries the Arabic section headers.
+        assert "## التوصية الرئيسية" in body["memo_text"]
+        # Persisted row records the Arabic locale (PR #4a column).
+        assert db.persisted is not None
+        assert db.persisted["lang"] == "ar"
+        assert db.committed is True
+
+
+# ── §6.5 — persistence / regenerate-on-mismatch (new) ───────────────
+
+
+class _RecordingDB(FakeDB):
+    """FakeDB that records UPDATE params and supports commit/rollback so
+    the regenerate-on-mismatch path can be exercised."""
+
+    def __init__(self, memo_row):
+        super().__init__(memo_row=memo_row)
+        self.updates: list[dict] = []
+        self.committed = False
+
+    def execute(self, stmt, params=None):
+        sql = stmt.text if hasattr(stmt, "text") else str(stmt)
+        if "UPDATE expansion_candidate" in sql:
+            self.updates.append(dict(params or {}))
+            return _Result([])
+        return super().execute(stmt, params)
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        pass
+
+
+def _memo_row(decision_memo_lang):
+    return {
+        "candidate_id": "c-regen",
+        "search_id": "s-regen",
+        "brand_name": "Brand X",
+        "category": "burger",
+        "service_model": "qsr",
+        "parcel_id": "p-regen",
+        "district": "Olaya",
+        "area_m2": 180,
+        "final_score": 82,
+        "economics_score": 70,
+        "cannibalization_score": 35,
+        "confidence_grade": "A",
+        "rank_position": 1,
+        "deterministic_rank": 1,
+        "final_rank": 1,
+        "rerank_applied": False,
+        "rerank_reason": None,
+        "rerank_delta": 0,
+        "rerank_status": "flag_off",
+        "decision_memo": "## Headline Recommendation\nRecommend",
+        "decision_memo_json": dict(VALID_STRUCTURED_RESPONSE),
+        "decision_memo_lang": decision_memo_lang,
+    }
+
+
+def _import_service():
+    from app.services import expansion_advisor as svc
+    return svc
+
+
+class TestRegenerateOnMismatch:
+
+    def test_en_memo_en_request_no_regeneration(self):
+        svc = _import_service()
+        db = _RecordingDB(_memo_row("en"))
+        with patch(
+            "app.services.llm_decision_memo.generate_structured_memo"
+        ) as gen:
+            memo = svc.get_candidate_memo(db, "c-regen", lang="en")
+        assert memo is not None
+        gen.assert_not_called()
+        assert db.updates == []
+
+    def test_en_memo_ar_request_triggers_regeneration(self):
+        svc = _import_service()
+        db = _RecordingDB(_memo_row("en"))
+        ar_json = {
+            **VALID_STRUCTURED_RESPONSE,
+            "headline_recommendation": "نوصي بالموقع — اقتصاديات قوية",
+        }
+        with patch(
+            "app.services.llm_decision_memo.generate_structured_memo",
+            return_value=ar_json,
+        ) as gen:
+            memo = svc.get_candidate_memo(db, "c-regen", lang="ar")
+        assert memo is not None
+        gen.assert_called_once()
+        # Response carries the freshly-generated Arabic memo.
+        assert memo["decision_memo_json"]["headline_recommendation"].startswith(
+            "نوصي"
+        )
+        assert "## التوصية الرئيسية" in memo["decision_memo"]
+        # Persisted with decision_memo_lang = "ar".
+        assert len(db.updates) == 1
+        assert db.updates[0]["lang"] == "ar"
+        assert db.committed is True
+
+    def test_null_lang_en_request_no_regeneration(self):
+        """Pre-PR-4a row (decision_memo_lang IS NULL) — back-compat path."""
+        svc = _import_service()
+        db = _RecordingDB(_memo_row(None))
+        with patch(
+            "app.services.llm_decision_memo.generate_structured_memo"
+        ) as gen:
+            memo = svc.get_candidate_memo(db, "c-regen", lang="en")
+        assert memo is not None
+        gen.assert_not_called()
+        assert db.updates == []
+
+    def test_null_lang_ar_request_triggers_regeneration(self):
+        svc = _import_service()
+        db = _RecordingDB(_memo_row(None))
+        ar_json = {
+            **VALID_STRUCTURED_RESPONSE,
+            "headline_recommendation": "نرفض الموقع — عبء الإيجار مرتفع",
+        }
+        with patch(
+            "app.services.llm_decision_memo.generate_structured_memo",
+            return_value=ar_json,
+        ) as gen:
+            memo = svc.get_candidate_memo(db, "c-regen", lang="ar")
+        assert memo is not None
+        gen.assert_called_once()
+        assert len(db.updates) == 1
+        assert db.updates[0]["lang"] == "ar"
+
+    def test_regeneration_unavailable_serves_existing_memo(self):
+        """When structured generation returns None (flag off / LLM error),
+        the persisted memo is served unchanged — no crash, no update."""
+        svc = _import_service()
+        db = _RecordingDB(_memo_row("en"))
+        with patch(
+            "app.services.llm_decision_memo.generate_structured_memo",
+            return_value=None,
+        ):
+            memo = svc.get_candidate_memo(db, "c-regen", lang="ar")
+        assert memo is not None
+        # Falls back to the persisted English memo.
+        assert memo["decision_memo_json"] == dict(VALID_STRUCTURED_RESPONSE)
+        assert db.updates == []
+
+
+# ── §6.6 — migration ────────────────────────────────────────────────
+
+
+class TestDecisionMemoLangMigration:
+    """Static verification of the additive migration. A live up/down/up
+    cycle needs a PostgreSQL instance, unavailable in this environment;
+    instead the migration module is imported and its upgrade/downgrade
+    bodies are executed against a mocked ``op`` so the exact column spec
+    is asserted."""
+
+    def _load(self):
+        import importlib.util
+        path = (
+            pathlib.Path(__file__).parent.parent
+            / "alembic" / "versions" / "20260519_decision_memo_lang.py"
+        )
+        spec = importlib.util.spec_from_file_location("_mig_4a", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_revision_chain(self):
+        mod = self._load()
+        assert mod.revision == "20260519_decision_memo_lang"
+        assert len(mod.revision) <= 32
+        assert mod.down_revision == "20260518_ea_strengths_risks"
+
+    def test_upgrade_adds_nullable_varchar8_column(self):
+        mod = self._load()
+        captured = {}
+
+        def fake_add_column(table, column):
+            captured["table"] = table
+            captured["column"] = column
+
+        with patch.object(mod.op, "add_column", side_effect=fake_add_column):
+            mod.upgrade()
+
+        assert captured["table"] == "expansion_candidate"
+        col = captured["column"]
+        assert col.name == "decision_memo_lang"
+        assert col.nullable is True
+        assert col.default is None
+        assert col.server_default is None
+        assert isinstance(col.type, mod.sa.String)
+        assert col.type.length == 8
+
+    def test_downgrade_drops_column(self):
+        mod = self._load()
+        dropped = {}
+
+        def fake_drop_column(table, column):
+            dropped["table"] = table
+            dropped["column"] = column
+
+        with patch.object(mod.op, "drop_column", side_effect=fake_drop_column):
+            mod.downgrade()
+
+        assert dropped["table"] == "expansion_candidate"
+        assert dropped["column"] == "decision_memo_lang"


### PR DESCRIPTION
## Problem

When `lang="ar"` is requested, the structured-memo headline validator / retry /
rewrite layer is English-only. The model correctly produces Arabic (the LOCALE
addendum fires), but `_headline_validity_reason` rejects the Arabic prefix, the
retry's English corrective preamble re-orders the model back to English, and
`_rewrite_headline_locally` stamps a literal English `"Recommend — "` onto a
`[:80]`-truncated Arabic body while nulling every body field — producing the
"Recommend — الإيجار السنوي…" screenshot. The CRITICAL block also asserts the
English-prefix rule outranks the addendum, so a prompt-only fix is insufficient.

PR #4a makes the structured memo Arabic end-to-end: locale-branched CRITICAL
block, locale-aware validator/retry/rewrite, and a persisted `decision_memo_lang`
with regenerate-on-mismatch in the GET endpoint.

## Four confirmed decisions (verbatim)

- **Q1 (a) — AR prefix canon.** Use the addendum's existing triad: `نوصي`,
  `نوصي مع تحفظات`, `نرفض`. Do not shift the canon; the validator accepts what
  the addendum already tells the model to produce.
- **Q2 (a) — CRITICAL block locale-branched.** The structured-memo system
  prompt's CRITICAL block branches on `ctx.locale`. EN branch byte-identical to
  HEAD. AR branch internally coherent: Arabic-prefix mandate, no English-prefix
  mandate.
- **Q3 (b) — additive `decision_memo_lang` column with regenerate-on-mismatch
  in GET.** Single new nullable column on `expansion_candidate`.
  `GET /candidates/{id}/memo` regenerates when the persisted memo's locale
  doesn't match the requested `lang`.
- **Q4 (a) — defer the three other LLM surfaces** (legacy memo `{llm_reasoning}`
  leak, LLM rerank `rerank_reason`, `llm_suitability.classify_listing`). PR #4a
  is structured-memo only.

## Seven-rule discipline walkthrough

1. **EN persisted strings byte-identical.** `_compose_structured_system_prompt("en")`
   == pre-PR-4a `STRUCTURED_MEMO_SYSTEM_PROMPT` (38,399 chars, exact). Validator
   `llm_decision_memo.py` `_headline_validity_reason` (~`:2031`), rewrite
   `_rewrite_headline_locally` (~`:2148`) and `_corrective_retry_preamble`
   (~`:2349`) all default `locale="en"` and reproduce the original literals/logic.
2. **`_normalize_candidate_payload(en)` byte-identical.** N/A — memo prose does
   not pass through it; `_normalize_candidate_payload` (`expansion_advisor.py:1283`)
   does `dict(candidate)` and the new column rides through like `decision_memo`.
3. **Migrations add only new nullable columns, no backfill.**
   `20260519_decision_memo_lang.py` adds `decision_memo_lang VARCHAR(8)` nullable,
   no default, no data migration.
4. **No backfill.** Pre-PR-4a rows keep `decision_memo_lang IS NULL`; GET treats
   NULL as English (regenerate only when `lang != (decision_memo_lang or "en")`).
5. **`_humanize_gate_list` en/omitted byte-identical.** Not touched.
6. **Gate split.** Not touched.
7. **No frontend / no handler-signature changes / no `_prewarm` change.**
   `post_decision_memo(req, db)` unchanged. `_prewarm_decision_memos` untouched
   (`lang="en"` hardcoded); `_decision_memo_cache_write` gained a `lang="en"`
   default so its pre-warm call site is unchanged. `CandidateMemoResponse`
   unchanged — the new column is not surfaced on the response. Frontend untouched.

## Change inventory

| File | + | - |
|---|---|---|
| `alembic/versions/20260519_decision_memo_lang.py` | 39 | 0 |
| `app/api/expansion_advisor.py` | 11 | 2 |
| `app/services/expansion_advisor.py` | 94 | 2 |
| `app/services/llm_decision_memo.py` | 235 | 23 |
| `tests/data/pr4a_structured_memo_system_prompt_en_head.txt` | 419 | 0 |
| `tests/test_pr4a_arabic_structured_memo.py` | 532 | 0 |

- `llm_decision_memo.py`: split the system prompt into `_STRUCTURED_MEMO_PREAMBLE`
  + `_CRITICAL_BLOCK_EN` / `_CRITICAL_BLOCK_AR`, `_compose_structured_system_prompt(locale)`;
  added `_ALLOWED_HEADLINE_PREFIXES_AR`; `locale` arg on `_headline_validity_reason`
  and `_rewrite_headline_locally`; `_corrective_retry_preamble` factored EN/AR.
- `app/api/expansion_advisor.py`: `_decision_memo_cache_write` persists
  `decision_memo_lang`; `post_decision_memo` passes the request locale.
- `app/services/expansion_advisor.py`: `get_candidate_memo` SELECTs
  `decision_memo_lang` and regenerates+persists on a locale mismatch.

## Migration

- Revision `20260519_decision_memo_lang` (27 chars ≤ 32),
  `down_revision = "20260518_ea_strengths_risks"` (the live single head).
- `upgrade()` adds `decision_memo_lang VARCHAR(8)` nullable, no default;
  `downgrade()` drops it.

## Tests

- Baseline `tests/`: 1,749 passed, 20 skipped → new total **1,785 passed, 20
  skipped** (+36 in `tests/test_pr4a_arabic_structured_memo.py`). No
  newly-failing pre-existing tests.

## Yeh verification

`grep -P '[\x{06cc}]' app/services/llm_decision_memo.py` → **ARABIC_YEH_CLEAN**
(no Persian yeh; all Arabic-yeh U+064A).

## Notes

- `/tmp/pr4a_investigation.md` was absent in the container; scope was
  re-derived from live `main`. `/tmp/pr4a_validation.md` (CC-side, not in repo)
  carries the full validation report; `/tmp/pr4a_drift.md` records that the
  drift vs the investigation was line-numbers/paths only — substance intact.

## Known follow-ups

Legacy memo `{llm_reasoning}` English leak; LLM rerank `rerank_reason`;
`llm_suitability.classify_listing`; pre-warm AR plumbing (still `lang="en"`, so
the first AR view of a not-yet-Arabic candidate pays a one-time GET-time
regeneration cost); `_decision_memo_cache_lookup` revival; the four side
findings; intermittent 401; key rotation.

https://claude.ai/code/session_01KTSNf9fsTh3G9AJamoCduJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTSNf9fsTh3G9AJamoCduJ)_