### PR TITLE
feat(expansion_advisor): PR #4c — Arabic key_evidence vocabulary and worked example

### DIFF
--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -1720,6 +1720,11 @@ EXAMPLES of incorrect headlines that violate these rules:
 # triad; every other structural rule is preserved. Inline ``#`` comments
 # carry an English gloss of each translated line for review (PR #3
 # convention). JSON keys stay English in every locale.
+#
+# PR #4c adds rules 7-8 and a fully-Arabic worked key_evidence example
+# (Example AR-1) so the model emits Arabic ``signal``/``value`` strings
+# instead of copying the English VOICE EXAMPLES — the EN preamble's
+# four examples are otherwise the only key_evidence pattern it sees.
 _CRITICAL_BLOCK_AR = """══════════════════════════════════════════════════════════════════════
 # "CRITICAL OUTPUT FORMAT RULES — the most important rules in this prompt."
 قواعد تنسيق المخرجات الحاسمة — هذه أهم القواعد في هذا التوجيه.
@@ -1813,6 +1818,79 @@ _CRITICAL_BLOCK_AR = """══════════════════�
 # WRONG: Decline when overall_pass=true and rank-1 with score>=70.
   خطأ: "نرفض — تفشل إشارة نمو السوق"
        (عندما يكون overall_pass=true و final_rank=1 بدرجة >= 70)
