### PR TITLE
fix(i18n): make language toggle reload reliably on Safari

### DIFF
--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import type { ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { runFormatSanityCheck } from "../i18n/format";
+import { restartInLocale } from "../i18n";
 
 const LANGUAGE_OPTIONS = [
   { value: "en", labelKey: "language.english" },
@@ -13,7 +14,7 @@ export default function LanguageSwitcher() {
   const labelRef = useRef<HTMLSpanElement | null>(null);
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    void i18n.changeLanguage(event.target.value);
+    restartInLocale(event.target.value);
   };
 
   const currentLanguage = i18n.language.startsWith("ar") ? "ar" : "en";

--- a/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
+++ b/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import React from "react";
 import "../../i18n";
@@ -254,28 +254,43 @@ describe("PR #4e §4 — F&B outlet fallback localizes via threaded t", () => {
 
 /* ─── language-change reload behaviour ──────────────────────────────── */
 
-describe("language-change reload — boot vs user toggle", () => {
-  // We cannot exercise window.location.reload() in jsdom (it is a no-op
-  // there and logs to stderr). What we DO assert: the listener is wired
-  // at module load, and an identity changeLanguage call resolves without
-  // throwing — proving the identity-skip path returns early.
+describe("restartInLocale — persist + reload from the click site", () => {
+  // The reload is driven from the UI click handlers (not from an i18next
+  // listener), so it works the same on Safari and Chrome. The test env is
+  // plain node (no jsdom), so we stub `window` for the duration of the
+  // test and assert the helper persists the chosen locale and calls
+  // reload exactly once per invocation.
 
-  it("the reload listener is registered at module load", () => {
-    // i18next v25 stores listeners in observers[event] as a Map keyed by
-    // the listener function; older shapes used _events[event] arrays.
-    // Accept either, count both.
-    const i18nAny = i18n as any;
-    const observerMap = i18nAny.observers?.languageChanged;
-    const legacyArray = i18nAny._events?.languageChanged;
-    const count =
-      (observerMap && typeof observerMap.size === "number" ? observerMap.size : 0) +
-      (Array.isArray(legacyArray) ? legacyArray.length : legacyArray ? 1 : 0);
-    expect(count).toBeGreaterThanOrEqual(1);
-  });
+  it("persists the normalized locale and calls window.location.reload()", async () => {
+    const { restartInLocale, LOCALE_STORAGE_KEY } = await import("../../i18n");
+    const reload = vi.fn();
+    const store: Record<string, string> = {};
+    const fakeWindow = {
+      localStorage: {
+        getItem: (key: string) => (key in store ? store[key] : null),
+        setItem: (key: string, value: string) => {
+          store[key] = value;
+        },
+        removeItem: (key: string) => {
+          delete store[key];
+        },
+      },
+      location: { reload },
+    };
+    const g = globalThis as any;
+    const originalWindow = g.window;
+    g.window = fakeWindow;
+    try {
+      restartInLocale("ar");
+      expect(store[LOCALE_STORAGE_KEY]).toBe("ar");
+      expect(reload).toHaveBeenCalledTimes(1);
 
-  it("changing language to the same locale does not throw", async () => {
-    const current = i18n.language;
-    await i18n.changeLanguage(current);
-    expect(i18n.language).toBe(current);
+      restartInLocale("en-US");
+      expect(store[LOCALE_STORAGE_KEY]).toBe("en");
+      expect(reload).toHaveBeenCalledTimes(2);
+    } finally {
+      if (originalWindow === undefined) delete g.window;
+      else g.window = originalWindow;
+    }
   });
 });

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -59,35 +59,27 @@ i18n.on("languageChanged", (locale) => {
 // locale-bound state (memo/report payloads, expanded panels, candidate
 // selections, MapLibre tiles, React Query cache) survives the toggle.
 //
-// __lastObservedLocale tracks the last locale we saw. It absorbs i18next's
-// boot-time languageChanged fire (so opening the app in AR does not loop
-// reload) and suppresses identity changes (changeLanguage(currentLocale)).
-// We track manually instead of comparing document.documentElement.lang
-// because the listener above already mutates that attribute before this
-// one runs (listeners fire in attachment order), so a doc-based check
-// would always read the new value and never reload.
-let __lastObservedLocale: string | null = null;
-
-i18n.on("languageChanged", (locale) => {
+// Driven directly from the UI click handlers (LanguageSwitcher, HeaderBar)
+// via restartInLocale instead of routing through i18next's languageChanged
+// event. Safari did not reliably fire languageChanged during init(), so
+// the previous boot-guard absorbed the first real user toggle and the
+// page never reloaded. Persisting + reloading at the click site removes
+// that dependency — on the next load, getInitialLocale() reads back the
+// stored choice.
+const restartInLocale = (locale: string) => {
   const normalized = normalizeLocale(locale);
-
-  if (__lastObservedLocale === null) {
-    __lastObservedLocale = normalized;
-    return;
-  }
-
-  if (__lastObservedLocale === normalized) {
-    return;
-  }
-
-  __lastObservedLocale = normalized;
-
-  if (typeof window !== "undefined") {
-    window.location.reload();
-  }
-});
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(LOCALE_STORAGE_KEY, normalized);
+  window.location.reload();
+};
 
 applyDocumentLocale(normalizeLocale(i18n.language));
 
-export { LOCALE_STORAGE_KEY, applyDocumentLocale, getInitialLocale, normalizeLocale };
+export {
+  LOCALE_STORAGE_KEY,
+  applyDocumentLocale,
+  getInitialLocale,
+  normalizeLocale,
+  restartInLocale,
+};
 export default i18n;

--- a/frontend/src/ui-v2/HeaderBar.tsx
+++ b/frontend/src/ui-v2/HeaderBar.tsx
@@ -1,6 +1,7 @@
 import { GlobeAltIcon } from "@heroicons/react/24/outline";
 import { useTranslation } from "react-i18next";
 import type { SearchItem } from "../types/search";
+import { restartInLocale } from "../i18n";
 import SearchBar from "./SearchBar";
 
 type HeaderBarProps = {
@@ -24,7 +25,7 @@ export default function HeaderBar({ onSearchSelect }: HeaderBarProps) {
           <button
             type="button"
             className="oak-btn oak-btn--secondary oak-btn--md"
-            onClick={() => void i18n.changeLanguage(isArabic ? "en" : "ar")}
+            onClick={() => restartInLocale(isArabic ? "en" : "ar")}
           >
             <GlobeAltIcon width={16} height={16} />
             <span>{isArabic ? "English" : "العربية"}</span>


### PR DESCRIPTION
The hard-reload on language change worked on Chrome but not on Safari.
The listener-based approach in i18n/index.ts depended on i18next firing
languageChanged once during init() so that the __lastObservedLocale=null
boot-guard would absorb it and let the first real user toggle through.
Safari's init path did not consistently fire that boot event, so the
first user click was silently swallowed by the guard (it just set the
tracker) and the page never reloaded.

Drive the reload directly from the click site instead. A new
restartInLocale(locale) helper in i18n/index.ts persists the normalized
locale to localStorage and calls window.location.reload() unconditionally.
Both language switcher UIs — LanguageSwitcher (legacy dropdown) and
HeaderBar (v2 globe button) — call it from their click/change handlers.
After the reload, getInitialLocale() re-reads the persisted choice.

This removes every dependency on i18next event timing or listener order,
so the behavior is identical across Chrome and Safari. The previous
boot-guarded listener is gone; the persist+apply listener that updates
localStorage and the <html dir/lang> attributes is retained for
programmatic changeLanguage() calls (used by tests).

Test updated: replaces the old listener-registration assertion with one
that stubs window globally and verifies restartInLocale persists the
normalized locale and triggers exactly one reload per invocation. All
24 tests in Pr4dI18n.test.tsx pass. tsc and vite build are clean.

https://claude.ai/code/session_01QmQcrPy7dcf54k8DeuVJQb