### PR TITLE
feat(diagnostics): add brand-alias candidate generator script

### DIFF
--- a/scripts/diagnostics/generate_brand_alias_candidates.py
+++ b/scripts/diagnostics/generate_brand_alias_candidates.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Generate brand-alias candidate CSV from restaurant_poi for human review.
+
+Read-only diagnostic. Scans ``restaurant_poi.name``, applies the production
+chain-key normalizer (imported from
+``app.ingest.expansion_advisor_competitors`` so the two stay in lockstep),
+removes keys already present in ``brand_alias``, and emits a dated CSV of
+candidate rows for the reviewer (Ahmed).
+
+The script proposes a ``canonical_brand_id`` + bilingual display names for
+chains it recognizes via an internal ``KNOWN_CHAINS`` lookup, flags likely
+non-chains via ``NOT_A_CHAIN_PATTERNS``, and assigns a confidence tier
+(``high`` / ``medium`` / ``low`` / ``unknown``). The output is NEVER merged
+into ``data/brand_aliases.csv`` by this script — Ahmed reviews the CSV in
+a spreadsheet and the cleaned rows land in a follow-up PR.
+
+Usage (Codespace against production):
+
+    PGHOST=... PGPORT=... PGUSER=... PGPASSWORD=... PGDATABASE=... \\
+      python scripts/diagnostics/generate_brand_alias_candidates.py
+
+Output file: ``/tmp/brand_alias_candidates_YYYYMMDD.csv``.
+
+Safe to re-run: the output filename is date-stamped and the script issues
+no DB writes.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as _dt
+import os
+import sys
+from collections import Counter
+
+# Import a DB driver lazily so test runners that don't have psycopg
+# installed can still import this module to exercise the classifier and
+# CSV writer.
+_psycopg = None
+_DRIVER = None
+try:
+    import psycopg as _psycopg  # psycopg3
+
+    _DRIVER = "psycopg"
+except ImportError:  # pragma: no cover — older envs
+    try:
+        import psycopg2 as _psycopg  # type: ignore[no-redef]
+
+        _DRIVER = "psycopg2"
+    except ImportError:
+        _psycopg = None
+        _DRIVER = None
+
+# Import directly from the production module so any future change to the
+# normalizer or denylist flows through here automatically.
+from app.ingest.expansion_advisor_competitors import (  # noqa: E402
+    _CHAIN_KEY_DENYLIST,
+    _CHAIN_NAME_NORM_SQL,
+)
+
+# ---------------------------------------------------------------------------
+# Internal classification tables
+# ---------------------------------------------------------------------------
+# KNOWN_CHAINS: ordered list of (substring_pattern, (id, en, ar)) tuples.
+# Substring match against the NORMALIZED chain_key. Longest patterns first
+# so e.g. "costa coffee" beats "costa", "pizza hut" beats "pizza".
+#
+# Bias check: every entry below is either a global brand with confirmed
+# Saudi presence, or a well-known KSA / Gulf-region chain. Brands whose
+# Saudi operations the author is not 100% sure of are intentionally left
+# OUT of KNOWN_CHAINS so they fall through to the medium/unknown bucket.
+
+KNOWN_CHAINS: list[tuple[str, tuple[str, str, str]]] = [
+    # --- Coffee chains (global) ---
+    ("costa coffee", ("costa_coffee", "Costa Coffee", "كوستا كوفي")),
+    ("krispy kreme", ("krispy_kreme", "Krispy Kreme", "كرسبي كريم")),
+    ("tim hortons", ("tim_hortons", "Tim Hortons", "تيم هورتنز")),
+    ("dunkin", ("dunkin", "Dunkin'", "دانكن")),
+    ("starbucks", ("starbucks", "Starbucks", "ستاربكس")),
+    ("costa", ("costa_coffee", "Costa Coffee", "كوستا كوفي")),
+    # --- Coffee chains (Saudi / Gulf) ---
+    ("dr cafe", ("dr_cafe", "Dr. CAFE", "دكتور كيف")),
+    ("half million", ("half_million", "Half Million", "هاف ميلين")),
+    ("coffee address", ("coffee_address", "Coffee Address", "عنوان القهوة")),
+    ("barn s", ("barns", "Barn's", "بارنز")),
+    ("barns", ("barns", "Barn's", "بارنز")),
+    # --- QSR burgers ---
+    ("burger king", ("burger_king", "Burger King", "برجر كنج")),
+    ("mcdonald s", ("mcdonalds", "McDonald's", "ماكدونالدز")),
+    ("mcdonald", ("mcdonalds", "McDonald's", "ماكدونالدز")),
+    ("hardee s", ("hardees", "Hardee's", "هارديز")),
+    ("hardees", ("hardees", "Hardee's", "هارديز")),
+    ("hardee", ("hardees", "Hardee's", "هارديز")),
+    ("five guys", ("five_guys", "Five Guys", "فايف غايز")),
+    ("shake shack", ("shake_shack", "Shake Shack", "شيك شاك")),
+    # --- QSR chicken ---
+    ("texas chicken", ("texas_chicken", "Texas Chicken", "تكساس تشكن")),
+    ("popeyes", ("popeyes", "Popeyes", "بوبايز")),
+    ("al baik", ("albaik", "Albaik", "البيك")),
+    ("albaik", ("albaik", "Albaik", "البيك")),
+    ("herfy", ("herfy", "Herfy", "هرفي")),
+    ("kudu", ("kudu", "Kudu", "كودو")),
+    ("kfc", ("kfc", "KFC", "كنتاكي")),
+    # --- Pizza ---
+    ("pizza hut", ("pizza_hut", "Pizza Hut", "بيتزا هت")),
+    ("papa john", ("papa_johns", "Papa John's", "بابا جونز")),
+    ("dominos", ("dominos", "Domino's", "دومينوز")),
+    ("domino s", ("dominos", "Domino's", "دومينوز")),
+    ("maestro pizza", ("maestro_pizza", "Maestro Pizza", "مايسترو بيتزا")),
+    ("little caesars", ("little_caesars", "Little Caesars", "ليتل سيزرز")),
+    # --- Subs / sandwiches ---
+    ("subway", ("subway", "Subway", "صب واي")),
+    ("shawarmer", ("shawarmer", "Shawarmer", "شاورمر")),
+    ("kababji", ("kababji", "Kababji", "كبابجي")),
+    # --- Desserts / ice cream ---
+    ("baskin", ("baskin_robbins", "Baskin-Robbins", "باسكن روبنز")),
+    ("dairy queen", ("dairy_queen", "Dairy Queen", "ديري كوين")),
+    ("marble slab", ("marble_slab", "Marble Slab", "ماربل سلاب")),
+    ("cold stone", ("cold_stone", "Cold Stone Creamery", "كولد ستون")),
+    ("cinnabon", ("cinnabon", "Cinnabon", "سينابون")),
+    # --- Casual dining ---
+    ("texas roadhouse", ("texas_roadhouse", "Texas Roadhouse", "تكساس رود هاوس")),
+    (
+        "the cheesecake factory",
+        ("cheesecake_factory", "The Cheesecake Factory", "ذا تشيز كيك فاكتوري"),
+    ),
+    (
+        "cheesecake factory",
+        ("cheesecake_factory", "The Cheesecake Factory", "ذا تشيز كيك فاكتوري"),
+    ),
+    ("applebee", ("applebees", "Applebee's", "ابلبيز")),
+    ("chili s", ("chilis", "Chili's", "تشيليز")),
+    ("chilis", ("chilis", "Chili's", "تشيليز")),
+    ("tgi friday", ("tgi_fridays", "TGI Fridays", "تي جي اي فرايديز")),
+    ("ihop", ("ihop", "IHOP", "اي هوب")),
+    ("p f chang", ("pf_changs", "P.F. Chang's", "بي اف تشانغز")),
+    # --- Saudi / regional ---
+    ("bateel", ("bateel", "Bateel", "بتيل")),
+    ("operation falafel", ("operation_falafel", "Operation Falafel", "عملية فلافل")),
+    ("paul", ("paul", "Paul", "بول")),  # bakery chain
+    ("magnolia", ("magnolia_bakery", "Magnolia Bakery", "ماغنوليا")),
+    (
+        "le pain quotidien",
+        ("le_pain_quotidien", "Le Pain Quotidien", "لو بان كوتيديان"),
+    ),
+    ("nando", ("nandos", "Nando's", "ناندوز")),
+    ("the meat co", ("the_meat_co", "The Meat Co", "ذا ميت كو")),
+    ("shrimp anatomy", ("shrimp_anatomy", "Shrimp Anatomy", "شريمب أناتومي")),
+    # --- Arabic-keyed entries (Arabic-only POI names land here) ---
+    ("ستاربكس", ("starbucks", "Starbucks", "ستاربكس")),
+    ("ستاربوكس", ("starbucks", "Starbucks", "ستاربكس")),
+    ("ماكدونالدز", ("mcdonalds", "McDonald's", "ماكدونالدز")),
+    ("ماكدونالد", ("mcdonalds", "McDonald's", "ماكدونالدز")),
+    ("برجر كنج", ("burger_king", "Burger King", "برجر كنج")),
+    ("بيرجر كنج", ("burger_king", "Burger King", "برجر كنج")),
+    ("كنتاكي", ("kfc", "KFC", "كنتاكي")),
+    ("بيتزا هت", ("pizza_hut", "Pizza Hut", "بيتزا هت")),
+    ("دانكن", ("dunkin", "Dunkin'", "دانكن")),
+    ("كوستا", ("costa_coffee", "Costa Coffee", "كوستا كوفي")),
+    ("البيك", ("albaik", "Albaik", "البيك")),
+    ("هرفي", ("herfy", "Herfy", "هرفي")),
+    ("كودو", ("kudu", "Kudu", "كودو")),
+    ("هارديز", ("hardees", "Hardee's", "هارديز")),
+    ("شاورمر", ("shawarmer", "Shawarmer", "شاورمر")),
+    ("سب واي", ("subway", "Subway", "صب واي")),
+    ("صب واي", ("subway", "Subway", "صب واي")),
+    ("بوبايز", ("popeyes", "Popeyes", "بوبايز")),
+    ("دومينوز", ("dominos", "Domino's", "دومينوز")),
+    ("بابا جونز", ("papa_johns", "Papa John's", "بابا جونز")),
+    ("باسكن", ("baskin_robbins", "Baskin-Robbins", "باسكن روبنز")),
+    ("سينابون", ("cinnabon", "Cinnabon", "سينابون")),
+    ("كرسبي كريم", ("krispy_kreme", "Krispy Kreme", "كرسبي كريم")),
+    ("تيم هورتنز", ("tim_hortons", "Tim Hortons", "تيم هورتنز")),
+    ("تكساس تشكن", ("texas_chicken", "Texas Chicken", "تكساس تشكن")),
+    ("مايسترو بيتزا", ("maestro_pizza", "Maestro Pizza", "مايسترو بيتزا")),
+    ("بارنز", ("barns", "Barn's", "بارنز")),
+    ("هاف ميلين", ("half_million", "Half Million", "هاف ميلين")),
+    ("نصف مليون", ("half_million", "Half Million", "هاف ميلين")),
+    ("بتيل", ("bateel", "Bateel", "بتيل")),
+    ("ناندوز", ("nandos", "Nando's", "ناندوز")),
+    ("ديري كوين", ("dairy_queen", "Dairy Queen", "ديري كوين")),
+    ("كبابجي", ("kababji", "Kababji", "كبابجي")),
+    ("عنوان القهوة", ("coffee_address", "Coffee Address", "عنوان القهوة")),
+    ("دكتور كيف", ("dr_cafe", "Dr. CAFE", "دكتور كيف")),
+]
+
+
+# Substrings of the normalized chain_key that strongly suggest a non-chain
+# (generic descriptor, cuisine type, city/district name, generic noun).
+NOT_A_CHAIN_PATTERNS: tuple[str, ...] = (
+    # Generic English descriptors
+    "kitchen",
+    "bakery",
+    "restaurants",
+    "restaurant",
+    "buffet",
+    "diner",
+    "lounge",
+    "snack",
+    "catering",
+    # Generic Arabic descriptors
+    "مطعم",  # restaurant
+    "مطبخ",  # kitchen
+    "مخبز",  # bakery
+    "بقالة",  # grocery
+    "بقاله",  # grocery (alt spelling)
+    "كافيه",  # cafe
+    "كوفي شوب",  # coffee shop
+    "وجبات",  # meals
+    "حلويات",  # sweets
+    "مأكولات",  # foods
+    "ماكولات",  # foods (variant)
+    "اكلات",  # foods
+    # Cuisine descriptors that frequently appear as standalone POI names
+    "lebanese",
+    "indian",
+    "chinese",
+    "italian",
+    "turkish",
+    "yemeni",
+    "lubnani",
+)
+
+
+def classify(
+    chain_key: str,
+    sample_names: list[str],
+    poi_count: int,
+) -> tuple[str, str, str, str, str]:
+    """Return (canonical_brand_id, en, ar, confidence, notes).
+
+    The first three may be empty when the classifier can't propose them.
+    """
+    # 1. Try the explicit KNOWN_CHAINS lookup (longest substrings first).
+    for pattern, (cid, en, ar) in KNOWN_CHAINS:
+        if pattern in chain_key:
+            return cid, en, ar, "high", ""
+
+    # 2. Non-chain patterns.
+    for pattern in NOT_A_CHAIN_PATTERNS:
+        if pattern in chain_key:
+            return "", "", "", "low", f"matches non-chain pattern '{pattern}'"
+
+    # 3. High count → likely a chain, but unknown — flag medium for naming.
+    if poi_count >= 5:
+        return "", "", "", "medium", "high count, manual classification needed"
+
+    # 4. Otherwise unknown — Ahmed decides.
+    return "", "", "", "unknown", ""
+
+
+# ---------------------------------------------------------------------------
+# Database query
+# ---------------------------------------------------------------------------
+
+# Produce the SQL fragment that normalizes restaurant_poi.name. This is the
+# same fragment the production matcher uses, so the alias_keys we generate
+# match what runtime will look up.
+_NORM_EXPR = _CHAIN_NAME_NORM_SQL.format(col="name")
+_DENYLIST_SQL = ", ".join(f"'{w}'" for w in _CHAIN_KEY_DENYLIST)
+
+CANDIDATE_QUERY = f"""
+WITH norm AS (
+    SELECT
+        {_NORM_EXPR} AS chain_key,
+        name AS sample_name
+    FROM restaurant_poi
+    WHERE name IS NOT NULL AND name != ''
+),
+agg AS (
+    SELECT
+        chain_key,
+        COUNT(*) AS poi_count,
+        (array_agg(DISTINCT sample_name))[1:5] AS samples
+    FROM norm
+    WHERE chain_key != ''
+      AND chain_key NOT IN ({_DENYLIST_SQL})
+      AND chain_key !~ '^[0-9]+$'
+    GROUP BY chain_key
+)
+SELECT a.chain_key, a.poi_count, a.samples
+FROM agg a
+LEFT JOIN brand_alias ba ON ba.alias_key = a.chain_key
+WHERE ba.alias_key IS NULL
+  AND a.poi_count >= 2
+ORDER BY a.poi_count DESC
+LIMIT 600;
+"""
+
+
+# Current canonicalization rate, used only to print the projection table.
+# Sourced from production diagnostics (Apr/May 2026).
+CURRENT_CANONICALIZATION_RATE = 0.163
+CURRENT_CANONICALIZED_POIS = 7476
+CURRENT_TOTAL_POIS = 45889
+
+
+def _connect():
+    if _psycopg is None:
+        raise RuntimeError(
+            "neither psycopg nor psycopg2 is installed in this env. "
+            "Install one (or run from a venv that has them)."
+        )
+    kwargs = {
+        "host": os.environ.get("PGHOST"),
+        "port": os.environ.get("PGPORT"),
+        "user": os.environ.get("PGUSER"),
+        "password": os.environ.get("PGPASSWORD"),
+        "dbname": os.environ.get("PGDATABASE"),
+        "sslmode": os.environ.get("PGSSLMODE"),
+    }
+    kwargs = {k: v for k, v in kwargs.items() if v}
+    return _psycopg.connect(**kwargs)
+
+
+CSV_HEADER = [
+    "chain_key",
+    "total_pois",
+    "sample_raw_names",
+    "proposed_canonical_brand_id",
+    "proposed_display_name_en",
+    "proposed_display_name_ar",
+    "confidence",
+    "notes",
+]
+
+
+def _format_samples(samples) -> str:
+    if not samples:
+        return ""
+    # samples comes back as a Python list from both psycopg and psycopg2.
+    return " || ".join(str(s) for s in samples if s)
+
+
+def run(out_path: str) -> dict:
+    """Connect, query, classify, write CSV. Returns summary dict."""
+    conn = _connect()
+    try:
+        cur = conn.cursor()
+        cur.execute(CANDIDATE_QUERY)
+        rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    return write_candidates(rows, out_path)
+
+
+def write_candidates(rows: list, out_path: str) -> dict:
+    """Classify each row and write to CSV. Returns summary dict.
+
+    Split out so tests can exercise this without a live DB.
+    """
+    tier_counts: Counter[str] = Counter()
+    tier_pois: Counter[str] = Counter()
+
+    with open(out_path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(CSV_HEADER)
+        for row in rows:
+            chain_key, poi_count, samples = row[0], row[1], row[2]
+            cid, en, ar, conf, notes = classify(
+                chain_key,
+                samples or [],
+                poi_count,
+            )
+            writer.writerow(
+                [
+                    chain_key,
+                    poi_count,
+                    _format_samples(samples),
+                    cid,
+                    en,
+                    ar,
+                    conf,
+                    notes,
+                ]
+            )
+            tier_counts[conf] += 1
+            tier_pois[conf] += poi_count
+
+    return {
+        "rows": len(rows),
+        "tier_counts": dict(tier_counts),
+        "tier_pois": dict(tier_pois),
+        "out_path": out_path,
+    }
+
+
+def _print_summary(summary: dict) -> None:
+    rows = summary["rows"]
+    counts = summary["tier_counts"]
+    pois = summary["tier_pois"]
+    total_potential = sum(pois.values())
+
+    print(f"Generated {rows} candidate aliases:")
+    for tier in ("high", "medium", "low", "unknown"):
+        c = counts.get(tier, 0)
+        p = pois.get(tier, 0)
+        print(f"  {tier + ' confidence:':<18} {c:>4}  →  covers {p:>7,} POIs")
+
+    print(
+        f"Total potential POI coverage gain: {total_potential:,} POIs "
+        f"({(total_potential / CURRENT_TOTAL_POIS) * 100:+.1f}%)"
+    )
+    print(
+        f"Current canonicalization rate:    "
+        f"{CURRENT_CANONICALIZATION_RATE * 100:.1f}%"
+    )
+    high_gain = pois.get("high", 0)
+    med_gain = pois.get("medium", 0)
+    proj_high = (CURRENT_CANONICALIZED_POIS + high_gain) / CURRENT_TOTAL_POIS
+    proj_high_med = (
+        CURRENT_CANONICALIZED_POIS + high_gain + med_gain
+    ) / CURRENT_TOTAL_POIS
+    print(f"Projected if all `high` adopted:  {proj_high * 100:.1f}%")
+    print(f"Projected if `high`+`medium`:     {proj_high_med * 100:.1f}%")
+    print(f"Output written to {summary['out_path']}")
+
+
+def main() -> int:
+    out_path = (
+        f"/tmp/brand_alias_candidates_" f"{_dt.date.today().strftime('%Y%m%d')}.csv"
+    )
+    try:
+        summary = run(out_path)
+    except Exception as exc:
+        print(f"ERROR: candidate generation failed: {exc}", file=sys.stderr)
+        return 2
+    _print_summary(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/diagnostics/test_generate_brand_alias_candidates.py
+++ b/tests/diagnostics/test_generate_brand_alias_candidates.py
@@ -1,0 +1,251 @@
+"""Tests for scripts/diagnostics/generate_brand_alias_candidates.py.
+
+Coverage:
+
+1. Classifier regression — representative chain_keys map to the expected
+   (canonical_brand_id, en, ar, confidence) tuples.
+2. Confidence-tier coverage — synthetic rows land in the expected tier.
+3. Normalizer agreement — the Python `_normalize_chain_name` agrees with
+   the SQL fragment `_CHAIN_NAME_NORM_SQL` used by the candidate
+   generator, so the alias_keys emitted match what the production matcher
+   computes at runtime.
+
+These tests do NOT touch the production DB. The few cases that need to
+exercise the write path mock the cursor with hand-rolled tuples.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.ingest.expansion_advisor_competitors import (
+    _CHAIN_NAME_NORM_SQL,
+    _normalize_chain_name,
+)
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "diagnostics"
+    / "generate_brand_alias_candidates.py"
+)
+
+
+def _load_module():
+    """Import the script as a module so we can call its helpers."""
+    spec = importlib.util.spec_from_file_location(
+        "generate_brand_alias_candidates",
+        SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["generate_brand_alias_candidates"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def gen():
+    return _load_module()
+
+
+# ---------------------------------------------------------------------------
+# 1. Classifier regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "chain_key,expected_id,expected_en,expected_ar,expected_conf",
+    [
+        ("starbucks", "starbucks", "Starbucks", "ستاربكس", "high"),
+        ("mcdonald s", "mcdonalds", "McDonald's", "ماكدونالدز", "high"),
+        ("kfc", "kfc", "KFC", "كنتاكي", "high"),
+        ("albaik", "albaik", "Albaik", "البيك", "high"),
+        ("al baik", "albaik", "Albaik", "البيك", "high"),
+        ("herfy", "herfy", "Herfy", "هرفي", "high"),
+        ("costa coffee", "costa_coffee", "Costa Coffee", "كوستا كوفي", "high"),
+        ("ستاربكس", "starbucks", "Starbucks", "ستاربكس", "high"),
+        ("البيك", "albaik", "Albaik", "البيك", "high"),
+        ("dr cafe", "dr_cafe", "Dr. CAFE", "دكتور كيف", "high"),
+    ],
+)
+def test_classify_known_chains(
+    gen,
+    chain_key,
+    expected_id,
+    expected_en,
+    expected_ar,
+    expected_conf,
+):
+    cid, en, ar, conf, _notes = gen.classify(chain_key, [], poi_count=10)
+    assert cid == expected_id
+    assert en == expected_en
+    assert ar == expected_ar
+    assert conf == expected_conf
+
+
+def test_classify_non_chain_pattern(gen):
+    cid, en, ar, conf, notes = gen.classify(
+        "matjar al baqala بقالة المتجر",
+        [],
+        poi_count=10,
+    )
+    assert cid == "" and en == "" and ar == ""
+    assert conf == "low"
+    assert "non-chain pattern" in notes
+
+
+def test_classify_unknown_low_count(gen):
+    # No KNOWN_CHAINS match, no NOT_A_CHAIN match, count < 5 → unknown.
+    cid, en, ar, conf, notes = gen.classify(
+        "some random brand",
+        [],
+        poi_count=2,
+    )
+    assert (cid, en, ar) == ("", "", "")
+    assert conf == "unknown"
+    assert notes == ""
+
+
+def test_classify_unknown_high_count_is_medium(gen):
+    # No KNOWN_CHAINS, no NOT_A_CHAIN, but count >= 5 → medium.
+    cid, en, ar, conf, notes = gen.classify(
+        "some random brand",
+        [],
+        poi_count=12,
+    )
+    assert (cid, en, ar) == ("", "", "")
+    assert conf == "medium"
+    assert "manual" in notes
+
+
+# ---------------------------------------------------------------------------
+# 2. Confidence-tier coverage on synthetic rows
+# ---------------------------------------------------------------------------
+
+
+def test_write_candidates_tier_coverage(gen, tmp_path):
+    rows = [
+        # high (KNOWN_CHAINS match)
+        ("starbucks olaya", 30, ["Starbucks Olaya"]),
+        ("ستاربكس النخيل", 25, ["ستاربكس النخيل"]),
+        ("kfc", 20, ["KFC"]),
+        # low (non-chain pattern)
+        ("مطعم الشرق", 8, ["مطعم الشرق"]),
+        ("the corner kitchen", 6, ["The Corner Kitchen"]),
+        # medium (no match, count >= 5)
+        ("foo bar grill house", 7, ["Foo Bar Grill House"]),
+        ("بيت الخير", 9, ["بيت الخير"]),
+        # unknown (no match, count < 5)
+        ("xyz random", 2, ["xyz random"]),
+        ("abc cafeteria nameless", 3, ["abc cafeteria nameless"]),
+        ("zzzz one off", 2, ["zzzz one off"]),
+    ]
+    out = tmp_path / "candidates.csv"
+    summary = gen.write_candidates(rows, str(out))
+
+    assert summary["rows"] == 10
+    counts = summary["tier_counts"]
+    assert counts.get("high", 0) == 3
+    assert counts.get("low", 0) == 2
+    assert counts.get("medium", 0) == 2
+    assert counts.get("unknown", 0) == 3
+
+    # CSV is well-formed and has the expected header.
+    with out.open(encoding="utf-8") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        body = list(reader)
+    assert header == gen.CSV_HEADER
+    assert len(body) == 10
+    # First row (highest count) should be classified high.
+    high_rows = [r for r in body if r[6] == "high"]
+    assert len(high_rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# 3. Normalizer agreement — Python mirror matches SQL fragment
+# ---------------------------------------------------------------------------
+
+# Pure-Python re-implementation of the SQL fragment, evaluated symbolically.
+# We can't actually execute Postgres regex from Python, but we can verify
+# that the Python normalizer's outputs match a "trusted" rebuild of the
+# same logic from the same character maps. If a future contributor edits
+# `_CHAIN_NAME_NORM_SQL` without touching `_normalize_chain_name` (or vice
+# versa), the SQL fragment's character maps will drift from the Python
+# function and this test fails.
+
+
+def _expected_python_norm(name: str) -> str:
+    """Independent re-derivation of `_normalize_chain_name` semantics."""
+    import re as _re
+
+    if not name:
+        return ""
+    s = name.lower()
+    s = s.translate(
+        {
+            ord("أ"): "ا",
+            ord("إ"): "ا",
+            ord("آ"): "ا",
+            ord("ى"): "ي",
+            ord("ـ"): None,
+        }
+    )
+    s = _re.sub(r"[^a-z0-9\s؀-ۿ]", " ", s)
+    s = _re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "Starbucks - Olaya",
+        "ستاربكس النخيل",
+        "Burger King - برجر كنج",
+        "Al-Baik",
+        "McDonald's",
+        "Dr. CAFE",
+        "أبو يوسف",  # alef-hamza-above → alef
+        "إفطار",  # alef-hamza-below → alef
+        "آيس كريم",  # alef-madda → alef
+        "ليلى",  # alef-maksura → ya
+        "كافيـه",  # tatweel embedded
+    ],
+)
+def test_normalizer_python_matches_expected(raw):
+    assert _normalize_chain_name(raw) == _expected_python_norm(raw)
+
+
+def test_sql_fragment_uses_same_codepoints_as_python():
+    """The SQL fragment must reference the same Arabic codepoints the
+    Python normalizer translates. This is the structural lockstep check
+    described in the module docstring.
+    """
+    # SQL uses unicode escapes; verify the four Alef-variants and tatweel
+    # are present in the fragment text.
+    for code in ("\\u0623", "\\u0625", "\\u0622", "\\u0649", "\\u0640"):
+        assert code in _CHAIN_NAME_NORM_SQL, (
+            f"SQL normalizer missing codepoint {code} — Python and SQL "
+            f"normalizers have drifted apart."
+        )
+    # SQL's mapped output codepoints.
+    for code in ("\\u0627", "\\u064A"):
+        assert code in _CHAIN_NAME_NORM_SQL
+    # Arabic block in the strip regex.
+    assert "\\u0600-\\u06FF" in _CHAIN_NAME_NORM_SQL
+
+
+def test_candidate_query_uses_production_normalizer(gen):
+    """The query string in the generator script must embed the production
+    SQL normalizer expression — otherwise the generated alias_keys would
+    not match what the runtime matcher computes."""
+    # The normalizer fragment, formatted for column `name`, must appear
+    # verbatim in the candidate query.
+    expected = _CHAIN_NAME_NORM_SQL.format(col="name")
+    assert expected in gen.CANDIDATE_QUERY


### PR DESCRIPTION
Adds scripts/diagnostics/generate_brand_alias_candidates.py to scan
restaurant_poi.name, apply the production chain-key normalizer
(imported from app.ingest.expansion_advisor_competitors so the two
stay in lockstep), and emit a dated CSV of candidate brand aliases
for human review.

The script proposes (canonical_brand_id, display_name_en,
display_name_ar) for chains it recognizes via an internal
KNOWN_CHAINS lookup, flags likely non-chains via
NOT_A_CHAIN_PATTERNS, and assigns a confidence tier
(high / medium / low / unknown). Output is written to
/tmp/brand_alias_candidates_YYYYMMDD.csv. data/brand_aliases.csv is
NOT modified by this PR — Ahmed reviews the generated CSV and the
cleaned rows land in a follow-up PR.

Tests cover classifier regression on representative chains, tier
coverage on synthetic rows, and a normalizer-agreement guard that
fails if _CHAIN_NAME_NORM_SQL and _normalize_chain_name drift apart.