### PR TITLE
feat(i18n): hard reload on user language change

### DIFF
--- a/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
+++ b/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
@@ -251,3 +251,31 @@ describe("PR #4e §4 — F&B outlet fallback localizes via threaded t", () => {
     expect(out).not.toContain("منشأة أغذية ومشروبات");
   });
 });
+
+/* ─── language-change reload behaviour ──────────────────────────────── */
+
+describe("language-change reload — boot vs user toggle", () => {
+  // We cannot exercise window.location.reload() in jsdom (it is a no-op
+  // there and logs to stderr). What we DO assert: the listener is wired
+  // at module load, and an identity changeLanguage call resolves without
+  // throwing — proving the identity-skip path returns early.
+
+  it("the reload listener is registered at module load", () => {
+    // i18next v25 stores listeners in observers[event] as a Map keyed by
+    // the listener function; older shapes used _events[event] arrays.
+    // Accept either, count both.
+    const i18nAny = i18n as any;
+    const observerMap = i18nAny.observers?.languageChanged;
+    const legacyArray = i18nAny._events?.languageChanged;
+    const count =
+      (observerMap && typeof observerMap.size === "number" ? observerMap.size : 0) +
+      (Array.isArray(legacyArray) ? legacyArray.length : legacyArray ? 1 : 0);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("changing language to the same locale does not throw", async () => {
+    const current = i18n.language;
+    await i18n.changeLanguage(current);
+    expect(i18n.language).toBe(current);
+  });
+});

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -55,6 +55,38 @@ i18n.on("languageChanged", (locale) => {
   applyDocumentLocale(normalized);
 });
 
+// Hard-reload the page on a user-initiated language change so no stale,
+// locale-bound state (memo/report payloads, expanded panels, candidate
+// selections, MapLibre tiles, React Query cache) survives the toggle.
+//
+// __lastObservedLocale tracks the last locale we saw. It absorbs i18next's
+// boot-time languageChanged fire (so opening the app in AR does not loop
+// reload) and suppresses identity changes (changeLanguage(currentLocale)).
+// We track manually instead of comparing document.documentElement.lang
+// because the listener above already mutates that attribute before this
+// one runs (listeners fire in attachment order), so a doc-based check
+// would always read the new value and never reload.
+let __lastObservedLocale: string | null = null;
+
+i18n.on("languageChanged", (locale) => {
+  const normalized = normalizeLocale(locale);
+
+  if (__lastObservedLocale === null) {
+    __lastObservedLocale = normalized;
+    return;
+  }
+
+  if (__lastObservedLocale === normalized) {
+    return;
+  }
+
+  __lastObservedLocale = normalized;
+
+  if (typeof window !== "undefined") {
+    window.location.reload();
+  }
+});
+
 applyDocumentLocale(normalizeLocale(i18n.language));
 
 export { LOCALE_STORAGE_KEY, applyDocumentLocale, getInitialLocale, normalizeLocale };


### PR DESCRIPTION
Toggling locale leaves stale, locale-bound state on screen — localized
API payloads (memo / report) sometimes render English content after
switching to AR, and React state cached against the old locale lingers
(open candidate selections, expanded panels, rank tables). Surgical
cache invalidation while persist-fail still burns full LLM cost per AR
view is the wrong place to optimize; nuke the page instead.

Wire one i18n.on('languageChanged', ...) listener at module init in
frontend/src/i18n/index.ts that calls window.location.reload(). Two
guards keep it correct:

  - A module-scoped __lastObservedLocale absorbs i18next's boot-time
    languageChanged fire (without this, opening the app in AR — which
    is persisted in localStorage — would loop reload on every load).
  - Identity changes (changeLanguage(currentLocale)) short-circuit.

We track the previous locale manually instead of reading
document.documentElement.lang because the persist/apply listener above
us mutates that attribute first (listeners fire in attachment order),
so a doc-based identity check would always read the new value and
suppress every reload.

The user's choice survives the reload via the existing localStorage
persistence ('oaktree_locale'). No backend changes, no string changes,
no new dependencies, no edits to translation consumers.