### PR TITLE
feat(expansion_advisor): PR #4d — Tier 1 Arabic cleanup

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -5543,7 +5543,24 @@ def _build_strengths_and_risks(
     return strengths[:4], risks[:4], strengths_structured[:4], risks_structured[:4]
 
 
-def _recommended_use_case(service_model: str, area_m2: float) -> str:
+# PR #4d: Arabic phrases for the recommended use case, keyed by the
+# locale-invariant token from _recommended_use_case_token. The English
+# branches below are byte-untouched; the AR branch dispatches through
+# the existing token mirror so the two stay in lockstep.
+_RECOMMENDED_USE_CASE_AR: dict[str, str] = {
+    "flagship_dine_in": "مطعم رئيسي للتناول في الموقع",
+    "neighborhood_dine_in": "مطعم تناول في الموقع للحي",
+    "delivery_led_branch": "فرع يعتمد على التوصيل",
+    "compact_cafe": "مقهى صغير",
+    "destination_cafe": "مقهى وجهة",
+    "neighborhood_qsr": "مطعم خدمة سريعة للحي",
+}
+
+
+def _recommended_use_case(service_model: str, area_m2: float, lang: str = "en") -> str:
+    if lang == "ar":
+        token = _recommended_use_case_token(service_model, area_m2)
+        return _RECOMMENDED_USE_CASE_AR.get(token, _RECOMMENDED_USE_CASE_AR["neighborhood_qsr"])
     if service_model == "dine_in":
         return "flagship dine-in" if area_m2 >= 260 else "neighborhood dine-in"
     if service_model == "delivery_first":
@@ -10608,6 +10625,7 @@ def get_candidate_memo(db: Session, candidate_id: str, lang: str = "en") -> dict
     best_use_case = _recommended_use_case(
         str(candidate.get("service_model") or "qsr"),
         _safe_float(candidate.get("area_m2")),
+        lang=lang,
     )
     main_watchout = risks[0] if risks else "Validate lease and capex assumptions before commitment"
     district = candidate.get("district_display") or candidate.get("district") or "Riyadh"

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -11024,7 +11024,7 @@ def get_recommendation_report(db: Session, search_id: str, lang: str = "en") -> 
             "validation_clear_count": validation_clear_count,
             "why_best": why_best,
             "main_risk": (best.get("key_risks_json") or ["Validate lease and execution assumptions"])[0],
-            "best_format": _recommended_use_case(str(search.get("service_model") or "qsr"), _safe_float(best.get("area_m2"))),
+            "best_format": _recommended_use_case(str(search.get("service_model") or "qsr"), _safe_float(best.get("area_m2")), lang=lang),
             "summary": summary_text,
             "report_summary": report_summary_text,
         },

--- a/frontend/src/features/expansion-advisor/CategorySelect.test.tsx
+++ b/frontend/src/features/expansion-advisor/CategorySelect.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import React from "react";
+import "../../i18n";
 import CategorySelect from "./CategorySelect";
 import { CATEGORY_OPTIONS, findCategoryOption } from "./categoryOptions";
 

--- a/frontend/src/features/expansion-advisor/CategorySelect.tsx
+++ b/frontend/src/features/expansion-advisor/CategorySelect.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   CATEGORY_GROUPS,
   CATEGORY_OPTIONS,
