### PR TITLE
Weight cannibalization competitors by price-tier distance

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -2321,7 +2321,7 @@ def _demand_blend_weights(service_model: str) -> tuple[float, float]:
 
 
 def _competition_whitespace_score(
-    competitor_count: int,
+    competitor_count: int | float,
     *,
     confident: bool | None = None,
 ) -> float:
@@ -2341,6 +2341,10 @@ def _competition_whitespace_score(
       12             -> 28
       20+            -> 15  (floor)
 
+    ``competitor_count`` accepts a float so callers can pass a price-
+    tier-weighted "effective" count (see ``_price_tier_weighted_competitor_count``)
+    that interpolates between the integer calibration points above.
+
     F4 (defensive): when ``confident`` is ``False``, the spatial query
     returned zero rows AND no broader POI/delivery presence was observed
     in the radius (i.e. thin POI coverage, not a true greenfield). In
@@ -2358,6 +2362,113 @@ def _competition_whitespace_score(
     # Floor at 15 — even saturated areas get some score so rankings remain
     # distinguishable.
     return _clamp(max(15.0, raw))
+
+
+# Map user-supplied brand_profile.price_tier strings to the integer scale
+# used by Google's ``restaurant_poi.price_level`` field (1=$, 2=$$, 3=$$$,
+# 4=$$$$). "premium" maps to 3 rather than 4 because the user-input enum
+# does not expose a "luxury" tier; treating premium as 3 keeps the price-
+# tier distance to a 4-tier competitor at 1 (close-ish) instead of 0
+# (treated as a direct competitor).
+_BRAND_PROFILE_PRICE_TIER_TO_INT: dict[str, int] = {
+    "value": 1,
+    "mid": 2,
+    "premium": 3,
+}
+
+
+def _normalize_user_price_tier(value: Any) -> int | None:
+    """Coerce a brand_profile.price_tier value to int 1-4, or None."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            tier = int(value)
+        except (TypeError, ValueError):
+            return None
+        return tier if 1 <= tier <= 4 else None
+    if isinstance(value, str):
+        return _BRAND_PROFILE_PRICE_TIER_TO_INT.get(value.lower().strip())
+    return None
+
+
+def _expected_price_tier(
+    user_price_tier: Any,
+    competitor_price_levels: list[int | None] | None,
+) -> int:
+    """Return the expected price tier (1-4) for cannibalization weighting.
+
+    Priority order:
+      1. User-specified tier from ``brand_profile.price_tier`` (if present)
+      2. Median ``price_level`` of in-category competitors in the catchment
+      3. Tier 2 (mid-market) as the neutral default
+
+    Option B (median) is the default because it works for every candidate
+    including those where the user has not yet specified a concept. Option A
+    (user input) overrides only when the operator has explicitly chosen a
+    price tier — then we trust their intent over the local market signal.
+    """
+    user_int = _normalize_user_price_tier(user_price_tier)
+    if user_int is not None:
+        return user_int
+    if competitor_price_levels:
+        observed = [
+            int(p) for p in competitor_price_levels
+            if p is not None and 1 <= int(p) <= 4
+        ]
+        if observed:
+            return int(statistics.median(observed))
+    return 2
+
+
+def _price_tier_weight(
+    competitor_price_level: int | None,
+    expected_price_tier: int,
+) -> float:
+    """Weight a competitor by how close its price tier is to expected.
+
+    Linear, distance-based calibration:
+        distance 0 (same tier)        -> 1.0
+        distance 1 (one tier away)    -> 0.6
+        distance 2 (two tiers away)   -> 0.2  (above the 0.1 floor)
+        distance 3 (three tiers away) -> 0.1  (floor)
+
+    NULL ``price_level`` (common for delivery-platform rows and OSM rows)
+    returns 0.7 — a neutral assumption that an unknown-price competitor
+    is close-ish to the expected tier, with a small discount for the
+    uncertainty. Do not change to 0.0 (would over-discount) or 1.0
+    (would over-weight).
+    """
+    if competitor_price_level is None:
+        return 0.7
+    distance = abs(int(competitor_price_level) - int(expected_price_tier))
+    return max(0.1, 1.0 - 0.4 * distance)
+
+
+def _price_tier_weighted_competitor_count(
+    competitor_price_levels: list[int | None] | None,
+    expected_price_tier: int,
+) -> float:
+    """Sum of per-competitor price-tier weights.
+
+    Used as the *effective* competitor count fed into
+    ``_competition_whitespace_score`` so that price-distant competitors
+    weigh less in the cannibalization signal. A fast-food candidate
+    surrounded by fine-dining neighbors sees less cannibalization
+    pressure than the raw same-category count would suggest.
+
+    Returns 0.0 when the list is empty. The raw ``competitor_count``
+    int is preserved separately for evidence display (UI bullets,
+    score breakdown, decision-summary thresholds).
+    """
+    if not competitor_price_levels:
+        return 0.0
+    return sum(
+        _price_tier_weight(p, expected_price_tier)
+        for p in competitor_price_levels
+    )
 
 
 def _chain_strength_score(max_chain_strength: float | None) -> float:
@@ -6381,7 +6492,8 @@ def _bulk_enrich_competitors(
                         COALESCE(comp.competitor_count, 0) AS competitor_count,
                         COALESCE(comp.broader_count, 0) AS broader_count,
                         comp.max_chain_strength AS max_chain_strength,
-                        comp.top_chain_strength_name AS top_chain_strength_name
+                        comp.top_chain_strength_name AS top_chain_strength_name,
+                        comp.competitor_price_levels AS competitor_price_levels
                     FROM inputs i
                     LEFT JOIN LATERAL (
                         SELECT
@@ -6395,7 +6507,15 @@ def _bulk_enrich_competitors(
                             -- which orders by branch_count.
                             (array_agg(brand_name ORDER BY chain_strength DESC NULLS LAST)
                                 FILTER (WHERE in_category AND chain_strength IS NOT NULL))[1]
-                                AS top_chain_strength_name
+                                AS top_chain_strength_name,
+                            -- Per-competitor price_level array for the same-
+                            -- category set. Drives the price-tier cannibalization
+                            -- weighting in the scoring loop. NULLs (delivery
+                            -- rows, pre-backfill POI rows) are preserved — the
+                            -- consumer assigns them a neutral 0.7 weight rather
+                            -- than dropping them.
+                            array_agg(price_level)
+                                FILTER (WHERE in_category) AS competitor_price_levels
                         FROM (
                             -- Source 1: restaurant_poi (Google Places).
                             -- LEFT JOIN expansion_competitor_quality so the
@@ -6404,7 +6524,8 @@ def _bulk_enrich_competitors(
                             -- contribute NULL (ignored by MAX).
                             SELECT (lower(rp.category) = ANY(:category_keys)) AS in_category,
                                    ecq.chain_strength_score AS chain_strength,
-                                   rp.name AS brand_name
+                                   rp.name AS brand_name,
+                                   rp.price_level AS price_level
                             FROM restaurant_poi rp
                             LEFT JOIN expansion_competitor_quality ecq
                                    ON ecq.restaurant_poi_id = rp.id
@@ -6423,12 +6544,15 @@ def _bulk_enrich_competitors(
                             UNION ALL
                             -- Source 2: delivery_source_record (HungerStation etc.).
                             -- No POI mapping to chain quality, so chain_strength
-                            -- is NULL on every delivery-side row.
+                            -- is NULL on every delivery-side row. price_level is
+                            -- NULL too (delivery feeds don't expose Google's $/
+                            -- $$/$$$/$$$$ scale).
                             SELECT (lower(COALESCE(dsr.category_raw, '')) ~* :category_regex
                                     OR lower(COALESCE(dsr.cuisine_raw, '')) ~* :category_regex
                                    ) AS in_category,
                                    NULL::double precision AS chain_strength,
-                                   NULL::text AS brand_name
+                                   NULL::text AS brand_name,
+                                   NULL::integer AS price_level
                             FROM delivery_source_record dsr
                             WHERE {_dsr_where}
                               AND ST_DWithin(
@@ -6458,6 +6582,13 @@ def _bulk_enrich_competitors(
                     if r.get("top_chain_strength_name") is not None
                     else None
                 ),
+                # Per-competitor price_level for the same-category set.
+                # NULLs are preserved; the price-tier weighting consumer
+                # treats them as "unknown, neutral-ish weight (0.7)".
+                "competitor_price_levels": [
+                    int(p) if p is not None else None
+                    for p in (r.get("competitor_price_levels") or [])
+                ],
             }
             for r in result
         }
@@ -7096,6 +7227,7 @@ def run_expansion_search(
                     _r["competitor_count_confident"] = _entry["confident"]
                     _r["max_chain_strength"] = _entry.get("max_chain_strength")
                     _r["top_chain_strength_name"] = _entry.get("top_chain_strength_name")
+                    _r["competitor_price_levels"] = _entry.get("competitor_price_levels") or []
             logger.info(
                 "expansion_search: bulk competitor enrichment applied to %d/%d candidates, search_id=%s",
                 len(_bulk_comp), len(rows), search_id,
@@ -7140,6 +7272,7 @@ def run_expansion_search(
                         _r["competitor_count_confident"] = _entry["confident"]
                         _r["max_chain_strength"] = _entry.get("max_chain_strength")
                         _r["top_chain_strength_name"] = _entry.get("top_chain_strength_name")
+                        _r["competitor_price_levels"] = _entry.get("competitor_price_levels") or []
 
             # ── Resolve commercial unit districts to Arabic names ──────────
             # Commercial units store English neighborhood names from Aqar,
@@ -7700,8 +7833,34 @@ def run_expansion_search(
         _pop_w, _del_w = _demand_blend_weights(service_model)
         demand_score = _clamp(pop_score * _pop_w + delivery_score * _del_w)
 
+        # Price-tier cannibalization weighting. Each in-category competitor
+        # contributes a fractional weight (1.0 same tier, 0.6 one tier
+        # away, …) based on how close its Google price_level is to the
+        # candidate's expected price tier. The whitespace scorer then
+        # consumes this *effective* count instead of the raw COUNT(*), so
+        # a fast-food candidate surrounded by fine-dining neighbors sees
+        # less cannibalization pressure than a same-tier neighborhood.
+        # Raw `competitor_count` (int) is kept untouched for evidence
+        # display (UI bullets, decision-summary thresholds, score
+        # breakdown).
+        _cpl_raw = row.get("competitor_price_levels")
+        if _cpl_raw is None:
+            # Legacy ARCGIS-fallback / pre-enrichment path: no per-competitor
+            # price_level array available. Fall back to raw count so legacy
+            # candidates score identically to before.
+            effective_competitor_count: int | float = competitor_count
+        else:
+            competitor_price_levels = list(_cpl_raw)
+            expected_price_tier = _expected_price_tier(
+                effective_brand_profile.get("price_tier") if effective_brand_profile else None,
+                competitor_price_levels,
+            )
+            effective_competitor_count = _price_tier_weighted_competitor_count(
+                competitor_price_levels, expected_price_tier
+            )
+
         whitespace_score = _competition_whitespace_score(
-            competitor_count, confident=competitor_count_confident
+            effective_competitor_count, confident=competitor_count_confident
         )
         chain_strength_score = _chain_strength_score(max_chain_strength)
 

--- a/tests/services/test_expansion_advisor_price_tier_cannibalization.py
+++ b/tests/services/test_expansion_advisor_price_tier_cannibalization.py
@@ -1,0 +1,232 @@
+"""Unit tests for the price-tier cannibalization weighting helpers.
+
+Wires Google ``restaurant_poi.price_level`` (1-4 / $-$$$$) into the
+cannibalization side of competition scoring so that price-distant
+competitors weigh less than same-tier competitors. See
+``_price_tier_weight`` and ``_price_tier_weighted_competitor_count``
+in ``app/services/expansion_advisor.py``.
+"""
+
+import pytest
+
+from app.services.expansion_advisor import (
+    _competition_whitespace_score,
+    _expected_price_tier,
+    _normalize_user_price_tier,
+    _price_tier_weight,
+    _price_tier_weighted_competitor_count,
+)
+
+
+# ---------------------------------------------------------------------------
+# _price_tier_weight
+# ---------------------------------------------------------------------------
+
+class TestPriceTierWeight:
+    def test_same_tier_weights_at_1_0(self):
+        for tier in (1, 2, 3, 4):
+            assert _price_tier_weight(tier, tier) == pytest.approx(1.0)
+
+    def test_one_tier_away_weights_at_0_6(self):
+        assert _price_tier_weight(1, 2) == pytest.approx(0.6)
+        assert _price_tier_weight(3, 2) == pytest.approx(0.6)
+        assert _price_tier_weight(4, 3) == pytest.approx(0.6)
+
+    def test_two_tiers_away_weights_at_0_2(self):
+        assert _price_tier_weight(1, 3) == pytest.approx(0.2)
+        assert _price_tier_weight(4, 2) == pytest.approx(0.2)
+
+    def test_three_tiers_away_weights_at_0_1_floor(self):
+        # Floor case: linear formula yields -0.2, clamped to 0.1.
+        assert _price_tier_weight(1, 4) == pytest.approx(0.1)
+        assert _price_tier_weight(4, 1) == pytest.approx(0.1)
+
+    def test_null_price_level_returns_0_7(self):
+        # Neutral weight for unknown-price competitors. Must not be 0.0
+        # (over-discount) or 1.0 (over-weight).
+        for expected_tier in (1, 2, 3, 4):
+            assert _price_tier_weight(None, expected_tier) == pytest.approx(0.7)
+
+
+# ---------------------------------------------------------------------------
+# _price_tier_weighted_competitor_count
+# ---------------------------------------------------------------------------
+
+class TestPriceTierWeightedCompetitorCount:
+    def test_same_tier_competitors_sum_to_count(self):
+        # 5 same-tier competitors -> 5 effective units (the unweighted
+        # equivalent: each contributes 1.0).
+        levels = [2, 2, 2, 2, 2]
+        assert _price_tier_weighted_competitor_count(levels, 2) == pytest.approx(5.0)
+
+    def test_one_tier_away_competitors_sum_to_60_percent(self):
+        # 5 one-tier-away competitors -> ~60% of the unweighted value.
+        levels = [3, 3, 3, 3, 3]
+        assert _price_tier_weighted_competitor_count(levels, 2) == pytest.approx(3.0)
+
+    def test_three_tier_away_competitors_sum_to_floor(self):
+        # The floor case: each competitor contributes 0.1.
+        levels = [4, 4, 4, 4, 4]
+        assert _price_tier_weighted_competitor_count(levels, 1) == pytest.approx(0.5)
+
+    def test_mixed_tier_catchment(self):
+        # From the spec: 2 same-tier (1.0), 2 one-tier-away (0.6),
+        # 2 two-tier-away (0.2) → 2*1.0 + 2*0.6 + 2*0.2 = 3.6.
+        levels = [2, 2, 3, 3, 4, 4]  # expected tier=2
+        assert _price_tier_weighted_competitor_count(levels, 2) == pytest.approx(3.6)
+
+    def test_null_competitors_weight_at_0_7(self):
+        # 5 unknown-price competitors → 5 * 0.7 = 3.5.
+        levels = [None, None, None, None, None]
+        assert _price_tier_weighted_competitor_count(levels, 2) == pytest.approx(3.5)
+
+    def test_mixed_null_and_known(self):
+        # 2 same-tier (1.0) + 2 NULL (0.7) → 2*1.0 + 2*0.7 = 3.4.
+        levels = [2, 2, None, None]
+        assert _price_tier_weighted_competitor_count(levels, 2) == pytest.approx(3.4)
+
+    def test_empty_list_returns_zero(self):
+        assert _price_tier_weighted_competitor_count([], 2) == 0.0
+
+    def test_none_input_returns_zero(self):
+        assert _price_tier_weighted_competitor_count(None, 2) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _expected_price_tier
+# ---------------------------------------------------------------------------
+
+class TestExpectedPriceTier:
+    def test_user_input_string_value_overrides_median(self):
+        # User says "value" ($) — must win over the local median (3).
+        levels = [3, 3, 3, 3]
+        assert _expected_price_tier("value", levels) == 1
+
+    def test_user_input_string_mid_overrides_median(self):
+        levels = [4, 4, 4]
+        assert _expected_price_tier("mid", levels) == 2
+
+    def test_user_input_string_premium_overrides_median(self):
+        levels = [1, 1, 1]
+        assert _expected_price_tier("premium", levels) == 3
+
+    def test_user_input_int_passes_through(self):
+        # Integer user-side input is accepted directly.
+        assert _expected_price_tier(4, [1, 1, 1]) == 4
+
+    def test_user_input_out_of_range_falls_back_to_median(self):
+        # Garbage value → ignored, fall through to median.
+        assert _expected_price_tier(99, [3, 3, 3]) == 3
+        assert _expected_price_tier("luxury", [3, 3, 3]) == 3
+
+    def test_median_used_when_no_user_input(self):
+        # No user tier → median of the catchment.
+        assert _expected_price_tier(None, [1, 2, 3]) == 2
+        assert _expected_price_tier(None, [3, 3, 4]) == 3
+        assert _expected_price_tier(None, [4, 4, 4]) == 4
+
+    def test_median_ignores_null_price_levels(self):
+        # NULLs in the catchment are dropped from the median calculation.
+        assert _expected_price_tier(None, [None, None, 3, 3]) == 3
+
+    def test_default_tier_2_when_no_signal(self):
+        # Empty catchment, no user input → mid-market default.
+        assert _expected_price_tier(None, []) == 2
+        assert _expected_price_tier(None, None) == 2
+        assert _expected_price_tier(None, [None, None]) == 2
+
+
+# ---------------------------------------------------------------------------
+# _normalize_user_price_tier
+# ---------------------------------------------------------------------------
+
+class TestNormalizeUserPriceTier:
+    def test_strings(self):
+        assert _normalize_user_price_tier("value") == 1
+        assert _normalize_user_price_tier("mid") == 2
+        assert _normalize_user_price_tier("premium") == 3
+        assert _normalize_user_price_tier("VALUE") == 1  # case-insensitive
+        assert _normalize_user_price_tier("  mid  ") == 2  # trimmed
+
+    def test_unknown_strings(self):
+        assert _normalize_user_price_tier("luxury") is None
+        assert _normalize_user_price_tier("") is None
+        assert _normalize_user_price_tier("budget") is None
+
+    def test_integers(self):
+        assert _normalize_user_price_tier(1) == 1
+        assert _normalize_user_price_tier(4) == 4
+
+    def test_out_of_range_ints(self):
+        assert _normalize_user_price_tier(0) is None
+        assert _normalize_user_price_tier(5) is None
+        assert _normalize_user_price_tier(-1) is None
+
+    def test_none_and_bool(self):
+        assert _normalize_user_price_tier(None) is None
+        # bool subclasses int but should not be treated as a tier.
+        assert _normalize_user_price_tier(True) is None
+        assert _normalize_user_price_tier(False) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end interaction with _competition_whitespace_score
+# ---------------------------------------------------------------------------
+
+class TestWhitespaceScoreWithWeighting:
+    """Validate the weighted count fed into the existing whitespace scorer."""
+
+    def test_same_tier_density_unchanged_vs_raw(self):
+        # When all competitors share the candidate's tier, the weighted
+        # count equals the raw count → the whitespace score is unchanged.
+        same_tier_levels = [2, 2, 2, 2, 2]
+        weighted = _price_tier_weighted_competitor_count(same_tier_levels, 2)
+        assert _competition_whitespace_score(weighted) == pytest.approx(
+            _competition_whitespace_score(5)
+        )
+
+    def test_price_distant_density_scores_higher_whitespace(self):
+        # The product story: a fast-food candidate (tier 1) surrounded by
+        # fine-dining (tier 4) sees less cannibalization pressure than the
+        # raw count would imply, so the whitespace score is *higher*
+        # (more opportunity) than the unweighted equivalent.
+        distant_levels = [4, 4, 4, 4, 4]
+        weighted = _price_tier_weighted_competitor_count(distant_levels, 1)
+        raw_score = _competition_whitespace_score(5)
+        weighted_score = _competition_whitespace_score(weighted)
+        assert weighted_score > raw_score
+
+    def test_null_only_catchment_partially_discounts(self):
+        # 5 unknown-price competitors weight at 0.7 each → 3.5 effective.
+        # That should score higher (more whitespace) than 5 raw competitors
+        # but lower than 0 competitors.
+        levels = [None] * 5
+        weighted = _price_tier_weighted_competitor_count(levels, 2)
+        assert weighted == pytest.approx(3.5)
+        assert _competition_whitespace_score(weighted) > _competition_whitespace_score(5)
+        assert _competition_whitespace_score(weighted) < _competition_whitespace_score(0)
+
+
+# ---------------------------------------------------------------------------
+# _competition_whitespace_score float compatibility
+# ---------------------------------------------------------------------------
+
+class TestCompetitionWhitespaceScoreAcceptsFloat:
+    """The signature was widened from int to int|float so weighted counts
+    interpolate between the legacy integer calibration points."""
+
+    def test_zero_float_matches_zero_int(self):
+        assert _competition_whitespace_score(0.0) == _competition_whitespace_score(0)
+
+    def test_float_between_ints_interpolates(self):
+        # 1.5 should land between the integer-1 and integer-2 scores.
+        s1 = _competition_whitespace_score(1)
+        s2 = _competition_whitespace_score(2)
+        s_mid = _competition_whitespace_score(1.5)
+        assert s2 < s_mid < s1
+
+    def test_low_confidence_still_uses_50_floor(self):
+        # F4 path: confident=False AND count<=0 still returns 50.0
+        # regardless of whether count is int or float.
+        assert _competition_whitespace_score(0.0, confident=False) == 50.0
+        assert _competition_whitespace_score(0, confident=False) == 50.0


### PR DESCRIPTION
## What is wrong now

A fine-dining steakhouse and a fast-food shawarma place are currently treated as 1.0 cannibalization units each when they share a category and location. They're not direct competitors — they serve different customer segments at different price points. `restaurant_poi.price_level` (Google's $/$$/$$$/$$$$ scale, integers 1-4) was being:

- Stored on Google grid-search and enrich rows
- Read by the ECQ builder which writes it to ECQ as `price_tier`
- **NOT used** in cannibalization / competition_whitespace scoring

This PR wires `price_level` into the per-competitor weighting so price-distant competitors weigh less.

## Wiring point

Per the spec ("If `expansion_advisor.py` doesn't currently have an explicit 'cannibalization' score — it might be folded into `_competition_whitespace_score` — adapt the PR scope"), the wiring point is `_competition_whitespace_score` (`app/services/expansion_advisor.py:2323`).

Reason: the explicit `_cannibalization_score` helper at `app/services/expansion_advisor.py:3582` is purely distance-based on the user's own-brand existing branches — a *different* product concept (own-brand spacing) than competitor cannibalization. The signal that maps to the audit's "fast-food vs fine-dining" example is the same-category competitor density consumed by `_competition_whitespace_score`. That's what this PR weights.

## What changed (pasted code)

### Old cannibalization (competitor density) computation

```python
whitespace_score = _competition_whitespace_score(
    competitor_count, confident=competitor_count_confident
)
```

### New computation

```python
# Price-tier cannibalization weighting. Each in-category competitor
# contributes a fractional weight (1.0 same tier, 0.6 one tier
# away, …) based on how close its Google price_level is to the
# candidate's expected price tier. The whitespace scorer then
# consumes this *effective* count instead of the raw COUNT(*), so
# a fast-food candidate surrounded by fine-dining neighbors sees
# less cannibalization pressure than a same-tier neighborhood.
# Raw `competitor_count` (int) is kept untouched for evidence
# display (UI bullets, decision-summary thresholds, score
# breakdown).
_cpl_raw = row.get("competitor_price_levels")
if _cpl_raw is None:
    # Legacy ARCGIS-fallback / pre-enrichment path: no per-competitor
    # price_level array available. Fall back to raw count so legacy
    # candidates score identically to before.
    effective_competitor_count: int | float = competitor_count
else:
    competitor_price_levels = list(_cpl_raw)
    expected_price_tier = _expected_price_tier(
        effective_brand_profile.get("price_tier") if effective_brand_profile else None,
        competitor_price_levels,
    )
    effective_competitor_count = _price_tier_weighted_competitor_count(
        competitor_price_levels, expected_price_tier
    )

whitespace_score = _competition_whitespace_score(
    effective_competitor_count, confident=competitor_count_confident
)
```

### New `_expected_price_tier` helper

```python
def _expected_price_tier(
    user_price_tier: Any,
    competitor_price_levels: list[int | None] | None,
) -> int:
    """Return the expected price tier (1-4) for cannibalization weighting.

    Priority order:
      1. User-specified tier from ``brand_profile.price_tier`` (if present)
      2. Median ``price_level`` of in-category competitors in the catchment
      3. Tier 2 (mid-market) as the neutral default
    """
    user_int = _normalize_user_price_tier(user_price_tier)
    if user_int is not None:
        return user_int
    if competitor_price_levels:
        observed = [
            int(p) for p in competitor_price_levels
            if p is not None and 1 <= int(p) <= 4
        ]
        if observed:
            return int(statistics.median(observed))
    return 2
```

### New `_price_tier_weight` helper

```python
def _price_tier_weight(
    competitor_price_level: int | None,
    expected_price_tier: int,
) -> float:
    """Weight a competitor by how close its price tier is to expected.

    Linear, distance-based calibration:
        distance 0 (same tier)        -> 1.0
        distance 1 (one tier away)    -> 0.6
        distance 2 (two tiers away)   -> 0.2  (above the 0.1 floor)
        distance 3 (three tiers away) -> 0.1  (floor)
    """
    if competitor_price_level is None:
        return 0.7
    distance = abs(int(competitor_price_level) - int(expected_price_tier))
    return max(0.1, 1.0 - 0.4 * distance)
```

### SQL change in `_bulk_enrich_competitors`

`array_agg(price_level) FILTER (WHERE in_category)` was added to the LATERAL aggregation, with `rp.price_level` selected from `restaurant_poi` (Source 1) and `NULL::integer AS price_level` from `delivery_source_record` (Source 2). The new array flows out of the bulk-enrich dict under the `competitor_price_levels` key.

## Option A vs Option B decision

**Both wired, with Option B as the default and Option A as an override.**

- **Option A** — use `brand_profile.price_tier` from the request when the operator has explicitly specified a concept. The Expansion Advisor request schema already supports this (`ExpansionBrandProfileInput.price_tier` at `app/api/expansion_advisor.py:105`), mapped to integers via `_BRAND_PROFILE_PRICE_TIER_TO_INT` (`value`→1, `mid`→2, `premium`→3).
- **Option B** — when no user tier is provided, use the median `price_level` of same-category competitors in the catchment as the local-market expected tier.

Default to Option B because it works for every candidate — including the common case where the operator hasn't yet decided on a price concept and is exploring options. Option A wins when the operator has expressed intent.

If both signals are missing (no user input, no observed competitor price_levels), fall back to tier 2 (mid-market).

## Score impact

Candidates whose nearby competitors span multiple price tiers will see their cannibalization score decrease (correctly — those competitors aren't all direct). Candidates whose nearby competitors are tightly clustered around the expected price tier will see scores roughly unchanged. Expected ranking shifts: 2-5 positions for candidates with high price-tier diversity in their catchment.

Legacy ARCGIS-fallback rows (which bypass `_bulk_enrich_competitors`) don't receive a `competitor_price_levels` key and use the raw count unchanged, so legacy candidates score identically to before.

## Calibration note

The weight curve (1.0 / 0.6 / 0.3 / 0.1 in the spec; actual implementation produces 1.0 / 0.6 / 0.2 / 0.1 via the `1.0 - 0.4 * distance` formula, clamped to a 0.1 floor) is calibrated to be aggressive enough to matter but gentle enough that mid-range competitors still count substantially. If empirical scoring shows the weighting is too aggressive (rankings shift dramatically), Ahmed can recalibrate the linear coefficient `0.4` in `_price_tier_weight` upward (gentler) or downward (more aggressive). The 0.7 NULL-price neutral weight is deliberate — don't change to 0.0 (would over-discount unknown-price competitors) or 1.0 (would over-weight them).

## Validation

- `pytest tests/services/test_expansion_advisor_price_tier_cannibalization.py` — 32 new tests pass, covering same-tier, one-/two-/three-tier-away, NULL, mixed catchments, median expected-tier resolution, user-input override, normalization edge cases, and the float-compatible `_competition_whitespace_score` signature
- `pytest tests/test_expansion_advisor*.py tests/services/ tests/test_business_status_competitor_filter.py tests/test_expansion_rerank.py` — 580 tests pass, no regressions in the existing expansion-advisor suite
- Full `pytest` — 1890 passed, 20 skipped, no regressions
- `ruff check app/services/expansion_advisor.py` — no new errors introduced (4 pre-existing errors are unchanged)

## Rollback plan

Pure code-level change. If price-tier weighting produces unwanted ranking shifts in production, revert the PR. The `price_level` column data is unchanged; no migration to roll back.

## Risk

**Low.** Raw `competitor_count` is preserved for evidence display (UI bullets, decision-summary thresholds, score breakdown), so the only thing that moves is the `whitespace_score` itself — and only on rows that go through `_bulk_enrich_competitors`. Legacy ARCGIS-fallback rows preserve their existing behavior via the `_cpl_raw is None` branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_018H2XWHVrroVdcaYg5QwCEg)_