### PR TITLE
PR-A: decouple restaurant_poi upsert from delivery scrape

### DIFF
--- a/.github/workflows/ingest-restaurant-pois.yml
+++ b/.github/workflows/ingest-restaurant-pois.yml
@@ -112,7 +112,7 @@ jobs:
           from app.ingest.restaurant_pois import (
               ingest_overture_restaurants,
               ingest_osm_restaurants,
-              ingest_delivery_platforms,
+              upsert_restaurant_poi_from_delivery,
           )
 
           sources = '${{ steps.sources.outputs.list }}'.split(',')
@@ -147,11 +147,16 @@ jobs:
                   db.close()
 
           if 'delivery' in sources:
+              db = SessionLocal()
               try:
-                  results['delivery_platforms'] = ingest_delivery_platforms(sources=delivery_sources)
+                  results['delivery_platforms'] = upsert_restaurant_poi_from_delivery(
+                      db, platforms=delivery_sources
+                  )
               except Exception as exc:
-                  logger.error('Delivery ingestion failed: %s', exc)
+                  logger.error('Stage 2 POI upsert from delivery failed: %s', exc)
                   results['delivery_platforms'] = 0
+              finally:
+                  db.close()
 
           logger.info('Ingestion complete: %s', results)
           "

--- a/app/ingest/restaurant_pois.py
+++ b/app/ingest/restaurant_pois.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from typing import Iterable
 
 from sqlalchemy.orm import Session
 
@@ -22,6 +23,14 @@ from app.services.restaurant_categories import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Filter constants shared with the legacy Stage 2 block in
+# ``ingest_delivery_platforms``. Keep these in lock-step with that block; this
+# is intentionally the same allow-list so the decoupled upsert produces the
+# same row set the original code would have.
+_DELIVERY_POI_GEOCODE_ALLOWLIST = ("platform_payload", "json_ld", "address_geocode")
+_DELIVERY_POI_MIN_LOCATION_CONFIDENCE = 0.7
+_DEFAULT_DELIVERY_RUN_STATUSES = ("completed", "completed_with_errors")
 
 
 def _upsert_poi(db: Session, poi: dict) -> bool:
@@ -191,9 +200,10 @@ def ingest_delivery_platforms(
                 DeliverySourceRecord.ingest_run_id.in_(run_ids),
                 DeliverySourceRecord.lat.isnot(None),
                 DeliverySourceRecord.lon.isnot(None),
-                DeliverySourceRecord.location_confidence >= 0.7,
+                DeliverySourceRecord.location_confidence
+                >= _DELIVERY_POI_MIN_LOCATION_CONFIDENCE,
                 DeliverySourceRecord.geocode_method.in_(
-                    ["platform_payload", "json_ld", "address_geocode"]
+                    _DELIVERY_POI_GEOCODE_ALLOWLIST
                 ),
             )
             .all()
@@ -237,6 +247,181 @@ def ingest_delivery_platforms(
         n, total_inserted,
     )
     return n