@@ -28,8 +29,10 @@ export default function CategorySelect({
   value,
   onChange,
   disabled = false,
-  placeholder = "Select a restaurant category",
+  placeholder,
 }: Props) {
+  const { t } = useTranslation();
+  const resolvedPlaceholder = placeholder ?? t("expansionAdvisor.categorySelectPlaceholder");
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -161,7 +164,7 @@ export default function CategorySelect({
                   clearSelection();
                 }}
                 tabIndex={-1}
-                aria-label={`Clear ${displayLabel}`}
+                aria-label={t("expansionAdvisor.clearCategoryAriaLabel", { label: displayLabel })}
               >
                 ×
               </button>
@@ -182,7 +185,7 @@ export default function CategorySelect({
           onFocus={() => setOpen(true)}
           onKeyDown={handleKeyDown}
           disabled={disabled}
-          placeholder={value && !open ? "" : placeholder}
+          placeholder={value && !open ? "" : resolvedPlaceholder}
           autoComplete="off"
           role="combobox"
           aria-expanded={open}
@@ -198,7 +201,7 @@ export default function CategorySelect({
       {/* Helper text */}
       {!value && !open && (
         <span className="ea-category-select__helper">
-          Choose the closest match for better search quality
+          {t("expansionAdvisor.categorySelectHelp")}
         </span>
       )}
 

--- a/frontend/src/features/expansion-advisor/ExpansionBriefForm.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionBriefForm.tsx
@@ -120,7 +120,7 @@ export default function ExpansionBriefForm({ initialValue, onSubmit, loading }: 
               value={brief.brand_name}
               onChange={(e) => set("brand_name", e.target.value)}
               disabled={loading}
-              placeholder="e.g. Al Baik, Kudu"
+              placeholder={t("expansionAdvisor.brandExamplesPlaceholder")}
             />
             {touched && errors.brand_name && <span className="ea-form__error">{t(`expansionAdvisor.${errors.brand_name}`)}</span>}
           </div>
@@ -130,7 +130,6 @@ export default function ExpansionBriefForm({ initialValue, onSubmit, loading }: 
               value={brief.category}
               onChange={(val) => set("category", val)}
               disabled={loading}
-              placeholder="Select a restaurant category"
             />
           </div>
         </div>

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
@@ -457,7 +457,15 @@ export default function ExpansionMemoPanel({
                                 <ConfidenceBadge grade={cand.confidence_grade as string | undefined} />
                               </div>
                             </div>
-                            {rec.gate_verdict && <p className="ea-detail__text" style={{ fontStyle: "italic", marginTop: 8 }}>{rec.gate_verdict}</p>}
+                            {rec.gate_verdict && (
+                              <p className="ea-detail__text" style={{ fontStyle: "italic", marginTop: 8 }}>
+                                {rec.gate_verdict === "pass"
+                                  ? t("expansionAdvisor.gatePass")
+                                  : rec.gate_verdict === "fail"
+                                  ? t("expansionAdvisor.gateFail")
+                                  : t("expansionAdvisor.gateNeedsValidation")}
+                              </p>
+                            )}
                           </div>
                         )}
 

--- a/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
+++ b/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
@@ -1,0 +1,184 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+import "../../i18n";
+import i18n from "../../i18n";
+import en from "../../i18n/en.json";
+import ar from "../../i18n/ar.json";
+import ExpansionMemoPanel from "./ExpansionMemoPanel";
+import ExpansionBriefForm, { defaultBrief } from "./ExpansionBriefForm";
+import CategorySelect from "./CategorySelect";
+import SearchBar from "../../ui-v2/SearchBar";
+
+beforeEach(async () => {
+  if (i18n.language !== "en") await i18n.changeLanguage("en");
+});
+
+afterEach(async () => {
+  if (i18n.language !== "en") await i18n.changeLanguage("en");
+});
+
+/* ─── §2 gate_verdict on the Site tab ─────────────────────────────────── */
+
+function renderSiteTab(gate_verdict: string) {
+  return renderToStaticMarkup(
+    <ExpansionMemoPanel
+      loading={false}
+      memo={{
+        recommendation: { verdict: "go", headline: "GO headline", gate_verdict },
+        candidate: {},
+        market_research: {},
+        brand_profile: {},
+      } as any}
+      initialTab="site"
+    />,
+  );
+}
+
+describe("PR #4d §2 — gate_verdict i18n on the Site tab", () => {
+  const cases: Array<[string, string, string]> = [
+    ["pass", en.expansionAdvisor.gatePass, ar.expansionAdvisor.gatePass],
+    ["fail", en.expansionAdvisor.gateFail, ar.expansionAdvisor.gateFail],
+    ["unknown", en.expansionAdvisor.gateNeedsValidation, ar.expansionAdvisor.gateNeedsValidation],
+  ];
+
+  for (const [verdict, enLabel, arLabel] of cases) {
+    it(`renders '${enLabel}' in EN for verdict '${verdict}'`, () => {
+      const html = renderSiteTab(verdict);
+      expect(html).toContain(enLabel);
+      expect(html).not.toMatch(/>pass</);
+    });
+
+    it(`renders '${arLabel}' in AR for verdict '${verdict}'`, async () => {
+      await i18n.changeLanguage("ar");
+      const html = renderSiteTab(verdict);
+      expect(html).toContain(arLabel);
+      expect(html).not.toMatch(/>pass</);
+      expect(html).not.toMatch(/>fail</);
+      expect(html).not.toMatch(/>unknown</);
+    });
+  }
+});
+
+/* ─── §3 brief-form placeholders ──────────────────────────────────────── */
+
+describe("PR #4d §3 — brief-form placeholders", () => {
+  it("renders the brand-examples placeholder localized (EN)", () => {
+    const html = renderToStaticMarkup(
+      <ExpansionBriefForm initialValue={defaultBrief} onSubmit={() => {}} loading={false} />,
+    );
+    expect(html).toContain("e.g. Al Baik, Kudu");
+    expect(html).toContain("Select a restaurant category");
+    expect(html).toContain("Choose the closest match for better search quality");
+  });
+
+  it("renders the brand-examples placeholder localized (AR)", async () => {
+    await i18n.changeLanguage("ar");
+    const html = renderToStaticMarkup(
+      <ExpansionBriefForm initialValue={defaultBrief} onSubmit={() => {}} loading={false} />,
+    );
+    expect(html).toContain("مثال: البيك، كودو");
+    expect(html).toContain("اختر فئة المطعم");
+    expect(html).toContain("اختر أقرب تطابق للحصول على نتائج بحث أفضل");
+    expect(html).not.toContain("e.g. Al Baik, Kudu");
+    expect(html).not.toContain("Select a restaurant category");
+  });
+
+  it("CategorySelect defaults its placeholder to the localized key", () => {
+    const html = renderToStaticMarkup(<CategorySelect value="" onChange={() => {}} />);
+    expect(html).toContain("Select a restaurant category");
+    expect(html).not.toContain("expansionAdvisor.categorySelectPlaceholder");
+  });
+
+  it("§3e — searchLimit AR value is translated, not the English fallback", () => {
+    expect(en.expansionAdvisor.searchLimit).toBe("Search limit");
+    expect(ar.expansionAdvisor.searchLimit).toBe("حد البحث");
+    expect(i18n.getFixedT("ar")("expansionAdvisor.searchLimit")).toBe("حد البحث");
+  });
+});
+
+/* ─── §4 SearchBar + CategorySelect literals ──────────────────────────── */
+
+describe("PR #4d §4 — SearchBar i18n", () => {
+  it("renders the search placeholder localized (EN)", () => {
+    const html = renderToStaticMarkup(<SearchBar onSelect={() => {}} />);
+    expect(html).toContain("Search by parcels, streets, districts");
+  });
+
+  it("renders the search placeholder localized (AR)", async () => {
+    await i18n.changeLanguage("ar");
+    const html = renderToStaticMarkup(<SearchBar onSelect={() => {}} />);
+    expect(html).toContain("ابحث عن القطع والشوارع والأحياء");
+    expect(html).not.toContain("Search by parcels, streets, districts");
+  });
+
+  it("resolves all search-state keys in both locales", () => {
+    const enT = i18n.getFixedT("en");
+    const arT = i18n.getFixedT("ar");
+    expect(enT("search.loading")).toBe("Searching…");
+    expect(arT("search.loading")).toBe("جارٍ البحث…");
+    expect(enT("search.unavailable")).toBe("Search unavailable");
+    expect(arT("search.unavailable")).toBe("البحث غير متاح");
+    expect(enT("search.noMatches")).toBe("No matches found");
+    expect(arT("search.noMatches")).toBe("لا توجد نتائج مطابقة");
+    expect(enT("search.resultsAriaLabel")).toBe("Search results");
+    expect(arT("search.resultsAriaLabel")).toBe("نتائج البحث");
+  });
+});
+
+describe("PR #4d §4e — CategorySelect clear aria-label", () => {
+  it("interpolates the localized clear label (EN)", () => {
+    const html = renderToStaticMarkup(<CategorySelect value="burger" onChange={() => {}} />);
+    expect(html).toContain('aria-label="Clear Burger"');
+  });
+
+  it("interpolates the localized clear label (AR)", async () => {
+    await i18n.changeLanguage("ar");
+    const html = renderToStaticMarkup(<CategorySelect value="burger" onChange={() => {}} />);
+    expect(html).toContain('aria-label="مسح Burger"');
+  });
+});
+
+/* ─── i18n parity ─────────────────────────────────────────────────────── */
+
+describe("PR #4d — i18n parity", () => {
+  function flatKeys(obj: Record<string, unknown>, prefix = ""): Set<string> {
+    const out = new Set<string>();
+    for (const [k, v] of Object.entries(obj)) {
+      const p = prefix ? `${prefix}.${k}` : k;
+      if (v && typeof v === "object") {
+        for (const nk of flatKeys(v as Record<string, unknown>, p)) out.add(nk);
+      } else {
+        out.add(p);
+      }
+    }
+    return out;
+  }
+
+  it("every new PR #4d key exists in both locales", () => {
+    const newKeys = [
+      "search.placeholder",
+      "search.loading",
+      "search.unavailable",
+      "search.noMatches",
+      "search.resultsAriaLabel",
+      "expansionAdvisor.categorySelectPlaceholder",
+      "expansionAdvisor.brandExamplesPlaceholder",
+      "expansionAdvisor.categorySelectHelp",
+      "expansionAdvisor.clearCategoryAriaLabel",
+    ];
+    const enKeys = flatKeys(en as Record<string, unknown>);
+    const arKeys = flatKeys(ar as Record<string, unknown>);
+    for (const k of newKeys) {
+      expect(enKeys.has(k)).toBe(true);
+      expect(arKeys.has(k)).toBe(true);
+    }
+  });
+
+  it("en.json and ar.json have identical key sets", () => {
+    const enKeys = flatKeys(en as Record<string, unknown>);
+    const arKeys = flatKeys(ar as Record<string, unknown>);
+    expect([...enKeys].filter((k) => !arKeys.has(k))).toEqual([]);
+    expect([...arKeys].filter((k) => !enKeys.has(k))).toEqual([]);
+  });
+});

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -530,7 +530,11 @@
     "targetArea": "المساحة المستهدفة (م²)",
     "targetDistricts": "الأحياء المستهدفة (مفصولة بفواصل)",
     "existingBranches": "الفروع الحالية (الاسم،خط العرض،خط الطول،الحي لكل سطر)",
-    "searchLimit": "Search limit",
+    "searchLimit": "حد البحث",
+    "categorySelectPlaceholder": "اختر فئة المطعم",
+    "brandExamplesPlaceholder": "مثال: البيك، كودو",
+    "categorySelectHelp": "اختر أقرب تطابق للحصول على نتائج بحث أفضل",
+    "clearCategoryAriaLabel": "مسح {{label}}",
     "runSearch": "تشغيل البحث",
     "loadingSearch": "جاري تحميل البحث…",
     "noCandidates": "لم يتم العثور على عقارات متاحة.",
@@ -1320,5 +1324,12 @@
     "area": "المساحة",
     "annualRent": "الإيجار السنوي",
     "streetWidth": "عرض الشارع"
+  },
+  "search": {
+    "placeholder": "ابحث عن القطع والشوارع والأحياء",
+    "loading": "جارٍ البحث…",
+    "unavailable": "البحث غير متاح",
+    "noMatches": "لا توجد نتائج مطابقة",
+    "resultsAriaLabel": "نتائج البحث"
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -479,6 +479,10 @@
     "targetDistricts": "Target Districts (comma-separated)",
     "existingBranches": "Existing Branches (name,lat,lon,district per line)",
     "searchLimit": "Search limit",
+    "categorySelectPlaceholder": "Select a restaurant category",
+    "brandExamplesPlaceholder": "e.g. Al Baik, Kudu",
+    "categorySelectHelp": "Choose the closest match for better search quality",
+    "clearCategoryAriaLabel": "Clear {{label}}",
     "runSearch": "Run Search",
     "loadingSearch": "Loading search…",
     "noCandidates": "No available listings found.",
@@ -1321,5 +1325,12 @@
     "area": "Area",
     "annualRent": "Annual rent",
     "streetWidth": "Street width"
+  },
+  "search": {
+    "placeholder": "Search by parcels, streets, districts",
+    "loading": "Searching…",
+    "unavailable": "Search unavailable",
+    "noMatches": "No matches found",
+    "resultsAriaLabel": "Search results"
   }
 }

--- a/frontend/src/ui-v2/SearchBar.tsx
+++ b/frontend/src/ui-v2/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { buildApiUrl } from "../api";
 import type { SearchItem, SearchResponse } from "../types/search";
 
@@ -10,6 +11,7 @@ const DEBOUNCE_MS = 250;
 const MIN_QUERY_LENGTH = 2;
 
 export default function SearchBar({ onSelect }: SearchBarProps) {
+  const { t } = useTranslation();
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -52,7 +54,7 @@ export default function SearchBar({ onSelect }: SearchBarProps) {
         if (requestId !== requestIdRef.current) return;
         setItems([]);
         setOpen(true);
-        setError(fetchError instanceof Error ? fetchError.message : "Search unavailable");
+        setError(fetchError instanceof Error ? fetchError.message : t("search.unavailable"));
       } finally {
         if (requestId !== requestIdRef.current) return;
         setLoading(false);
@@ -63,7 +65,7 @@ export default function SearchBar({ onSelect }: SearchBarProps) {
       controller.abort();
       window.clearTimeout(handle);
     };
-  }, [trimmed]);
+  }, [trimmed, t]);
 
   return (
     <div className="ui-v2-search app-topbar__search" onBlur={() => window.setTimeout(() => setOpen(false), 120)}>
@@ -73,14 +75,14 @@ export default function SearchBar({ onSelect }: SearchBarProps) {
         value={query}
         onFocus={() => setOpen(items.length > 0 || Boolean(error))}
         onChange={(event) => setQuery(event.target.value)}
-        placeholder="Search by parcels, streets, districts"
-        aria-label="Search by parcels, streets, districts"
+        placeholder={t("search.placeholder")}
+        aria-label={t("search.placeholder")}
       />
-      {loading ? <span className="ui-v2-search__loading">Searching…</span> : null}
+      {loading ? <span className="ui-v2-search__loading">{t("search.loading")}</span> : null}
       {open ? (
-        <div className="ui-v2-search__results" role="listbox" aria-label="Search results">
-          {error ? <div className="ui-v2-search__status">Search unavailable</div> : null}
-          {!error && !items.length ? <div className="ui-v2-search__status">No matches found</div> : null}
+        <div className="ui-v2-search__results" role="listbox" aria-label={t("search.resultsAriaLabel")}>
+          {error ? <div className="ui-v2-search__status">{t("search.unavailable")}</div> : null}
+          {!error && !items.length ? <div className="ui-v2-search__status">{t("search.noMatches")}</div> : null}
           {items.map((item) => (
             <button
               key={`${item.type}-${item.id}`}

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -4737,3 +4737,65 @@ def test_recommended_use_case_unknown_locale_falls_back_to_english():
         expansion_service._recommended_use_case("qsr", 200.0, lang="fr")
         == "neighborhood qsr"
     )
+
+
+# ---------------------------------------------------------------------------
+# PR #4d follow-up §1 — get_recommendation_report.best_format honors lang
+# ---------------------------------------------------------------------------
+
+def _install_recommendation_report_fixture(
+    monkeypatch, *, service_model: str, area_m2: float
+) -> None:
+    """Stub get_search and get_candidates for a single-candidate report fixture."""
+    monkeypatch.setattr(
+        expansion_service,
+        "get_search",
+        lambda *_a, **_kw: {
+            "id": "search-1",
+            "service_model": service_model,
+            "brand_profile": {"expansion_goal": "balanced"},
+        },
+    )
+    monkeypatch.setattr(
+        expansion_service,
+        "get_candidates",
+        lambda *_a, **_kw: [
+            {
+                "id": "c1", "final_score": 80, "brand_fit_score": 70, "economics_score": 65,
+                "area_m2": area_m2, "district": "Olaya", "key_risks_json": ["risk"],
+                "gate_status_json": {"overall_pass": True},
+                "confidence_grade": "B", "confidence_score": 70,
+                "rank_position": 1, "score_breakdown_json": {"final_score": 80},
+                "top_positives_json": [], "top_risks_json": ["risk"],
+                "feature_snapshot_json": {"parcel_area_m2": area_m2, "data_completeness_score": 70},
+            }
+        ],
+    )
+
+
+def test_get_recommendation_report_best_format_english_byte_identical(monkeypatch):
+    """best_format is byte-identical to the pre-PR EN output when lang is
+    omitted, lang='en', or an unknown locale (e.g. 'fr' → EN fallback)."""
+    for (service_model, area_m2), expected in _USE_CASE_EN_SNAPSHOT.items():
+        _install_recommendation_report_fixture(
+            monkeypatch, service_model=service_model, area_m2=area_m2
+        )
+        # Implicit default.
+        report = get_recommendation_report(FakeDB(), "search-1")
+        assert report["recommendation"]["best_format"] == expected, (service_model, area_m2)
+        # Explicit lang="en".
+        report = get_recommendation_report(FakeDB(), "search-1", lang="en")
+        assert report["recommendation"]["best_format"] == expected, (service_model, area_m2)
+        # Unknown locale → English fallback.
+        report = get_recommendation_report(FakeDB(), "search-1", lang="fr")
+        assert report["recommendation"]["best_format"] == expected, (service_model, area_m2)
+
+
+def test_get_recommendation_report_best_format_arabic(monkeypatch):
+    """best_format returns the matching AR phrase when lang='ar'."""
+    for (service_model, area_m2), expected in _USE_CASE_AR_SNAPSHOT.items():
+        _install_recommendation_report_fixture(
+            monkeypatch, service_model=service_model, area_m2=area_m2
+        )
+        report = get_recommendation_report(FakeDB(), "search-1", lang="ar")
+        assert report["recommendation"]["best_format"] == expected, (service_model, area_m2)

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -4681,3 +4681,59 @@ def test_feature_snapshot_parcel_candidate_omits_listing_quality_signals(
     # brand_presence still has the chain_strength provenance key, but with
     # a None value because the bulk enricher returned no chain_strength rows.
     assert snapshot["brand_presence"]["top_chain_strength_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# PR #4d §1 — _recommended_use_case Arabic localization
+# ---------------------------------------------------------------------------
+
+# Snapshot of every English phrase the pre-PR-4d function could return,
+# keyed by (service_model, area_m2). Used to prove the EN branch is
+# byte-identical after adding the ``lang`` parameter.
+_USE_CASE_EN_SNAPSHOT = {
+    ("dine_in", 300.0): "flagship dine-in",
+    ("dine_in", 200.0): "neighborhood dine-in",
+    ("delivery_first", 150.0): "delivery-led branch",
+    ("cafe", 150.0): "compact cafe",
+    ("cafe", 220.0): "destination cafe",
+    ("qsr", 200.0): "neighborhood qsr",
+}
+
+_USE_CASE_AR_SNAPSHOT = {
+    ("dine_in", 300.0): "مطعم رئيسي للتناول في الموقع",
+    ("dine_in", 200.0): "مطعم تناول في الموقع للحي",
+    ("delivery_first", 150.0): "فرع يعتمد على التوصيل",
+    ("cafe", 150.0): "مقهى صغير",
+    ("cafe", 220.0): "مقهى وجهة",
+    ("qsr", 200.0): "مطعم خدمة سريعة للحي",
+}
+
+
+def test_recommended_use_case_english_is_byte_identical():
+    """The default (lang='en') branch must not drift from the pre-PR-4d output."""
+    for (service_model, area_m2), expected in _USE_CASE_EN_SNAPSHOT.items():
+        # Implicit default and explicit lang="en" both return the EN phrase.
+        assert (
+            expansion_service._recommended_use_case(service_model, area_m2) == expected
+        )
+        assert (
+            expansion_service._recommended_use_case(service_model, area_m2, lang="en")
+            == expected
+        )
+
+
+def test_recommended_use_case_arabic_phrases():
+    """lang='ar' returns the six pre-approved Arabic phrases."""
+    for (service_model, area_m2), expected in _USE_CASE_AR_SNAPSHOT.items():
+        assert (
+            expansion_service._recommended_use_case(service_model, area_m2, lang="ar")
+            == expected
+        )
+
+
+def test_recommended_use_case_unknown_locale_falls_back_to_english():
+    """An unexpected lang token is treated as English (no crash, no key leak)."""
+    assert (
+        expansion_service._recommended_use_case("qsr", 200.0, lang="fr")
+        == "neighborhood qsr"
+    )


### PR DESCRIPTION
## Summary

Localizes four English surfaces that leaked to Arabic users in production AR screenshots. Investigation report: `pr4d_investigation.md`; validation report: `pr4d_validation.md`.

- **§1 — `best_use_case` (backend-literal).** `_recommended_use_case` gains a `lang` parameter and an Arabic phrase table dispatched through the existing `_recommended_use_case_token` mirror. `get_candidate_memo` passes `lang`. **No contract drift** — same field name `best_use_case`, same response shape; only the string value changes when `lang="ar"`. English output is byte-identical (proven by a snapshot test of all 6 mappings).
- **§2 — `gate_verdict` (frontend-i18n).** `ExpansionMemoPanel.tsx:460` (Site tab) rendered the raw `pass`/`fail`/`unknown` identifier. Now mapped through the existing `gatePass`/`gateFail`/`gateNeedsValidation` keys — the same expression used at `DecisionSnapshotCard`/`ExpansionReportPanel`/`FinalistsWorkspace`. No new keys.
- **§3 — brief-form placeholders (frontend-i18n).** Search bar, category select, brand-examples input, and helper text wired to `t()`. `expansionAdvisor.searchLimit` AR value (was the English `"Search limit"`) translated to `"حد البحث"`.
- **§4 — SearchBar + CategorySelect (frontend-i18n).** `ui-v2/SearchBar.tsx` was fully un-internationalized; now wired under a new top-level `search.*` namespace (shared component, kept out of `expansionAdvisor.*`). CategorySelect clear-button `aria-label` keyed with interpolation.

## Scope

`recommendation.headline` / `main_watchout` confirmed to have **no visible JSX consumer** (the `headline`/`headline_recommendation` renders in `DecisionMemoNarrative` belong to the separate `LLMDecisionMemo`/`StructuredMemo` objects) — left English as scoped. Tier 2 tokens and MapLibre attribution untouched.

## Validation

- **i18n parity:** `en.json` / `ar.json` key sets identical; 9 new keys present in both.
- **Arabic-yeh:** no Persian yeh (U+06CC) in any changed/new file.
- **Frontend:** `vitest run` → 641 passed, 17 failed. The 17 are pre-existing (15 in `ExpansionAdvisorPage.test.tsx`, 2 environment `?raw`-CSS-import artifacts in `expansionAdvisorRtl.test.ts` — confirmed identical on a clean stash). **0 new failures.** New `Pr4dI18n.test.tsx` (17 tests) + updated `CategorySelect.test.tsx` (21) all green.
- **Backend:** `pytest tests/test_expansion_advisor_service.py` → 149 passed (146 + 3 new), 0 failed.
- **Build:** `tsc && vite build` succeeds.

## Test plan

- [ ] AR memo → Risks & Validation tab: `أفضل حالة استخدام` shows an Arabic phrase, not `neighborhood qsr`.
- [ ] AR memo → Diagnostics → Site tab: verdict reads `ناجح`/`فاشل`/`يحتاج تحقق`, not `pass`/`fail`/`unknown`.
- [ ] AR brief form: brand placeholder, category placeholder, helper text, and `حد البحث` label all render in Arabic.
- [ ] AR top-bar search: placeholder + loading/error/empty states render in Arabic.
- [ ] EN regression: all surfaces byte-identical to pre-PR behavior.

https://claude.ai/code/session_019AdbNbPeGMB6eXEVB6aTDP

---
_Generated by [Claude Code](https://claude.ai/code/session_019AdbNbPeGMB6eXEVB6aTDP)_