### PR TITLE
Promote business_status to typed column, filter closed venues from competitor counts

### DIFF
--- a/alembic/versions/20260522_restaurant_poi_business_status.py
+++ b/alembic/versions/20260522_restaurant_poi_business_status.py
@@ -1,0 +1,69 @@
+"""add typed business_status column to restaurant_poi
+
+Promotes ``business_status`` (OPERATIONAL / CLOSED_TEMPORARILY /
+CLOSED_PERMANENTLY) from ``restaurant_poi.raw`` JSONB to a typed,
+indexed column so competitor-count queries can exclude closed venues.
+
+Backfills the new column from ``raw->>'business_status'`` for existing
+grid-search rows. Enrich-path rows store the field under
+``raw.google.business_status`` instead and are intentionally out of
+scope here — they get populated going forward via the enrich path.
+
+The number of rows backfilled is logged for validation; expect roughly
+18,000-21,000 (most grid-search rows).
+
+Revision ID: 20260522_poi_business_status
+Revises: 20260519_decision_memo_lang
+Create Date: 2026-05-22 00:00:00.000000
+
+NOTE: the revision id is kept <= 32 chars to fit alembic_version.version_num.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260522_poi_business_status"
+down_revision = "20260519_decision_memo_lang"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "restaurant_poi",
+        sa.Column("business_status", sa.String(32), nullable=True),
+    )
+    op.create_index(
+        "ix_restaurant_poi_business_status",
+        "restaurant_poi",
+        ["business_status"],
+    )
+
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            """
+            UPDATE restaurant_poi
+            SET business_status = raw->>'business_status'
+            WHERE raw->>'business_status' IS NOT NULL
+              AND business_status IS NULL
+            """
+        )
+    )
+    logger.info(
+        "20260522_poi_business_status: backfilled business_status on %s row(s)",
+        result.rowcount,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_restaurant_poi_business_status", table_name="restaurant_poi"
+    )
+    op.drop_column("restaurant_poi", "business_status")

--- a/app/connectors/google_places.py
+++ b/app/connectors/google_places.py
@@ -157,9 +157,11 @@ def get_place_details(place_id: str) -> dict:
         return _details_cache[place_id]
 
     key = _get_api_key()
+    # business_status is a Basic-tier field — including it does not bump
+    # the Place Details SKU pricing.
     fields = (
         "place_id,name,rating,user_ratings_total,price_level,"
-        "geometry,types,formatted_address"
+        "geometry,types,formatted_address,business_status"
     )
     params = {
         "place_id": place_id,
@@ -184,6 +186,7 @@ def get_place_details(place_id: str) -> dict:
         "lng": r.get("geometry", {}).get("location", {}).get("lng"),
         "types": r.get("types", []),
         "formatted_address": r.get("formatted_address", ""),
+        "business_status": r.get("business_status"),
     }
     _details_cache[place_id] = details
     return details

--- a/app/connectors/google_places_async.py
+++ b/app/connectors/google_places_async.py
@@ -414,9 +414,11 @@ class AsyncGooglePlacesClient:
             return _details_cache[place_id]
 
         key = _get_api_key()
+        # business_status is a Basic-tier field — including it does not
+        # bump the Place Details SKU pricing.
         fields = (
             "place_id,name,rating,user_ratings_total,price_level,"
-            "geometry,types,formatted_address"
+            "geometry,types,formatted_address,business_status"
         )
         params = {
             "place_id": place_id,
@@ -441,6 +443,7 @@ class AsyncGooglePlacesClient:
             "lng": r.get("geometry", {}).get("location", {}).get("lng"),
             "types": r.get("types", []),
             "formatted_address": r.get("formatted_address", ""),
+            "business_status": r.get("business_status"),
         }
         _details_cache[place_id] = details
         return details

--- a/app/ingest/expansion_advisor_competitors.py
+++ b/app/ingest/expansion_advisor_competitors.py
@@ -207,6 +207,9 @@ def _build_competitor_quality(db, replace: bool) -> dict:
                 WHERE name IS NOT NULL AND name != ''
                   AND {_name_norm} ~ '[a-z0-9\\u0600-\\u06FF]'
                   AND {_name_norm} NOT IN ({_denylist_sql})
+                  -- Closed venues do not count toward chain size.
+                  AND (business_status IS NULL
+                       OR business_status = 'OPERATIONAL')
             ) raw
             LEFT JOIN brand_alias ba ON ba.alias_key = raw.chain_key
             GROUP BY COALESCE(ba.canonical_brand_id, raw.chain_key)

--- a/app/ingest/google_reviews_enrich.py
+++ b/app/ingest/google_reviews_enrich.py
@@ -237,6 +237,12 @@ async def _enrich_one(
     poi.google_place_id = place_id
     poi.google_fetched_at = now
     poi.google_confidence = confidence
+    # Promote venue lifecycle to the typed column so closed venues are
+    # excluded from competitor counts. Only overwrite when Google
+    # returned a value — never clear an existing status to NULL.
+    business_status = details.get("business_status") or best.get("business_status")
+    if business_status:
+        poi.business_status = business_status
 
     existing_raw = poi.raw or {}
     existing_raw["google"] = {

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -324,6 +324,10 @@ class RestaurantPOI(Base):
     google_place_id = Column(Text)
     google_fetched_at = Column(DateTime(timezone=True))
     google_confidence = Column(Numeric)
+    # Google Places venue lifecycle: OPERATIONAL / CLOSED_TEMPORARILY /
+    # CLOSED_PERMANENTLY. NULL for non-Google sources or rows ingested
+    # before this column existed.
+    business_status = Column(String(32))
 
     __table_args__ = (
         Index("ix_restaurant_poi_category", "category"),
@@ -331,6 +335,7 @@ class RestaurantPOI(Base):
         Index("ix_restaurant_poi_district", "district"),
         Index("ix_restaurant_poi_chain_name", "chain_name"),
         Index("ix_restaurant_poi_google_place_id", "google_place_id"),
+        Index("ix_restaurant_poi_business_status", "business_status"),
     )
 
 

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -6409,7 +6409,13 @@ def _bulk_enrich_competitors(
                             LEFT JOIN expansion_competitor_quality ecq
                                    ON ecq.restaurant_poi_id = rp.id
                                   AND ecq.city = 'riyadh'
-                            WHERE ST_DWithin(
+                            -- Exclude closed venues: a CLOSED_PERMANENTLY /
+                            -- CLOSED_TEMPORARILY restaurant is not live
+                            -- competition. NULL is kept for non-Google
+                            -- sources and pre-backfill rows.
+                            WHERE (rp.business_status IS NULL
+                                   OR rp.business_status = 'OPERATIONAL')
+                              AND ST_DWithin(
                                   rp.geom::geography,
                                   ST_SetSRID(ST_MakePoint(i.lon, i.lat), 4326)::geography,
                                   :radius_m

--- a/scripts/google_places_grid_search.py
+++ b/scripts/google_places_grid_search.py
@@ -350,6 +350,7 @@ def _upsert_poi(db, place: dict) -> tuple[bool, bool]:
         google_place_id=place_id,
         google_fetched_at=datetime.now(timezone.utc),
         google_confidence=0.95,  # direct Nearby Search = high confidence
+        business_status=business_status,
         district=vicinity[:128] if vicinity else None,
         raw={
             "types": types,

--- a/tests/test_business_status_competitor_filter.py
+++ b/tests/test_business_status_competitor_filter.py
@@ -1,0 +1,295 @@
+"""Tests for the typed ``business_status`` column and the closed-venue
+filter applied to competitor counts.
+
+Covers:
+  * the 20260522 migration upgrade/downgrade roundtrip + backfill
+  * the RestaurantPOI model carrying the new column
+  * the Expansion Advisor competitor-count query excluding closed venues
+  * the ECQ chain_counts CTE excluding closed venues
+  * the Place Details ``fields`` parameter requesting business_status
+
+PostGIS is not available in the test environment, so the spatial query
+shape is exercised via a simplified SQLite query that preserves the
+exact ``business_status`` filter clause. The production query strings
+are additionally asserted against directly to guard regressions.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+from unittest.mock import patch
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import sessionmaker
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+MIGRATION_PATH = (
+    REPO_ROOT
+    / "alembic"
+    / "versions"
+    / "20260522_restaurant_poi_business_status.py"
+)
+
+
+def _has_closed_filter(src: str, prefix: str = "") -> bool:
+    """True if src contains the OPERATIONAL-or-NULL filter, ignoring the
+    whitespace the SQL is wrapped across. ``prefix`` is the optional
+    table alias (e.g. ``rp.``)."""
+    collapsed = " ".join(src.split())
+    needle = (
+        f"WHERE ({prefix}business_status IS NULL "
+        f"OR {prefix}business_status = 'OPERATIONAL')"
+    )
+    alt = (
+        f"AND ({prefix}business_status IS NULL "
+        f"OR {prefix}business_status = 'OPERATIONAL')"
+    )
+    return needle in collapsed or alt in collapsed
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("mig_20260522", MIGRATION_PATH)
+    mig = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mig)
+    return mig
+
+
+def _seed_poi_table(conn):
+    conn.execute(
+        text(
+            "CREATE TABLE restaurant_poi ("
+            "id TEXT PRIMARY KEY, name TEXT, raw TEXT)"
+        )
+    )
+    conn.execute(
+        text(
+            "INSERT INTO restaurant_poi (id, name, raw) VALUES "
+            "('g:1', 'Open Diner', '{\"business_status\": \"OPERATIONAL\"}'),"
+            "('g:2', 'Gone Grill', '{\"business_status\": \"CLOSED_PERMANENTLY\"}'),"
+            "('g:3', 'Paused Pizza', '{\"business_status\": \"CLOSED_TEMPORARILY\"}'),"
+            "('osm:4', 'No Status Cafe', '{}')"
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Migration upgrade/downgrade roundtrip + backfill
+# ---------------------------------------------------------------------------
+
+
+def test_migration_upgrade_downgrade_roundtrip():
+    """upgrade() adds the column + index and backfills; downgrade() drops
+    the column cleanly, leaving the table at its original shape."""
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        _seed_poi_table(conn)
+
+    conn = engine.connect()
+    op = Operations(MigrationContext.configure(conn))
+    mig = _load_migration()
+    mig.op = op  # bind the alembic op proxy used inside the migration
+
+    mig.upgrade()
+    cols = {c["name"] for c in inspect(conn).get_columns("restaurant_poi")}
+    assert "business_status" in cols
+    indexes = {i["name"] for i in inspect(conn).get_indexes("restaurant_poi")}
+    assert "ix_restaurant_poi_business_status" in indexes
+
+    mig.downgrade()
+    cols_after = {c["name"] for c in inspect(conn).get_columns("restaurant_poi")}
+    assert "business_status" not in cols_after
+    indexes_after = {i["name"] for i in inspect(conn).get_indexes("restaurant_poi")}
+    assert "ix_restaurant_poi_business_status" not in indexes_after
+    conn.close()
+
+
+def test_migration_backfills_business_status_from_raw():
+    """The backfill copies raw->>'business_status' for rows that have it
+    and leaves rows without it NULL."""
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        _seed_poi_table(conn)
+
+    conn = engine.connect()
+    op = Operations(MigrationContext.configure(conn))
+    mig = _load_migration()
+    mig.op = op
+    mig.upgrade()
+
+    rows = dict(
+        conn.execute(
+            text("SELECT id, business_status FROM restaurant_poi")
+        ).all()
+    )
+    assert rows == {
+        "g:1": "OPERATIONAL",
+        "g:2": "CLOSED_PERMANENTLY",
+        "g:3": "CLOSED_TEMPORARILY",
+        "osm:4": None,
+    }
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Model carries the new column
+# ---------------------------------------------------------------------------
+
+
+def test_restaurant_poi_model_has_business_status_column():
+    from app.models.tables import RestaurantPOI
+
+    col = RestaurantPOI.__table__.columns.get("business_status")
+    assert col is not None, "RestaurantPOI is missing business_status column"
+    assert col.nullable is True
+    assert col.type.length == 32  # String(32)
+    index_cols = {
+        tuple(c.name for c in idx.columns)
+        for idx in RestaurantPOI.__table__.indexes
+    }
+    assert ("business_status",) in index_cols
+
+
+# ---------------------------------------------------------------------------
+# 3. Competitor count excludes closed venues
+# ---------------------------------------------------------------------------
+
+
+def _competitor_count_session():
+    """SQLite restaurant_poi with the typed business_status column."""
+    engine = create_engine("sqlite:///:memory:")
+    db = sessionmaker(bind=engine)()
+    db.execute(
+        text(
+            "CREATE TABLE restaurant_poi ("
+            "id TEXT PRIMARY KEY, name TEXT, category TEXT, "
+            "business_status TEXT)"
+        )
+    )
+    db.execute(
+        text(
+            "INSERT INTO restaurant_poi "
+            "(id, name, category, business_status) VALUES "
+            "('g:1', 'Open Burger', 'burger', 'OPERATIONAL'),"
+            "('g:2', 'Closed Burger', 'burger', 'CLOSED_PERMANENTLY'),"
+            "('g:3', 'Paused Burger', 'burger', 'CLOSED_TEMPORARILY'),"
+            "('osm:4', 'Legacy Burger', 'burger', NULL)"
+        )
+    )
+    db.commit()
+    return db
+
+
+def test_competitor_count_excludes_closed_venues():
+    """Mirrors the Source-1 restaurant_poi subquery filter: closed venues
+    are excluded, OPERATIONAL and NULL rows are counted."""
+    db = _competitor_count_session()
+    count = db.execute(
+        text(
+            "SELECT COUNT(*) FROM restaurant_poi "
+            "WHERE (business_status IS NULL "
+            "       OR business_status = 'OPERATIONAL')"
+        )
+    ).scalar()
+    # g:1 (OPERATIONAL) + osm:4 (NULL) counted; g:2, g:3 excluded.
+    assert count == 2
+
+
+def test_competitor_query_source_carries_closed_filter():
+    """Guard: the production competitor-count query keeps the filter."""
+    src = (REPO_ROOT / "app" / "services" / "expansion_advisor.py").read_text()
+    assert _has_closed_filter(src, prefix="rp."), (
+        "competitor-count query lost the OPERATIONAL-or-NULL filter"
+    )
+    # The unsafe single-sided form must not be used.
+    assert "business_status != 'CLOSED_PERMANENTLY'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 4. ECQ chain_counts CTE excludes closed venues
+# ---------------------------------------------------------------------------
+
+
+def test_ecq_chain_counts_excludes_closed_venues():
+    """Closed venues do not inflate chain sizes."""
+    engine = create_engine("sqlite:///:memory:")
+    db = sessionmaker(bind=engine)()
+    db.execute(
+        text("CREATE TABLE restaurant_poi (id TEXT PRIMARY KEY, "
+             "name TEXT, business_status TEXT)")
+    )
+    # Four "Burger King" branches: two open, one closed permanently,
+    # one closed temporarily. Only the two open ones count.
+    db.execute(
+        text(
+            "INSERT INTO restaurant_poi (id, name, business_status) VALUES "
+            "('g:1', 'Burger King', 'OPERATIONAL'),"
+            "('g:2', 'Burger King', 'OPERATIONAL'),"
+            "('g:3', 'Burger King', 'CLOSED_PERMANENTLY'),"
+            "('g:4', 'Burger King', 'CLOSED_TEMPORARILY')"
+        )
+    )
+    db.commit()
+    chain_size = db.execute(
+        text(
+            "SELECT COUNT(*) FROM restaurant_poi "
+            "WHERE name IS NOT NULL AND name != '' "
+            "  AND (business_status IS NULL "
+            "       OR business_status = 'OPERATIONAL')"
+        )
+    ).scalar()
+    assert chain_size == 2
+
+
+def test_ecq_chain_counts_source_carries_closed_filter():
+    """Guard: the chain_counts CTE keeps the OPERATIONAL-or-NULL filter."""
+    src = (
+        REPO_ROOT / "app" / "ingest" / "expansion_advisor_competitors.py"
+    ).read_text()
+    assert _has_closed_filter(src), (
+        "chain_counts CTE lost the OPERATIONAL-or-NULL filter"
+    )
+    assert "business_status != 'CLOSED_PERMANENTLY'" not in src
+
+
+# ---------------------------------------------------------------------------
+# 5. Place Details fields parameter requests business_status
+# ---------------------------------------------------------------------------
+
+
+def test_place_details_fields_includes_business_status_sync():
+    from app.connectors import google_places
+
+    captured = {}
+
+    def fake_request(url, params):
+        captured["url"] = url
+        captured["params"] = params
+        return {
+            "status": "OK",
+            "result": {
+                "place_id": "p1",
+                "name": "Test Venue",
+                "business_status": "CLOSED_PERMANENTLY",
+            },
+        }
+
+    google_places._details_cache.clear()
+    with patch.object(google_places, "_get_api_key", return_value="k"), patch.object(
+        google_places, "_request_with_retry", side_effect=fake_request
+    ):
+        details = google_places.get_place_details("p1")
+
+    assert "business_status" in captured["params"]["fields"]
+    assert details["business_status"] == "CLOSED_PERMANENTLY"
+    google_places._details_cache.clear()
+
+
+def test_place_details_fields_includes_business_status_async():
+    """The async connector requests the same Basic-tier field."""
+    src = (
+        REPO_ROOT / "app" / "connectors" / "google_places_async.py"
+    ).read_text()
+    # The async get_place_details fields string must request the field.
+    assert "formatted_address,business_status" in src


### PR DESCRIPTION
## What is wrong now

`business_status` from Google Places Nearby Search lives only inside
`restaurant_poi.raw` JSONB. The Expansion Advisor's competitor counts
treat **closed** restaurants (`CLOSED_PERMANENTLY` / `CLOSED_TEMPORARILY`)
as live competitors. Both `competition_whitespace` / `chain_strength`
(`app/services/expansion_advisor.py`) and the ECQ `chain_counts` CTE
(`app/ingest/expansion_advisor_competitors.py`) `COUNT(*)` over all
`restaurant_poi` rows in a buffer with no status filter. Candidate sites
near closed-venue clusters are penalized for competition that no longer
exists.

## The fix

Promote `business_status` to a typed, indexed column, backfill it from
`raw`, and apply an `OPERATIONAL`-or-`NULL` filter to the two
competitor-count consumers. This is recommendation #1 from the data
utilization audit — a free correctness win on data already paid for.

## Files read first

- **`app/models/tables.py`** — `RestaurantPOI` model (lines ~302-334).
  Existing columns confirmed: `id, name, name_ar, category, subcategory,
  source, lat, lon, rating, review_count, price_level, chain_name,
  district, raw, observed_at, google_place_id, google_fetched_at,
  google_confidence`. No `business_status` column.
- **`alembic/versions/`** — head revision confirmed as
  `20260519_decision_memo_lang` (no migration uses it as a
  `down_revision`). New migration chains from it.
- **`scripts/google_places_grid_search.py:340-361`** — grid-search insert
  writes `business_status` into `raw` at the top level
  (`raw.business_status`), confirmed.
- **`app/services/expansion_advisor.py:6405-6416`** — Source-1
  `restaurant_poi` subquery; previously filtered only by `ST_DWithin`.
- **`app/ingest/expansion_advisor_competitors.py:190-215`** — `chain_counts`
  CTE; previously filtered only by name normalization / denylist.

## Changes

### Alembic migration (`20260522_restaurant_poi_business_status.py`)
- Adds `business_status String(32)` nullable column + index
  `ix_restaurant_poi_business_status`.
- Backfills `business_status = raw->>'business_status'` for rows where the
  JSON path is set and the column is still NULL; logs the affected
  row count for validation.
- `downgrade()` drops the index then the column.
- `down_revision = "20260519_decision_memo_lang"`; passes
  `scripts/validate_alembic_chain.py`.

### Query / filter diffs

**2c — competitor-count query** (`app/services/expansion_advisor.py`)
```diff
  FROM restaurant_poi rp
  LEFT JOIN expansion_competitor_quality ecq ...
- WHERE ST_DWithin(
+ WHERE (rp.business_status IS NULL
+        OR rp.business_status = 'OPERATIONAL')
+   AND ST_DWithin(
        rp.geom::geography, ...)
```

**2d — ECQ `chain_counts` CTE** (`app/ingest/expansion_advisor_competitors.py`)
```diff
  FROM restaurant_poi
  WHERE name IS NOT NULL AND name != ''
    AND {_name_norm} ~ '[a-z0-9؀-ۿ]'
    AND {_name_norm} NOT IN ({_denylist_sql})
+   AND (business_status IS NULL
+        OR business_status = 'OPERATIONAL')
```

**2e — grid-search insert** (`scripts/google_places_grid_search.py`)
```diff
  google_confidence=0.95,
+ business_status=business_status,
  district=vicinity[:128] if vicinity else None,
  raw={ ... "business_status": business_status, ... },
```
`raw.business_status` is preserved for backward compatibility.

**2f — Google enrich path** (`app/ingest/google_reviews_enrich.py` +
`app/connectors/google_places.py` + `google_places_async.py`)
```diff
  fields = (
    "place_id,name,rating,user_ratings_total,price_level,"
-   "geometry,types,formatted_address"
+   "geometry,types,formatted_address,business_status"
  )
```
```diff
  poi.google_confidence = confidence
+ business_status = details.get("business_status") or best.get("business_status")
+ if business_status:
+     poi.business_status = business_status
```
`business_status` is a **Basic-tier** Place Details field — adding it does
**not** bump Google's SKU pricing. The enrich path only writes the column
when Google returns a value (never clears an existing status to NULL).

### Model (`app/models/tables.py`)
`business_status = Column(String(32))` added near the other Google-derived
columns, with `Index("ix_restaurant_poi_business_status", ...)`.

## Backfill row count

**To be confirmed against prod on next deploy.** Per the audit, ~18,000-21,000
grid-search rows have `raw.business_status` set (most but not all of the
21,422 grid rows; enrich-path rows store under `raw.google.business_status`
and are out of scope for the migration backfill). The migration logs the
exact `UPDATE` rowcount at upgrade time.

## Score impact

Candidates with closed-venue clusters in their competition buffer will see
their `competition_whitespace` score **increase** (less perceived
competition). Magnitude depends on how many `CLOSED` rows are in each
cluster. Expected ranking shifts: **small (1-3 positions)** for affected
candidates. No scoring weight or formula was changed — only the set of
rows counted.

## Tests

`tests/test_business_status_competitor_filter.py` (9 tests):
- migration upgrade/downgrade roundtrip (column + index added then
  dropped cleanly)
- migration backfill copies `raw->>'business_status'`, leaves status-less
  rows NULL
- `RestaurantPOI` model carries the typed, indexed column
- competitor count excludes `CLOSED_*`, includes `OPERATIONAL` + NULL
- ECQ `chain_counts` excludes closed venues from chain size
- production query strings still carry the filter (regression guard,
  rejects the unsafe `!= 'CLOSED_PERMANENTLY'` single-sided form)
- Place Details `fields` (sync + async) now request `business_status`

No test hits Google — responses are mocked.

## Validation performed

- `pytest tests/` — **1858 passed, 20 skipped**, no regressions
- `python scripts/validate_alembic_chain.py` — all 87 revisions valid
- `pytest tests/test_alembic_unique_revisions.py` — passes
- `ruff check` on the new migration + test file — clean (the 8
  pre-existing `ruff` findings in the touched modules are unrelated and
  untouched by this PR)
- Migration upgrade/downgrade exercised against SQLite via a real alembic
  `Operations` context.

**Note:** `alembic upgrade heads` against a fresh DB could not be run in
the CI sandbox because PostGIS is not installed there (the full chain
includes PostGIS geometry/materialized-view migrations). The new
migration itself is PostGIS-free (plain column + index + JSONB backfill)
and is verified by the roundtrip test.

## Rules / risk

- Filter uses `IS NULL OR business_status = 'OPERATIONAL'` — **not** the
  unsafe `!= 'CLOSED_PERMANENTLY'` (SQL NULL-comparisons yield unknown,
  which would silently drop NULL rows).
- Migration is reversible; backfill is idempotent (`business_status IS NULL`
  guard).
- No new dependencies. Additive schema change. **Risk: low.**

## Post-merge plan

> After merge, Ahmed will:
> 1. Deploy to SCCC (`oaktree-estimator` deployment)
> 2. Run `SELECT business_status, COUNT(*) FROM restaurant_poi GROUP BY business_status ORDER BY 2 DESC;` to confirm distribution
> 3. Trigger `expansion-advisor-data-competitors.yml` manually to rebuild ECQ against the filtered query
> 4. Compare a sample of candidate rankings before vs after for sanity

https://claude.ai/code/session_01Y5u7PGN5VGHAsPpQtHG4b8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5u7PGN5VGHAsPpQtHG4b8)_