### PR TITLE
Stop EPA polygon centroid collapse in parking ingest

### DIFF
--- a/app/ingest/expansion_advisor_parking.py
+++ b/app/ingest/expansion_advisor_parking.py
@@ -146,7 +146,7 @@ def _ingest_from_polygons(db, replace: bool) -> int:
                 WHEN lower(COALESCE({amenity_expr}, '')) = 'parking' THEN 'surface'
                 ELSE 'unknown'
             END,
-            ST_Centroid(ST_Transform(op.way, 4326)),
+            ST_Transform(op.way, 4326),
             CASE
                 WHEN {capacity_expr} ~ '^[0-9]+$' THEN CAST({capacity_expr} AS INTEGER)
                 ELSE NULL


### PR DESCRIPTION
## What was wrong

`_ingest_from_polygons` in `app/ingest/expansion_advisor_parking.py` was collapsing every polygon to its centroid before insert (`ST_Centroid(ST_Transform(op.way, 4326))`), even though:

- `expansion_parking_asset.geom` is declared as `geometry(Geometry, 4326)` — generic, not Point.
- The scoring side reads it back with `ST_DWithin(epa.geom::geography, candidate, 350)`, which is polygon-aware (distance-from-edge).

## Why it matters

Codespace diagnostic numbers:

- EPA ingest is 100% faithful to its filter (source matches = 1,197, EPA rows = 1,197, gap = 0).
- The top 25 EPA rows are all `amenity_type = surface` with source areas between **91,428 m² and 989,134 m²**.

Geometric consequence: a square 989,134 m² lot is ~994 m per side, so the centroid sits ~497 m from the nearest edge. Because the scoring radius is 350 m, **a candidate at the perimeter of that lot — i.e., where a real restaurant would actually be — sits 497 m from the stored centroid and falls outside the 350 m radius**. The lot is invisible to a candidate sitting on its own edge. All 25 largest lots in EPA exhibit this dead zone.

## The fix

Store the polygon directly:

```diff
-            ST_Centroid(ST_Transform(op.way, 4326)),
+            ST_Transform(op.way, 4326),
```

`ST_DWithin(geom::geography, candidate, 350)` against a polygon geography returns distance-from-edge, which is the correct semantic. Points ingest (`_ingest_from_points`) is unchanged.

## Why this is safe (no schema migration, no scoring change)

- `expansion_parking_asset.geom` column: `geometry(Geometry, 4326)` (`alembic/versions/d4e5f6a1b2c3_create_expansion_advisor_tables.py:53`).
- Generic GiST index `ix_epa_geom` (`ibid:62`) and geography GiST `ix_epa_geom_geog` on `(geom::geography)` (`alembic/versions/20260322_ea_geography_gist_indexes.py:26`) — both work for any geometry shape.
- Both EPA scoring queries use `ST_DWithin(epa.geom::geography, ..., 350)` (`app/services/expansion_advisor.py:2140` and `:8209`). Neither uses `ST_X`, `ST_Y`, or any Point-specific function on `epa.geom`.
- No tests assert that the ingested `geom` is a Point. `test_parking_polygon_detects_srid` only asserts `ST_Transform` is present — still true after the edit.

## Codespace validation TODO (run after review approval / merge)

- [ ] Re-run the ingest workflow `expansion-advisor-data-parking.yml`.
- [ ] `SELECT ST_GeometryType(geom), source, COUNT(*) FROM expansion_parking_asset GROUP BY 1, 2;` — expect polygon types (`ST_Polygon`, `ST_MultiPolygon`) for `osm_polygon` source rows and `ST_Point` for `osm_point` source rows.
- [ ] Spot-check 3 candidates near the top-area lots from the diagnostic Query E. Compare their `nearby_parking_amenity_count` before vs. after the ingest re-run.

## Risk

Low. One-line change, no schema migration, no scoring code change, no test-suite breakage expected. Counts will increase for candidates near large parking lots, which is the intended behavior.

**Do not merge — waiting on explicit review approval.**

https://claude.ai/code/session_019iaivkxsXsyERhvZcWqUUs

---
_Generated by [Claude Code](https://claude.ai/code/session_019iaivkxsXsyERhvZcWqUUs)_