### PR TITLE
fix(ingest): silence Overture stale-release + Overpass 406 log errors

### DIFF
--- a/app/connectors/overture_places.py
+++ b/app/connectors/overture_places.py
@@ -8,6 +8,7 @@ Filters to restaurant-related categories within the Riyadh bounding box.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Iterator
 
 logger = logging.getLogger(__name__)
@@ -15,8 +16,13 @@ logger = logging.getLogger(__name__)
 # Riyadh metro bounding box (generous)
 RIYADH_BBOX = (46.20, 24.20, 47.30, 25.10)
 
-# Overture release — bump when a new release lands
-OVERTURE_RELEASE = "2026-02-18.0"
+# Overture release. Override at runtime with the ``OVERTURE_RELEASE`` env var
+# (handy when a new release ships before this default is bumped). Bump the
+# default whenever an older release is pruned from
+# s3://overturemaps-us-west-2/release/ — Overture only keeps the most recent
+# couple of releases on S3, so a stale default produces a "No files found"
+# IO error in DuckDB.
+OVERTURE_RELEASE = os.environ.get("OVERTURE_RELEASE", "2026-05-20.0")
 OVERTURE_S3_PATH = (
     f"s3://overturemaps-us-west-2/release/{OVERTURE_RELEASE}/theme=places/type=place/*"
 )

--- a/app/ingest/restaurant_pois.py
+++ b/app/ingest/restaurant_pois.py
@@ -96,6 +96,8 @@ def ingest_osm_restaurants(db: Session) -> int:
     """Ingest restaurant POIs from OpenStreetMap via Overpass API."""
     import httpx
 
+    from app.connectors.delivery_platforms import _UA
+
     overpass_url = "https://overpass-api.de/api/interpreter"
     query = """
     [out:json][timeout:120];
@@ -109,7 +111,14 @@ def ingest_osm_restaurants(db: Session) -> int:
 
     logger.info("Querying Overpass API for Riyadh restaurants...")
     try:
-        r = httpx.post(overpass_url, data={"data": query}, timeout=180)
+        # Overpass returns 406 Not Acceptable when the default httpx
+        # ``Accept: */*`` is sent without a UA; explicit headers fix it.
+        r = httpx.post(
+            overpass_url,
+            data={"data": query},
+            headers={"User-Agent": _UA, "Accept": "application/json"},
+            timeout=180,
+        )
         r.raise_for_status()
         data = r.json()
     except Exception as exc:

--- a/tests/ingest/test_restaurant_pois.py
+++ b/tests/ingest/test_restaurant_pois.py
@@ -1,0 +1,23 @@
+"""Tests for ``ingest_osm_restaurants`` Overpass API call."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.connectors.delivery_platforms import _UA
+from app.ingest.restaurant_pois import ingest_osm_restaurants
+
+
+def test_ingest_osm_restaurants_sends_ua_and_accept_headers():
+    fake_response = MagicMock()
+    fake_response.json.return_value = {"elements": []}
+    fake_response.raise_for_status.return_value = None
+
+    with patch("httpx.post", return_value=fake_response) as mock_post:
+        ingest_osm_restaurants(db=MagicMock())
+
+    assert mock_post.call_count == 1
+    _, kwargs = mock_post.call_args
+    headers = kwargs["headers"]
+    assert headers["User-Agent"] == _UA
+    assert headers["Accept"] == "application/json"

--- a/tests/test_overture_places.py
+++ b/tests/test_overture_places.py
@@ -1,0 +1,24 @@
+"""Tests for ``app.connectors.overture_places`` module-level config."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_overture_release_default(monkeypatch):
+    monkeypatch.delenv("OVERTURE_RELEASE", raising=False)
+    module = importlib.reload(importlib.import_module("app.connectors.overture_places"))
+    assert module.OVERTURE_RELEASE == "2026-05-20.0"
+    assert module.OVERTURE_RELEASE in module.OVERTURE_S3_PATH
+
+
+def test_overture_release_env_override(monkeypatch):
+    monkeypatch.setenv("OVERTURE_RELEASE", "2099-01-01.0")
+    module = importlib.reload(importlib.import_module("app.connectors.overture_places"))
+    try:
+        assert module.OVERTURE_RELEASE == "2099-01-01.0"
+        assert "release/2099-01-01.0/theme=places/type=place/" in module.OVERTURE_S3_PATH
+    finally:
+        # Restore module to default state so other tests see a clean import.
+        monkeypatch.delenv("OVERTURE_RELEASE", raising=False)
+        importlib.reload(module)


### PR DESCRIPTION
Two one-line fixes to the residual ERROR lines in the weekly
ingest-restaurant-pois workflow:

1. Overture: ``OVERTURE_RELEASE`` is now env-overridable and the default
   bumped to ``2026-05-20.0`` — the prior ``2026-02-18.0`` default has
   been pruned from s3://overturemaps-us-west-2/release/ (S3 list
   confirms only ``2026-04-15.0`` and ``2026-05-20.0`` remain), which
   surfaced as "No files found" IO errors in DuckDB.

2. Overpass: ``ingest_osm_restaurants`` now sends ``User-Agent`` (the
   shared ``_UA`` constant from ``app.connectors.delivery_platforms``)
   and ``Accept: application/json`` on its POST. Overpass started
   returning 406 Not Acceptable for the default httpx UA.

Both changes are no-op-safe to revert.