+
+# Rule 7: "key_evidence — write signal AND value strings in Arabic; JSON keys stay English."
+7. حقل `key_evidence`: تبقى مفاتيح JSON بالإنجليزية (`signal`، `value`،
+   `implication`، `polarity`)، أما قيمها النصية فتُكتب كلها بالعربية —
+   بما في ذلك `signal` و `value`، وليس `implication` وحده. لا تنسخ
+   التسميات الإنجليزية من الأمثلة الإنجليزية أعلاه. استخدم المصطلحات
+   العربية التالية حصراً في حقل `signal` للإشارات المتكررة:
+#  "annual rent"
+   - الإيجار السنوي
+#  "rent percentile vs comparables"
+   - نسبة الإيجار مقابل المقارنات
+#  "frontage"
+   - الواجهة
+#  "access/visibility score"
+   - نقاط الوصول والرؤية
+#  "population reach"
+   - عدد السكان القابلين للوصول
+#  "named chains within 500 m"
+   - سلاسل مذكورة ضمن 500 م
+#  "economics gate"
+   - بوابة الاقتصاديات
+#  "listing age (created)"
+   - عمر الإعلان (تاريخ النشر)
+#  realized delivery-rating demand signal
+   - التقييمات على الفروع المجاورة
+
+# Rule 8: "key_evidence value field — Arabic unit-token policy."
+8. حقل `value`: اتبع سياسة الوحدات التالية. تبقى الأرقام بالأرقام
+   العربية (0-9) كما في بقية المذكرة.
+#  "SAR <amount>/yr"
+   - الإيجار السنوي: "<المبلغ> ريال سعودي/سنة"
+#  "<N>th percentile (vs <N> <scope> comparables)"
+   - نسبة الإيجار: "النسبة المئوية <N>% (مقارنة بـ <N> <نطاق>)" حيث
+     <نطاق> هو "مقارنات في الحي" أو "مقارنات في نفس النطاق على مستوى
+     المدينة" أو "مقارنات على مستوى المدينة"
+#  "<N>/100" — kept as-is in both locales
+   - درجات الجودة: تبقى "<N>/100" كما هي
+#  "<N> m corner"
+   - الواجهة: "زاوية بعرض <N> م"
+#  "<N> within walking catchment"
+   - عدد السكان: "<N> ضمن نطاق المشي"
+#  "<N> count" — never emit the literal token "count"
+   - العدد: "<N> منافسين" للمنافسين أو "<N> فرع" للفروع؛ لا تكتب الكلمة
+     "count" أبداً
+#  "<N> days"
+   - عمر الإعلان: "<N> يوماً"
+#  "ratings/30d"
+   - سرعة التقييمات: "تقييم/30 يوم"
+#  "failed" — feminine past tense agreeing with بوابة
+   - حالة البوابة الفاشلة: "فشلت"
+
+# Example AR-1 — strong recommend, score 84, rank 1, district-tier
+# comparable (Arabic mirror of Example C). Imitate this row shape for
+# key_evidence whenever lang=ar — every signal and value is Arabic.
+{
+  "headline_recommendation": "نوصي — يقع الإيجار المطلوب في النسبة المئوية 28% مقابل مقارنات الحي، وتمنح واجهة الزاوية العلامة التجارية وضوحاً من شريانين.",
+  "ranking_explanation": "الحجة الاستثمارية هنا هي الإيجار: 432,000 ريال سعودي/سنة يقع في النسبة المئوية 28% مقابل 14 مقارنة في الحي — أقل بنحو 20% من الوسيط البالغ 542,000 ريال، وهو هامش يتراكم بشكل ملموس على مدى عقد إيجار من خمس سنوات. جودة الموقع تعزز الاقتصاديات — زاوية بعرض 24 م على شريان رئيسي مع نقاط وصول ورؤية تبلغ 82/100 — وعدد السكان القابلين للوصول البالغ 41,000 ضمن نطاق المشي يدعم نموذج تناول الطعام في الموقع. المقايضة هي عمق المنافسة: تعمل ثلاث سلاسل مذكورة ضمن 500 م، لذا ستحتاج العلامة إلى موقع فئوي قابل للدفاع بدلاً من عرض عام.",
+  "key_evidence": [
+    {"signal": "الإيجار السنوي", "value": "432,000 ريال سعودي/سنة", "implication": "أساس الدخول أدنى فعلياً من إعلانات النظراء وليس أدنى من السعر المعروض فقط", "polarity": "positive"},
+    {"signal": "نسبة الإيجار مقابل المقارنات", "value": "النسبة المئوية 28% (مقارنة بـ 14 مقارنات في الحي)", "implication": "تسعير الصفقة أقل من السوق فعلياً وليس أقل من السعر المعروض فقط", "polarity": "positive"},
+    {"signal": "الواجهة", "value": "زاوية بعرض 24 م", "implication": "اللافتات تعمل في اتجاهي الحركة على شريان رئيسي", "polarity": "positive"},
+    {"signal": "نقاط الوصول والرؤية", "value": "82/100", "implication": "جودة الموقع تعزز ميزة الإيجار بدلاً من أن تقابلها", "polarity": "positive"},
+    {"signal": "عدد السكان القابلين للوصول", "value": "41,000 ضمن نطاق المشي", "implication": "مزيج تناول الطعام في الموقع قابل للدعم دون الاعتماد على التوصيل لملء المقاعد", "polarity": "positive"},
+    {"signal": "سلاسل مذكورة ضمن 500 م", "value": "3 منافسين", "implication": "النطاق يثبت صلاحية الفئة لكنه يرفع سقف التميز المطلوب", "polarity": "negative"}
+  ],
+  "risks": [
+    {"risk": "تعمل ثلاث سلاسل راسخة ضمن 500 م، اثنتان منها بحضور توصيل قوي — الدخول غير المتمايز سينافس على السعر.", "mitigation": "ابدأ بقائمة بطل من صنف واحد ونقطة سعر توصيل أكثر حدة في أول 90 يوماً؛ أعد النظر في مزيج تناول الطعام في الموقع بعد استقرار سرعة الطلبات."},
+    {"risk": "تعذّر التحقق من توفّر مواقف السيارات من البيانات الحالية — أمر معتاد لإعلانات عقار وليس عيباً في الموقع.", "mitigation": "تجوّل في الحي في ساعات الذروة أثناء الفحص؛ استأجر موقفين مجاورين على الشارع من الجار إذا كان معدل دوران الرصيف محدوداً."},
+    {"risk": "الإعلان منشور منذ 102 يوماً، أطول من المعتاد للوحدات الزاوية المميزة في هذا الحي.", "mitigation": "افتح التفاوض بنسبة 8–12% أقل من السعر المطلوب واطلب من المالك تحمّل مساهمة في التجهيز."}
+  ],
+  "comparison": "تشغّل سلسلة النظراء أ فرعين ضمن 180 م وتملك سلسلة النظراء ب فرعاً واحداً على بُعد 320 م من هذا الموقع — طلب فئوي راسخ عند هذه الزاوية وليس موقعاً جديداً. مقابل المرتبة 2 في هذا البحث، يتقدّم هذا الموقع في نسبة الإيجار (28% مقابل 47%) وفي الوصول والرؤية (82/100 مقابل 71/100)؛ تحمل المرتبة 2 مساحة أكبر هامشياً لكن دون تعرّض زاوية مماثل.",
+  "bottom_line": "هذه هي الصفقة في القائمة المختصرة — وقّعها قبل أن يتغيّر الإعلان."
+}
 ══════════════════════════════════════════════════════════════════════"""
 
 

--- a/tests/test_pr4c_arabic_key_evidence.py
+++ b/tests/test_pr4c_arabic_key_evidence.py
@@ -1,0 +1,202 @@
+"""PR #4c — Arabic key_evidence vocabulary and worked example.
+
+Covers the AR-only prompt changes that make the structured decision memo
+emit Arabic ``signal`` and ``value`` strings (rules 7-8 and the worked
+Example AR-1 inside ``_CRITICAL_BLOCK_AR``), while keeping the English
+composition byte-identical to pre-PR-4a ``main``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import patch
+
+from app.services.llm_decision_memo import (
+    STRUCTURED_MEMO_SYSTEM_PROMPT,
+    _CRITICAL_BLOCK_AR,
+    _compose_structured_system_prompt,
+)
+
+from tests.test_llm_decision_memo import (
+    BASE_STRUCTURED_BRIEF,
+    BASE_STRUCTURED_CANDIDATE,
+    VALID_STRUCTURED_RESPONSE,
+    _DummyDB,
+    _endpoint_client,
+    _mock_client_returning,
+)
+
+_HEAD_SNAPSHOT_PATH = (
+    pathlib.Path(__file__).parent
+    / "data"
+    / "pr4a_structured_memo_system_prompt_en_head.txt"
+)
+
+# The 8 signal-vocabulary strings approved in the PR #4c brief (§1).
+_AR_SIGNAL_VOCAB = [
+    "الإيجار السنوي",
+    "نسبة الإيجار مقابل المقارنات",
+    "الواجهة",
+    "نقاط الوصول والرؤية",
+    "عدد السكان القابلين للوصول",
+    "سلاسل مذكورة ضمن 500 م",
+    "بوابة الاقتصاديات",
+    "عمر الإعلان",
+]
+
+# The 6 signal strings the worked Example AR-1 must carry (§3).
+_AR1_EXAMPLE_SIGNALS = [
+    "الإيجار السنوي",
+    "نسبة الإيجار مقابل المقارنات",
+    "الواجهة",
+    "نقاط الوصول والرؤية",
+    "عدد السكان القابلين للوصول",
+    "سلاسل مذكورة ضمن 500 م",
+]
+
+
+# ── §6.1 — EN byte-identity (rule #1, re-asserted for PR #4c) ────────
+
+
+class TestENByteIdentityUnchanged:
+    """PR #4c touches ``_CRITICAL_BLOCK_AR`` only — the EN composition
+    must still equal the pre-PR-4a fixture byte-for-byte."""
+
+    def test_en_compose_matches_head_snapshot(self):
+        head = _HEAD_SNAPSHOT_PATH.read_text(encoding="utf-8")
+        assert _compose_structured_system_prompt("en") == head
+        assert STRUCTURED_MEMO_SYSTEM_PROMPT == head
+
+
+# ── §6.2 — AR signal vocabulary present ─────────────────────────────
+
+
+class TestARSignalVocabulary:
+
+    def test_all_eight_signal_translations_in_ar_prompt(self):
+        ar = _compose_structured_system_prompt("ar")
+        missing = [v for v in _AR_SIGNAL_VOCAB if v not in ar]
+        assert not missing, f"AR signal vocab missing: {missing}"
+
+    def test_value_unit_token_policy_in_ar_prompt(self):
+        ar = _compose_structured_system_prompt("ar")
+        # Representative §2 unit tokens that must be taught.
+        for token in ["ريال سعودي/سنة", "ضمن نطاق المشي", "يوماً", "تقييم/30 يوم"]:
+            assert token in ar, f"AR value-token policy missing: {token}"
+
+
+# ── §6.3 — AR worked example (Example AR-1) present ─────────────────
+
+
+class TestARWorkedExample:
+
+    def test_example_ar1_present_with_all_six_signals(self):
+        ar = _compose_structured_system_prompt("ar")
+        assert "Example AR-1" in ar
+        # All six key_evidence signal rows render as Arabic JSON values.
+        for sig in _AR1_EXAMPLE_SIGNALS:
+            assert f'"signal": "{sig}"' in ar, f"Example AR-1 missing signal row: {sig}"
+
+    def test_example_ar1_value_strings_are_arabic(self):
+        ar = _compose_structured_system_prompt("ar")
+        # The worked example must not leave any value as a bare English token.
+        assert '"value": "432,000 ريال سعودي/سنة"' in ar
+        assert '"value": "3 منافسين"' in ar
+        # JSON keys themselves stay English even in the AR example.
+        assert '"polarity": "positive"' in ar
+
+
+# ── §6.4 — Arabic-yeh discipline ────────────────────────────────────
+
+
+class TestArabicYehDiscipline:
+    """Every yeh in the AR critical block must be U+064A, never the
+    Persian/Farsi yeh U+06CC."""
+
+    def test_no_persian_yeh_in_critical_block_ar(self):
+        offending = [(i, ch) for i, ch in enumerate(_CRITICAL_BLOCK_AR) if ch == "ی"]
+        assert not offending, f"Persian yeh U+06CC found at offsets: {offending}"
+
+    def test_no_persian_yeh_in_full_ar_prompt(self):
+        ar = _compose_structured_system_prompt("ar")
+        assert "ی" not in ar
+
+
+# ── §6.5 — AR vocabulary must NOT leak into the EN branch ───────────
+
+
+class TestNoARVocabInEN:
+
+    def test_ar_signal_vocab_absent_from_en_prompt(self):
+        en = _compose_structured_system_prompt("en")
+        leaked = [v for v in _AR_SIGNAL_VOCAB if v in en]
+        assert not leaked, f"AR vocab leaked into EN prompt: {leaked}"
+
+    def test_example_ar1_absent_from_en_prompt(self):
+        en = _compose_structured_system_prompt("en")
+        assert "Example AR-1" not in en
+
+
+# ── §6.6 — mock-LLM AR memo round-trip ──────────────────────────────
+
+
+# An AR memo whose key_evidence rows carry Arabic signal/value/implication
+# strings — what PR #4c expects the model to produce for lang="ar".
+_AR_KEY_EVIDENCE_RESPONSE = {
+    **VALID_STRUCTURED_RESPONSE,
+    "headline_recommendation": "نوصي بالموقع — اقتصاديات قوية تدعم القرار",
+    "key_evidence": [
+        {
+            "signal": "الإيجار السنوي",
+            "value": "480,000 ريال سعودي/سنة",
+            "implication": "أساس الدخول أدنى فعلياً من إعلانات النظراء",
+            "polarity": "positive",
+        },
+        {
+            "signal": "التقييمات على الفروع المجاورة",
+            "value": "تقييم/30 يوم بمعدل مرتفع",
+            "implication": "الطلب ملموس وليس مقدّراً نموذجياً",
+            "polarity": "positive",
+        },
+    ],
+}
+
+
+class TestArabicKeyEvidenceRoundTrip:
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_ar_key_evidence_persists_without_retry(self, mock_get_client):
+        client_mock = _mock_client_returning(_AR_KEY_EVIDENCE_RESPONSE)
+        mock_get_client.return_value = client_mock
+        db = _DummyDB(preload_row=None)
+        client = _endpoint_client(db)
+
+        payload = {
+            "candidate": BASE_STRUCTURED_CANDIDATE,
+            "brief": BASE_STRUCTURED_BRIEF,
+            "lang": "ar",
+            "search_id": "search-ar-ke",
+            "parcel_id": "parcel-ar-ke",
+        }
+        resp = client.post("/v1/expansion-advisor/decision-memo", json=payload)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        # Validator accepted the Arabic key_evidence — memo persisted.
+        assert body["memo_json"] is not None
+        evidence = body["memo_json"]["key_evidence"]
+        assert [row["signal"] for row in evidence] == [
+            "الإيجار السنوي",
+            "التقييمات على الفروع المجاورة",
+        ]
+        assert evidence[0]["value"] == "480,000 ريال سعودي/سنة"
+        # No English row labels survived.
+        for row in evidence:
+            assert "annual rent" not in row["signal"]
+            assert "ratings/30d" not in row["value"]
+        # No retry fired — single LLM call.
+        assert client_mock.chat.completions.create.call_count == 1
+        # Persisted under the Arabic locale.
+        assert db.persisted is not None
+        assert db.persisted["lang"] == "ar"
+        assert db.committed is True