+
+
+def upsert_restaurant_poi_from_delivery(
+    db: Session | None = None,
+    *,
+    since: datetime | None = None,
+    platforms: Iterable[str] | None = None,
+    statuses: Iterable[str] = _DEFAULT_DELIVERY_RUN_STATUSES,
+) -> int:
+    """Upsert restaurant_poi rows from existing delivery_source_record rows.
+
+    Independent of the live scrape. Reads the most recent delivery_ingest_run
+    rows (filtered by status and optionally by platforms / since), then
+    upserts the corresponding delivery_source_record rows into restaurant_poi
+    using the same filter conditions as the legacy Stage 2 block in
+    ``ingest_delivery_platforms``.
+
+    Args:
+        db: Optional existing session. If None, opens its own SessionLocal()
+            and closes it before returning.
+        since: Only consider delivery_ingest_run rows with finished_at >= since.
+            If None, takes the most recent completed run per platform.
+        platforms: Restrict to these platform names. If None, all platforms
+            with at least one matching run.
+        statuses: delivery_ingest_run.status values to include. Defaults to
+            successful and partial-success runs.
+
+    Returns:
+        Number of restaurant_poi rows upserted (count of _upsert_poi calls).
+    """
+    from sqlalchemy import func
+
+    from app.db.session import SessionLocal
+    from app.delivery.models import DeliveryIngestRun, DeliverySourceRecord
+
+    platforms_list = list(platforms) if platforms is not None else None
+    statuses_list = list(statuses)
+
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+
+    try:
+        # ── Run selection ────────────────────────────────────────────────
+        if since is not None:
+            # All runs with finished_at >= since matching status/platforms.
+            run_query = db.query(
+                DeliveryIngestRun.id,
+                DeliveryIngestRun.platform,
+                DeliveryIngestRun.finished_at,
+            ).filter(
+                DeliveryIngestRun.finished_at.isnot(None),
+                DeliveryIngestRun.finished_at >= since,
+                DeliveryIngestRun.status.in_(statuses_list),
+            )
+            if platforms_list:
+                run_query = run_query.filter(
+                    DeliveryIngestRun.platform.in_(platforms_list)
+                )
+            runs = run_query.all()
+        else:
+            # Most recent finished_at per platform (semantically equivalent to
+            # ``DISTINCT ON (platform) ... ORDER BY platform, finished_at DESC``
+            # but expressed portably as GROUP BY + self-join so the function
+            # also runs under SQLite in tests).
+            latest_subq = db.query(
+                DeliveryIngestRun.platform.label("platform"),
+                func.max(DeliveryIngestRun.finished_at).label("max_finished"),
+            ).filter(
+                DeliveryIngestRun.finished_at.isnot(None),
+                DeliveryIngestRun.status.in_(statuses_list),
+            )
+            if platforms_list:
+                latest_subq = latest_subq.filter(
+                    DeliveryIngestRun.platform.in_(platforms_list)
+                )
+            latest_subq = latest_subq.group_by(DeliveryIngestRun.platform).subquery()
+
+            runs = (
+                db.query(
+                    DeliveryIngestRun.id,
+                    DeliveryIngestRun.platform,
+                    DeliveryIngestRun.finished_at,
+                )
+                .join(
+                    latest_subq,
+                    (DeliveryIngestRun.platform == latest_subq.c.platform)
+                    & (DeliveryIngestRun.finished_at == latest_subq.c.max_finished),
+                )
+                .filter(DeliveryIngestRun.status.in_(statuses_list))
+                .all()
+            )
+
+        run_ids = [r[0] for r in runs]
+
+        if not run_ids:
+            logger.warning(
+                "upsert_restaurant_poi_from_delivery: no delivery_ingest_run rows "
+                "matched filter (since=%s, platforms=%s, statuses=%s); "
+                "nothing to upsert",
+                since, platforms_list, statuses_list,
+            )
+            return 0
+
+        logger.info(
+            "upsert_restaurant_poi_from_delivery: %d run(s) selected "
+            "(since=%s, platforms=%s, statuses=%s)",
+            len(run_ids), since, platforms_list, statuses_list,
+        )
+        for run_id, platform, finished_at in runs:
+            logger.debug(
+                "  run_id=%s platform=%s finished_at=%s",
+                run_id, platform, finished_at,
+            )
+
+        # ── Row selection — identical filter to legacy Stage 2 ──────────
+        resolved_rows = (
+            db.query(DeliverySourceRecord)
+            .filter(
+                DeliverySourceRecord.ingest_run_id.in_(run_ids),
+                DeliverySourceRecord.lat.isnot(None),
+                DeliverySourceRecord.lon.isnot(None),
+                DeliverySourceRecord.location_confidence
+                >= _DELIVERY_POI_MIN_LOCATION_CONFIDENCE,
+                DeliverySourceRecord.geocode_method.in_(
+                    _DELIVERY_POI_GEOCODE_ALLOWLIST
+                ),
+            )
+            .all()
+        )
+
+        n = 0
+        for row in resolved_rows:
+            category = normalize_category(row.cuisine_raw or row.category_raw)
+            poi = {
+                "id": f"{row.platform}:{row.source_listing_id or row.id}",
+                "name": (
+                    row.restaurant_name_normalized
+                    or row.restaurant_name_raw
+                    or "Unknown"
+                ),
+                "category": category,
+                "source": row.platform,
+                "lat": float(row.lat),
+                "lon": float(row.lon),
+                "chain_name": row.brand_raw,
+                "district": row.district_text,
+                "rating": float(row.rating) if row.rating else None,
+                "review_count": row.rating_count,
+                "raw": {
+                    "source_url": row.source_url,
+                    "delivery_pipeline": True,
+                    "geocode_method": row.geocode_method,
+                    "location_confidence": row.location_confidence,
+                },
+            }
+            _upsert_poi(db, poi)
+            n += 1
+
+        db.commit()
+        logger.info(
+            "upsert_restaurant_poi_from_delivery: upserted %d restaurant_poi "
+            "row(s) from %d delivery_source_record row(s) across %d run(s)",
+            n, len(resolved_rows), len(run_ids),
+        )
+        return n
+    except Exception:
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        raise
+    finally:
+        if own_session:
+            db.close()
 
 
 def ingest_all(db: Session) -> dict[str, int]:

--- a/tests/ingest/test_upsert_restaurant_poi_from_delivery.py
+++ b/tests/ingest/test_upsert_restaurant_poi_from_delivery.py
@@ -1,0 +1,427 @@
+"""Tests for ``upsert_restaurant_poi_from_delivery``.
+
+The function is the post-scrape Stage 2 that the weekly ``ingest-restaurant-pois``
+workflow now calls instead of re-running the delivery scrape. It must read the
+``delivery_source_record`` rows already produced by the SCCC daily K8s job and
+upsert them into ``restaurant_poi``.
+
+These tests use a SQLite in-memory engine with the real ORM tables
+(``Base.metadata.create_all``) — no SQL-layer mocks. JSONB columns are compiled
+to JSON on SQLite via ``@compiles`` (same pattern as ``tests/test_revenue_paths.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.delivery.models import DeliveryIngestRun, DeliverySourceRecord
+from app.ingest.restaurant_pois import upsert_restaurant_poi_from_delivery
+from app.models.base import Base
+from app.models.tables import RestaurantPOI
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb(element, compiler, **kw):  # noqa: ARG001
+    return "JSON"
+
+
+@pytest.fixture
+def session_factory():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(
+        bind=engine,
+        tables=[
+            DeliveryIngestRun.__table__,
+            DeliverySourceRecord.__table__,
+            RestaurantPOI.__table__,
+        ],
+    )
+    Session = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    yield Session
+    engine.dispose()
+
+
+@pytest.fixture
+def db(session_factory):
+    s = session_factory()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _make_run(
+    db,
+    *,
+    platform: str,
+    status: str = "completed",
+    finished_at: datetime | None = None,
+) -> DeliveryIngestRun:
+    started = (finished_at or datetime.now(timezone.utc)) - timedelta(minutes=10)
+    run = DeliveryIngestRun(
+        platform=platform,
+        started_at=started,
+        finished_at=finished_at or datetime.now(timezone.utc),
+        status=status,
+    )
+    db.add(run)
+    db.flush()
+    return run
+
+
+def _make_record(
+    db,
+    *,
+    run_id: int,
+    platform: str = "hungerstation",
+    source_listing_id: str | None = "lst-1",
+    lat: float | None = 24.7136,
+    lon: float | None = 46.6753,
+    location_confidence: float | None = 0.9,
+    geocode_method: str = "platform_payload",
+    name: str = "Burger King - Olaya",
+    cuisine_raw: str | None = "burger",
+    brand_raw: str | None = "Burger King",
+    district_text: str | None = "Al Olaya",
+    rating: float | None = None,
+    rating_count: int | None = None,
+) -> DeliverySourceRecord:
+    row = DeliverySourceRecord(
+        platform=platform,
+        source_listing_id=source_listing_id,
+        source_url=f"https://{platform}.example/{source_listing_id}",
+        scraped_at=datetime.now(timezone.utc),
+        city="riyadh",
+        lat=lat,
+        lon=lon,
+        geocode_method=geocode_method,
+        location_confidence=location_confidence,
+        restaurant_name_raw=name,
+        restaurant_name_normalized=name,
+        brand_raw=brand_raw,
+        cuisine_raw=cuisine_raw,
+        district_text=district_text,
+        rating=rating,
+        rating_count=rating_count,
+        ingest_run_id=run_id,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def _poi_count(db) -> int:
+    return db.query(RestaurantPOI).count()
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty case
+# ---------------------------------------------------------------------------
+
+class TestEmpty:
+    def test_no_runs_returns_zero(self, db):
+        n = upsert_restaurant_poi_from_delivery(db)
+        assert n == 0
+        assert _poi_count(db) == 0
+
+    def test_runs_but_no_records_returns_zero(self, db):
+        _make_run(db, platform="hungerstation")
+        db.commit()
+        n = upsert_restaurant_poi_from_delivery(db)
+        assert n == 0
+        assert _poi_count(db) == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Row-level filter correctness
+# ---------------------------------------------------------------------------
+
+class TestRowFilter:
+    def test_filters_by_geocode_method_and_confidence(self, db):
+        run = _make_run(db, platform="hungerstation")
+
+        # Should pass: platform_payload + 0.9 confidence
+        _make_record(
+            db, run_id=run.id, source_listing_id="ok-1",
+            geocode_method="platform_payload", location_confidence=0.9,
+        )
+        # Should pass: json_ld + 0.7 confidence
+        _make_record(
+            db, run_id=run.id, source_listing_id="ok-2",
+            geocode_method="json_ld", location_confidence=0.7,
+        )
+        # Should pass: address_geocode + 0.8 confidence
+        _make_record(
+            db, run_id=run.id, source_listing_id="ok-3",
+            geocode_method="address_geocode", location_confidence=0.8,
+        )
+        # Should reject: geocode_method='none'
+        _make_record(
+            db, run_id=run.id, source_listing_id="bad-none",
+            geocode_method="none", location_confidence=0.9,
+        )
+        # Should reject: confidence below 0.7
+        _make_record(
+            db, run_id=run.id, source_listing_id="bad-conf",
+            geocode_method="platform_payload", location_confidence=0.6,
+        )
+        # Should reject: missing lat
+        _make_record(
+            db, run_id=run.id, source_listing_id="bad-lat",
+            geocode_method="platform_payload", location_confidence=0.9,
+            lat=None,
+        )
+        # Should reject: missing lon
+        _make_record(
+            db, run_id=run.id, source_listing_id="bad-lon",
+            geocode_method="platform_payload", location_confidence=0.9,
+            lon=None,
+        )
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(db)
+        assert n == 3
+        ids = {p.id for p in db.query(RestaurantPOI).all()}
+        assert ids == {
+            "hungerstation:ok-1",
+            "hungerstation:ok-2",
+            "hungerstation:ok-3",
+        }
+
+
+# ---------------------------------------------------------------------------
+# 3. Most-recent-per-platform semantics (since=None)
+# ---------------------------------------------------------------------------
+
+class TestMostRecentPerPlatform:
+    def test_only_latest_run_per_platform_is_used(self, db):
+        now = datetime.now(timezone.utc)
+        old_run = _make_run(
+            db, platform="hungerstation", finished_at=now - timedelta(days=7),
+        )
+        new_run = _make_run(
+            db, platform="hungerstation", finished_at=now - timedelta(hours=1),
+        )
+
+        _make_record(
+            db, run_id=old_run.id, source_listing_id="old-listing",
+            name="Stale Burger",
+        )
+        _make_record(
+            db, run_id=new_run.id, source_listing_id="new-listing",
+            name="Fresh Burger",
+        )
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(db)
+        assert n == 1
+        ids = {p.id for p in db.query(RestaurantPOI).all()}
+        assert ids == {"hungerstation:new-listing"}
+
+    def test_picks_latest_per_platform_independently(self, db):
+        now = datetime.now(timezone.utc)
+        hs_old = _make_run(
+            db, platform="hungerstation", finished_at=now - timedelta(days=2),
+        )
+        hs_new = _make_run(
+            db, platform="hungerstation", finished_at=now - timedelta(hours=2),
+        )
+        jz_old = _make_run(
+            db, platform="jahez", finished_at=now - timedelta(days=2),
+        )
+        jz_new = _make_run(
+            db, platform="jahez", finished_at=now - timedelta(hours=3),
+        )
+
+        _make_record(
+            db, run_id=hs_old.id, platform="hungerstation",
+            source_listing_id="hs-old", name="HS Old",
+        )
+        _make_record(
+            db, run_id=hs_new.id, platform="hungerstation",
+            source_listing_id="hs-new", name="HS New",
+        )
+        _make_record(
+            db, run_id=jz_old.id, platform="jahez",
+            source_listing_id="jz-old", name="JZ Old",
+        )
+        _make_record(
+            db, run_id=jz_new.id, platform="jahez",
+            source_listing_id="jz-new", name="JZ New",
+        )
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(db)
+        assert n == 2
+        ids = {p.id for p in db.query(RestaurantPOI).all()}
+        assert ids == {"hungerstation:hs-new", "jahez:jz-new"}
+
+
+# ---------------------------------------------------------------------------
+# 4. ``since`` filter
+# ---------------------------------------------------------------------------
+
+class TestSinceFilter:
+    def test_since_excludes_older_runs(self, db):
+        now = datetime.now(timezone.utc)
+        old_run = _make_run(
+            db, platform="hungerstation", finished_at=now - timedelta(days=7),
+        )
+        new_run = _make_run(
+            db, platform="hungerstation", finished_at=now - timedelta(hours=2),
+        )
+
+        _make_record(
+            db, run_id=old_run.id, source_listing_id="should-be-skipped",
+        )
+        _make_record(
+            db, run_id=new_run.id, source_listing_id="should-be-included",
+        )
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(
+            db, since=now - timedelta(days=1),
+        )
+        assert n == 1
+        ids = {p.id for p in db.query(RestaurantPOI).all()}
+        assert ids == {"hungerstation:should-be-included"}
+
+    def test_since_keeps_multiple_runs_in_window(self, db):
+        # With since= provided, ALL runs in window are used, not just the latest.
+        now = datetime.now(timezone.utc)
+        run_a = _make_run(
+            db, platform="hungerstation", finished_at=now - timedelta(hours=5),
+        )
+        run_b = _make_run(
+            db, platform="hungerstation", finished_at=now - timedelta(hours=2),
+        )
+
+        _make_record(db, run_id=run_a.id, source_listing_id="a")
+        _make_record(db, run_id=run_b.id, source_listing_id="b")
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(
+            db, since=now - timedelta(days=1),
+        )
+        assert n == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. ``platforms`` filter
+# ---------------------------------------------------------------------------
+
+class TestPlatformsFilter:
+    def test_platforms_excludes_other_platform_runs(self, db):
+        _hs_run = _make_run(db, platform="hungerstation")
+        _jz_run = _make_run(db, platform="jahez")
+
+        _make_record(
+            db, run_id=_hs_run.id, platform="hungerstation",
+            source_listing_id="hs-1",
+        )
+        _make_record(
+            db, run_id=_jz_run.id, platform="jahez",
+            source_listing_id="jz-1",
+        )
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(db, platforms=["hungerstation"])
+        assert n == 1
+        ids = {p.id for p in db.query(RestaurantPOI).all()}
+        assert ids == {"hungerstation:hs-1"}
+
+
+# ---------------------------------------------------------------------------
+# 6. Status filter
+# ---------------------------------------------------------------------------
+
+class TestStatusFilter:
+    def test_failed_runs_excluded_by_default(self, db):
+        run = _make_run(db, platform="hungerstation", status="failed")
+        _make_record(db, run_id=run.id, source_listing_id="from-failed")
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(db)
+        assert n == 0
+        assert _poi_count(db) == 0
+
+    def test_failed_runs_included_when_requested(self, db):
+        run = _make_run(db, platform="hungerstation", status="failed")
+        _make_record(db, run_id=run.id, source_listing_id="from-failed")
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(
+            db, statuses=("failed",),
+        )
+        assert n == 1
+
+    def test_completed_with_errors_included_by_default(self, db):
+        run = _make_run(db, platform="hungerstation", status="completed_with_errors")
+        _make_record(db, run_id=run.id, source_listing_id="from-cwe")
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(db)
+        assert n == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Upsert behavior — existing row updated, not duplicated
+# ---------------------------------------------------------------------------
+
+class TestUpsertBehavior:
+    def test_existing_row_is_updated_not_duplicated(self, db):
+        # Pre-existing POI with the deterministic id this function would emit.
+        existing = RestaurantPOI(
+            id="hungerstation:dupe-listing",
+            name="Stale Name",
+            category="international",
+            source="hungerstation",
+            lat=24.0,
+            lon=46.0,
+            rating=2.0,
+            review_count=10,
+            observed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        db.add(existing)
+        db.commit()
+        assert _poi_count(db) == 1
+
+        run = _make_run(db, platform="hungerstation")
+        _make_record(
+            db,
+            run_id=run.id,
+            source_listing_id="dupe-listing",
+            name="Fresh Name",
+            cuisine_raw="burger",
+            rating=4.5,
+            rating_count=200,
+        )
+        db.commit()
+
+        n = upsert_restaurant_poi_from_delivery(db)
+        # Function counts both inserts and updates as upserts.
+        assert n == 1
+        # No duplicate row.
+        assert _poi_count(db) == 1
+
+        refreshed = db.query(RestaurantPOI).filter_by(
+            id="hungerstation:dupe-listing"
+        ).one()
+        assert refreshed.name == "Fresh Name"
+        # _upsert_poi update path refreshes rating / review_count / observed_at.
+        assert float(refreshed.rating) == pytest.approx(4.5)
+        assert refreshed.review_count == 200
+        # _upsert_poi update path does NOT change lat/lon — preserved from original.
+        assert float(refreshed.lat) == pytest.approx(24.0)
+        assert float(refreshed.lon) == pytest.approx(46.0)


### PR DESCRIPTION
## Summary

`ingest-restaurant-pois.yml` (weekly Monday cron, `timeout-minutes: 180`) has been timing out every run since 2026-04-06 because it serially scrapes HungerStation (~232 min workload at `max_pages=5000`). The downstream Stage 2 upsert at `app/ingest/restaurant_pois.py:185–233` never runs as a result, so `restaurant_poi` is stuck (`source='hungerstation'` last observed 2026-03-23).

Meanwhile, the sister workflow `.github/workflows/expansion-advisor-data-delivery-sccc.yml` (daily cron, 350-min GHA + 12 h K8s budget) already runs the same scrape to completion and keeps `delivery_source_record` fresh — Codespace confirms **17,082 `platform_payload` rows in the last 30 days**, all with `lat IS NOT NULL AND lon IS NOT NULL AND location_confidence >= 0.7`. The data Stage 2 needs is already in the DB.

This PR removes the duplication: Stage 2 stops depending on a fresh scrape, and instead reads the most recent `delivery_ingest_run` rows already written by the SCCC path.

## What changed

### 1. New function `upsert_restaurant_poi_from_delivery` in `app/ingest/restaurant_pois.py`

```python
def upsert_restaurant_poi_from_delivery(
    db: Session | None = None,
    *,
    since: datetime | None = None,
    platforms: Iterable[str] | None = None,
    statuses: Iterable[str] = _DEFAULT_DELIVERY_RUN_STATUSES,  # ("completed", "completed_with_errors")
) -> int:
    """Upsert restaurant_poi rows from existing delivery_source_record rows.

    Independent of the live scrape. Reads the most recent delivery_ingest_run
    rows (filtered by status and optionally by platforms / since), then
    upserts the corresponding delivery_source_record rows into restaurant_poi
    using the same filter conditions as the legacy Stage 2 block in
    ``ingest_delivery_platforms``.
    """
```

Behavior:

- Run selection:
  - `since` provided: every `delivery_ingest_run` with `finished_at >= since` matching status / platforms.
  - `since` is None: most recent `finished_at` **per platform**. Implemented as `GROUP BY platform` + self-join (semantically equivalent to `DISTINCT ON (platform) ORDER BY platform, finished_at DESC`, but portable to SQLite for tests).
- Row filter is byte-for-byte the legacy Stage 2 filter, now expressed via module-level constants so the two callers can't drift:
  ```python
  _DELIVERY_POI_GEOCODE_ALLOWLIST = ("platform_payload", "json_ld", "address_geocode")
  _DELIVERY_POI_MIN_LOCATION_CONFIDENCE = 0.7
  _DEFAULT_DELIVERY_RUN_STATUSES = ("completed", "completed_with_errors")
  ```
  The legacy `ingest_delivery_platforms` block was updated to reference the same constants so both code paths stay in lock-step.
- Upserts via the existing `_upsert_poi` helper (no logic duplication, no schema change).
- Single `db.commit()` at the end. Rolls back on exception, re-raises.
- Logs: number of runs selected, per-run `(run_id, platform, finished_at)` at DEBUG, final commit count at INFO.
- Empty case logs a warning and returns 0 (no raise).
- When `db` is None, opens / closes its own `SessionLocal()`.

### 2. Workflow inline script — `ingest-restaurant-pois.yml`

Before:

```python
from app.ingest.restaurant_pois import (
    ingest_overture_restaurants,
    ingest_osm_restaurants,
    ingest_delivery_platforms,
)
…
if 'delivery' in sources:
    try:
        results['delivery_platforms'] = ingest_delivery_platforms(sources=delivery_sources)
    except Exception as exc:
        logger.error('Delivery ingestion failed: %s', exc)
        results['delivery_platforms'] = 0
```

After:

```python
from app.ingest.restaurant_pois import (
    ingest_overture_restaurants,
    ingest_osm_restaurants,
    upsert_restaurant_poi_from_delivery,
)
…
if 'delivery' in sources:
    db = SessionLocal()
    try:
        results['delivery_platforms'] = upsert_restaurant_poi_from_delivery(
            db, platforms=delivery_sources
        )
    except Exception as exc:
        logger.error('Stage 2 POI upsert from delivery failed: %s', exc)
        results['delivery_platforms'] = 0
    finally:
        db.close()
```

No other changes to the workflow — schedule, `timeout-minutes: 180`, `concurrency`, and the smoke-test steps are untouched. The scrape no longer runs from this workflow.

### 3. Tests — `tests/ingest/test_upsert_restaurant_poi_from_delivery.py`

12 cases, all passing locally (`pytest -v`, 0.81s):

| # | Class | What it covers |
|---|---|---|
| 1 | `TestEmpty::test_no_runs_returns_zero` | No `delivery_ingest_run` rows → returns 0, no exception. |
| 2 | `TestEmpty::test_runs_but_no_records_returns_zero` | Run with no records → returns 0. |
| 3 | `TestRowFilter::test_filters_by_geocode_method_and_confidence` | `platform_payload`, `json_ld`, `address_geocode` pass; `none`, confidence<0.7, missing lat, missing lon are rejected. |
| 4 | `TestMostRecentPerPlatform::test_only_latest_run_per_platform_is_used` | `since=None` picks the newer run; older run's records are skipped. |
| 5 | `TestMostRecentPerPlatform::test_picks_latest_per_platform_independently` | Latest-per-platform applied independently across multiple platforms. |
| 6 | `TestSinceFilter::test_since_excludes_older_runs` | `finished_at < since` excluded. |
| 7 | `TestSinceFilter::test_since_keeps_multiple_runs_in_window` | With `since=`, **all** runs in window are used (not just the latest). |
| 8 | `TestPlatformsFilter::test_platforms_excludes_other_platform_runs` | `platforms=["hungerstation"]` excludes other platforms. |
| 9 | `TestStatusFilter::test_failed_runs_excluded_by_default` | Default status set excludes `failed`. |
| 10 | `TestStatusFilter::test_failed_runs_included_when_requested` | `statuses=("failed",)` includes them. |
| 11 | `TestStatusFilter::test_completed_with_errors_included_by_default` | `completed_with_errors` included by default. |
| 12 | `TestUpsertBehavior::test_existing_row_is_updated_not_duplicated` | Pre-existing `restaurant_poi` row with same deterministic id is updated, not duplicated; `_upsert_poi` update path refreshes `name`/`rating`/`review_count`/`observed_at` but preserves `lat`/`lon`. |

Test harness: SQLite in-memory + `Base.metadata.create_all` + `@compiles(JSONB, "sqlite")` — same pattern as `tests/test_revenue_paths.py:24–26` and `tests/test_expansion_advisor_data_pipeline.py:1056`. No SQL-layer mocks.

## Verification

- `pytest tests/ingest/test_upsert_restaurant_poi_from_delivery.py -v` → **12 passed in 0.81s**.
- `pytest tests/ingest/ tests/test_delivery_pipeline.py tests/test_delivery_platforms.py tests/test_restaurant_categories.py -q` → **175 passed in 1.21s** (existing delivery pipeline suite stays green).
- `flake8 app/ingest/restaurant_pois.py` → only E501 line-length warnings; the file already had pre-existing E501 violations and `.github/workflows/ci.yml` doesn't run flake8 (CI is `pytest -q` only).

## Remaining callers of `ingest_delivery_platforms`

Per the prompt, this function is **not** removed (separate audit). `grep -rn "ingest_delivery_platforms" app/ scripts/ .github/ tests/` after the patch:

```
app/ingest/restaurant_pois.py:155: def ingest_delivery_platforms(   # definition
app/ingest/restaurant_pois.py:265: ``ingest_delivery_platforms``.   # docstring reference in new fn
app/ingest/restaurant_pois.py:432: results["delivery_platforms"] = ingest_delivery_platforms(db)
                                                                   # legacy ingest_all() aggregator,
                                                                   # only used by `python -m app.ingest.restaurant_pois`
                                                                   # __main__ at L436–444
```

No workflow, script, or test references it after this PR. The legacy entry point (`python -m app.ingest.restaurant_pois`) is preserved as-is.

## Not touched in this PR

Per the scope rules:

- `app/delivery/pipeline.py`, `app/connectors/delivery_platforms.py`, `app/ingest/expansion_advisor_delivery.py` — SCCC path unchanged.
- `.github/workflows/expansion-advisor-data-delivery-sccc.yml` — daily K8s scrape unchanged.
- `ingest_delivery_platforms` left in place (deletion is a separate audit).
- Overture / Overpass code paths — out of scope (PR-B / PR-C).
- No scoring code, memo code, Arabic surfaces, or ECQ logic touched.
- No new third-party dependencies.

## Rollback plan

Revert the PR. The new code is additive: `upsert_restaurant_poi_from_delivery` uses the same `_upsert_poi` helper, which does INSERT-or-UPDATE on a deterministic id derived from `delivery_source_record.platform` + `source_listing_id` (falling back to `delivery_source_record.id`). There are no destructive deletes and no schema changes. Reverting restores the prior `ingest_delivery_platforms(...)` call in the workflow with no DB cleanup required.

https://claude.ai/code/session_015nqX6D2aZgm9beZHS7mGg9

---
_Generated by [Claude Code](https://claude.ai/code/session_015nqX6D2aZgm9beZHS7mGg9)_