### PR TITLE
feat(expansion_advisor): PR #4e — Tier 2 cosmetic AR cleanup (pts, % weight, F&B fallback)

### DIFF
--- a/frontend/src/features/expansion-advisor/CopySummaryBlock.tsx
+++ b/frontend/src/features/expansion-advisor/CopySummaryBlock.tsx
@@ -28,7 +28,7 @@ export default function CopySummaryBlock({ candidate, report, memo }: Props) {
   const handleCopyBriefing = async () => {
     if (!candidate) return;
     try {
-      const briefingText = formatLandlordBriefingText(candidate, report, memo);
+      const briefingText = formatLandlordBriefingText(candidate, report, memo, t);
       await navigator.clipboard.writeText(briefingText);
       setCopiedBriefing(true);
       setTimeout(() => setCopiedBriefing(false), 2000);

--- a/frontend/src/features/expansion-advisor/DecisionLogicCard.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionLogicCard.tsx
@@ -389,7 +389,7 @@ function ContributionsSection({
             </div>
             <div className="ea-decision-logic__component-meta-row">
               <dt>{t("expansionAdvisor.decisionLogic.contributionLabel")}</dt>
-              <dd>{c.points.toFixed(2)} pts</dd>
+              <dd>{t("expansionAdvisor.decisionLogicWeightedPoints", { points: c.points.toFixed(2) })}</dd>
             </div>
           </dl>
           {resolved.length > 0 && (

--- a/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
+++ b/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
@@ -9,6 +9,8 @@ import ExpansionMemoPanel from "./ExpansionMemoPanel";
 import ExpansionBriefForm, { defaultBrief } from "./ExpansionBriefForm";
 import CategorySelect from "./CategorySelect";
 import SearchBar from "../../ui-v2/SearchBar";
+import ScoreBreakdownCompact from "./ScoreBreakdownCompact";
+import { formatLandlordBriefingText } from "./studyAdapters";
 
 beforeEach(async () => {
   if (i18n.language !== "en") await i18n.changeLanguage("en");
@@ -166,6 +168,8 @@ describe("PR #4d — i18n parity", () => {
       "expansionAdvisor.brandExamplesPlaceholder",
       "expansionAdvisor.categorySelectHelp",
       "expansionAdvisor.clearCategoryAriaLabel",
+      "expansionAdvisor.decisionLogic.weightPercent",
+      "expansionAdvisor.landlordBriefing.fallbackFormat",
     ];
     const enKeys = flatKeys(en as Record<string, unknown>);
     const arKeys = flatKeys(ar as Record<string, unknown>);
@@ -180,5 +184,70 @@ describe("PR #4d — i18n parity", () => {
     const arKeys = flatKeys(ar as Record<string, unknown>);
     expect([...enKeys].filter((k) => !arKeys.has(k))).toEqual([]);
     expect([...arKeys].filter((k) => !enKeys.has(k))).toEqual([]);
+  });
+});
+
+/* ─── PR #4e Tier 2 cosmetic AR cleanup ─────────────────────────────── */
+
+describe("PR #4e §1/§2 — pts literal consumes decisionLogicWeightedPoints", () => {
+  const breakdown = {
+    weights: { economics: 0.4 },
+    inputs: { economics: 50 },
+    weighted_components: { economics: 12.3 },
+  } as any;
+
+  it("renders the pts label in EN with the existing key", () => {
+    const html = renderToStaticMarkup(<ScoreBreakdownCompact breakdown={breakdown} />);
+    expect(html).toContain("12.3 pts");
+  });
+
+  it("renders the pts label in AR with the existing key", async () => {
+    await i18n.changeLanguage("ar");
+    const html = renderToStaticMarkup(<ScoreBreakdownCompact breakdown={breakdown} />);
+    expect(html).toContain(" نقطة");
+    expect(html).not.toContain(" pts");
+  });
+});
+
+describe("PR #4e §3 — % weight uses new decisionLogic.weightPercent key", () => {
+  it("resolves both locales", () => {
+    expect(i18n.getFixedT("en")("expansionAdvisor.decisionLogic.weightPercent", { value: 25 })).toBe("25% weight");
+    expect(i18n.getFixedT("ar")("expansionAdvisor.decisionLogic.weightPercent", { value: 25 })).toBe("25٪ وزن");
+  });
+});
+
+describe("PR #4e §4 — F&B outlet fallback localizes via threaded t", () => {
+  it("returns English fallback when t is omitted (back-compat)", () => {
+    const out = formatLandlordBriefingText(
+      { parcel_id: "P1", rank_position: 1 } as any,
+      null,
+      null,
+    );
+    expect(out).toContain("F&B outlet");
+  });
+
+  it("returns localized AR fallback when t resolves AR", async () => {
+    await i18n.changeLanguage("ar");
+    const t = i18n.getFixedT("ar");
+    const out = formatLandlordBriefingText(
+      { parcel_id: "P1", rank_position: 1 } as any,
+      null,
+      null,
+      t as any,
+    );
+    expect(out).toContain("منشأة أغذية ومشروبات");
+    expect(out).not.toContain("F&B outlet");
+  });
+
+  it("prefers report.best_format over fallback when present", () => {
+    const t = i18n.getFixedT("ar");
+    const out = formatLandlordBriefingText(
+      { parcel_id: "P1", rank_position: 1 } as any,
+      { recommendation: { best_format: "مقهى صغير" } } as any,
+      null,
+      t as any,
+    );
+    expect(out).toContain("مقهى صغير");
+    expect(out).not.toContain("منشأة أغذية ومشروبات");
   });
 });

--- a/frontend/src/features/expansion-advisor/ScoreBreakdownCompact.tsx
+++ b/frontend/src/features/expansion-advisor/ScoreBreakdownCompact.tsx
@@ -47,10 +47,10 @@ export default function ScoreBreakdownCompact({ breakdown }: Props) {
             />
           </div>
           <span className="ea-score-breakdown-compact__value">
-            {fmtScore(comp.weighted, 1)} pts
+            {t("expansionAdvisor.decisionLogicWeightedPoints", { points: fmtScore(comp.weighted, 1) })}
           </span>
           <span className="ea-score-breakdown-compact__weight">
-            {normalizeWeightPercent(comp.weight)}% weight
+            {t("expansionAdvisor.decisionLogic.weightPercent", { value: normalizeWeightPercent(comp.weight) })}
           </span>
         </div>
       ))}

--- a/frontend/src/features/expansion-advisor/studyAdapters.ts
+++ b/frontend/src/features/expansion-advisor/studyAdapters.ts
@@ -15,6 +15,7 @@ import type {
   CandidateGateReasons,
   CandidateFeatureSnapshot,
 } from "../../lib/api/expansionAdvisor";
+import type { TFunction } from "i18next";
 import { defaultBrief } from "./ExpansionBriefForm";
 import { humanGateLabel, humanGateSentence, candidateDistrictLabel } from "./formatHelpers";
 
@@ -1105,13 +1106,15 @@ export function formatLandlordBriefingText(
   candidate: ExpansionCandidate,
   report?: RecommendationReportResponse | null,
   memo?: CandidateMemoResponse | null,
+  t?: TFunction,
 ): string {
   const district = candidateDistrictLabel(candidate, "—");
   const parcelId = candidate.parcel_id || "—";
   const rank = candidate.rank_position || "?";
   const rentM2 = candidate.estimated_rent_sar_m2_year ? `${Math.round(candidate.estimated_rent_sar_m2_year)} SAR/m²/yr` : "TBD";
   const annualRent = (candidate.display_annual_rent_sar ?? candidate.estimated_annual_rent_sar) ? `${Math.round(candidate.display_annual_rent_sar ?? candidate.estimated_annual_rent_sar!).toLocaleString()} SAR/yr` : "TBD";
-  const format = report?.recommendation?.best_format || memo?.recommendation?.best_use_case || "F&B outlet";
+  const fallback = t ? t("expansionAdvisor.landlordBriefing.fallbackFormat") : "F&B outlet";
+  const format = report?.recommendation?.best_format || memo?.recommendation?.best_use_case || fallback;
   const gatePass = candidate.gate_status_json?.overall_pass;
   const gateLabel = gatePass === true ? "All gates passed" : gatePass === false ? "Some gates require review" : "Gates pending verification";
 

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -853,6 +853,9 @@
     "showingOf": "عرض {{shown}} من {{total}}",
     "localSort": "ترتيب محلي",
     "reopenStudy": "إعادة فتح",
+    "landlordBriefing": {
+      "fallbackFormat": "منشأة أغذية ومشروبات"
+    },
     "leadSite": "الموقع الرئيسي",
     "setAsLead": "تعيين كرئيسي",
     "clearLead": "إلغاء الرئيسي",
@@ -1099,6 +1102,7 @@
       "weightLabel": "الوزن",
       "contributionLabel": "المساهمة",
       "weightAndPoints": "{{weight}}٪ · {{points}} نقطة",
+      "weightPercent": "{{value}}٪ وزن",
       "inputsHeading": "المدخلات",
       "bonusesHeading": "المكافآت والتعديلات",
       "subtotal": "الدرجة الأساسية",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -802,6 +802,9 @@
     "showingOf": "Showing {{shown}} of {{total}}",
     "localSort": "Local sort",
     "reopenStudy": "Reopen",
+    "landlordBriefing": {
+      "fallbackFormat": "F&B outlet"
+    },
     "leadSite": "Lead Site",
     "setAsLead": "Set as Lead",
     "clearLead": "Clear Lead",
@@ -1119,6 +1122,7 @@
       "weightLabel": "Weight",
       "contributionLabel": "Contribution",
       "weightAndPoints": "{{weight}}% · {{points}} pts",
+      "weightPercent": "{{value}}% weight",
       "inputsHeading": "Inputs",
       "bonusesHeading": "Bonuses & adjustments",
       "subtotal": "Base score",


### PR DESCRIPTION
Consume existing expansionAdvisor.decisionLogicWeightedPoints key at the
two `pts` sites (DecisionLogicCard.tsx:392, ScoreBreakdownCompact.tsx:50).
Add expansionAdvisor.decisionLogic.weightPercent for the `% weight` site
(ScoreBreakdownCompact.tsx:53). Thread an optional `t` into
formatLandlordBriefingText and localize the `F&B outlet` fallback via a
new expansionAdvisor.landlordBriefing.fallbackFormat key; English fallback
preserved when `t` is omitted, keeping existing test callers byte-stable.

The rest of studyAdapters.ts (Site Visit Briefing template and the dozens
of English builder labels) is deferred to PR #4f.