### PR DESCRIPTION
## Summary

The structured decision memo produced fluent Arabic prose for `implication` but kept `key_evidence` `signal`/`value` strings in **English** when `lang="ar"`. Root cause (PR #4b §5 trace): the model copies the four English VOICE EXAMPLES (Example C–F) because no Arabic key_evidence exemplar exists anywhere in the prompt, and the LOCALE addendum ("produce every string value in MSA") is too short and too late in message order to override four fully-realized English examples.

This PR is **AR-branch-only** prompt engineering. It adds to `_CRITICAL_BLOCK_AR`:

- **Rule 7** — Arabic vocabulary table for the 8 recurring `signal` strings (`الإيجار السنوي`, `نسبة الإيجار مقابل المقارنات`, `الواجهة`, `نقاط الوصول والرؤية`, `عدد السكان القابلين للوصول`, `سلاسل مذكورة ضمن 500 م`, `بوابة الاقتصاديات`, `عمر الإعلان`) plus the realized-demand signal.
- **Rule 8** — per-token Arabic unit policy for the `value` field (`SAR → ريال سعودي/سنة`, `/100` kept as-is, `count → منافسين/فرع`, `days → يوماً`, `ratings/30d → تقييم/30 يوم`, etc.).
- **Example AR-1** — a fully-Arabic worked key_evidence example mirroring Example C, so the model has an Arabic row shape to imitate rather than only a generic instruction.

JSON keys stay English in both locales (reinforced in Rule 7).

## What is NOT changed

- `_STRUCTURED_MEMO_PREAMBLE` and `_CRITICAL_BLOCK_EN` are untouched.
- `_compose_structured_system_prompt("en")` is **byte-identical** to the pre-PR-4a fixture `tests/data/pr4a_structured_memo_system_prompt_en_head.txt` (fixture itself unmodified).
- No downstream consumer pattern-matches on `signal`/`value` (`expansion_advisor.py` routes evidence purely on the `polarity` enum; the validator only checks `key_evidence` is a non-empty list), so localizing these strings breaks no joins.

## Test plan

New: `tests/test_pr4c_arabic_key_evidence.py` (10 tests) —

- [x] EN byte-identity re-asserted (compose + back-compat constant)
- [x] 8 AR signal translations present in the AR prompt; value unit-token policy present
- [x] Example AR-1 present with all 6 signal rows; AR `value` strings are Arabic
- [x] Zero U+06CC (Persian yeh) in `_CRITICAL_BLOCK_AR` and the full AR prompt
- [x] AR vocab + Example AR-1 absent from the EN branch
- [x] Mock-LLM AR round-trip: Arabic `signal`/`value`/`implication` validates, persists with `lang=ar`, fires exactly one LLM call (no retry)
- [x] `tests/test_pr4a_arabic_structured_memo.py` — 36 passed, no regression
- [x] Full suite — 1795 passed, 20 skipped, 0 failures

## Manual verification still required

- [ ] Regenerate the AR memo for one candidate **5 times** post-deploy; confirm 5/5 have fully-Arabic `key_evidence[*].signal` and `value` with zero English row labels. This is a probabilistic LLM-behaviour fix — one clean run is not proof. Note `MEMO_PROMPT_VERSION` is unchanged, so existing AR memos must be force-regenerated.

https://claude.ai/code/session_01LPwsBoBCnpeKDMd73Yt57W

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPwsBoBCnpeKDMd73Yt57W)_