### PR TITLE
Add Google Places parking ingest (source='google_places' in EPA)

### DIFF
--- a/.github/workflows/expansion-advisor-data-parking-google.yml
+++ b/.github/workflows/expansion-advisor-data-parking-google.yml
@@ -1,0 +1,84 @@
+name: "Expansion Advisor Data — Google Places Parking"
+
+on:
+  schedule:
+    - cron: "0 4 1 1,7 *"  # 04:00 UTC on Jan 1 and Jul 1 (6-month cadence)
+  workflow_dispatch:
+    inputs:
+      replace_mode:
+        description: "Replace existing Riyadh rows (suppressed if checkpoint present)"
+        required: false
+        default: "true"
+      refresh_after:
+        description: "Run post-ingestion refresh"
+        required: false
+        default: "true"
+
+jobs:
+  ingest-google-parking:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+      POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+      POSTGRES_PORT: ${{ secrets.POSTGRES_PORT || '5432' }}
+      PGSSLMODE: ${{ secrets.PGSSLMODE || 'require' }}
+      GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python requirements
+        run: pip install -r requirements.txt
+
+      - name: Run alembic upgrade
+        run: python -m alembic upgrade heads
+
+      - name: Run Google Places Parking ingest
+        run: |
+          python -m app.ingest.expansion_advisor_parking_google \
+            --replace ${{ github.event.inputs.replace_mode || 'true' }} \
+            --write-stats /tmp/google-parking-stats.json
+
+      - name: Run post-ingestion refresh
+        if: ${{ github.event.inputs.refresh_after != 'false' }}
+        run: |
+          python -m app.ingest.expansion_advisor_refresh \
+            --skip-alembic \
+            --write-stats /tmp/refresh-stats.json
+
+      - name: Print row counts
+        run: |
+          python -c "
+          from app.db.session import engine
+          from sqlalchemy import text
+          with engine.connect() as c:
+              r = c.execute(text(\"SELECT COUNT(*) FROM expansion_parking_asset WHERE source = 'google_places'\")).scalar()
+              print(f'expansion_parking_asset (google_places): {r} rows')
+          "
+
+      - name: Upload stats artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: expansion-advisor-google-parking-stats
+          path: /tmp/*-stats.json
+          retention-days: 30
+
+      - name: Upload checkpoint on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: google-parking-checkpoint
+          path: /tmp/google_parking_checkpoint.json
+          retention-days: 7

--- a/app/connectors/google_places_async.py
+++ b/app/connectors/google_places_async.py
@@ -408,6 +408,31 @@ class AsyncGooglePlacesClient:
 
         return [], fallback_info
 
+    async def nearby_search(
+        self,
+        lat: float,
+        lon: float,
+        radius_m: int = 350,
+        place_type: str = "parking",
+    ) -> dict:
+        """
+        Nearby Search (legacy endpoint) for amenity POIs in a radius.
+
+        Returns the raw response dict. Caller is responsible for handling
+        the ``status`` field, deduping ``place_id``, and capping at the
+        20-result page limit (no pagination via ``next_page_token``).
+
+        Used by the grid-driven Google Places parking ingest.
+        """
+        url = f"{_BASE_URL}/nearbysearch/json"
+        params: dict[str, Any] = {
+            "location": f"{lat},{lon}",
+            "radius": radius_m,
+            "type": place_type,
+            "key": _get_api_key(),
+        }
+        return await self._request(url, params)
+
     async def get_place_details(self, place_id: str) -> dict:
         """Fetch Place Details for a specific place_id."""
         if place_id in _details_cache:

--- a/app/ingest/expansion_advisor_parking_google.py
+++ b/app/ingest/expansion_advisor_parking_google.py
@@ -1,0 +1,370 @@
+"""Expansion Advisor — Google Places parking ingest.
+
+Grid-driven ingestion that queries Google Places Nearby Search at uniformly
+spaced points across built-up Riyadh and writes resulting parking POIs into
+the existing ``expansion_parking_asset`` table with ``source='google_places'``.
+
+Design choices (see ``cc_investigate_google_parking_ingest.md`` recon):
+- Single unified ``expansion_parking_asset`` table; no new schema.
+- Cap at 20 results per query (Nearby Search single-page limit), no
+  ``next_page_token`` pagination.
+- App-level dedup on ``place_id`` via in-process set.
+- Resumability: JSON checkpoint at ``/tmp/google_parking_checkpoint.json``;
+  flushed every 100 cells; deleted on successful completion.
+- Honest defaults for Google-unknown columns: ``amenity_type='unknown'``,
+  ``capacity=NULL``, ``covered=NULL``, ``public_access=NULL``.
+- Flat ``walk_access_score=65.0`` / ``dropoff_score=55.0`` matching the
+  OSM ingest's ``ELSE`` branches.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import math
+import os
+from typing import Any
+
+from sqlalchemy import text
+
+from app.connectors.google_places_async import AsyncGooglePlacesClient
+from app.ingest.expansion_advisor_common import (
+    get_session,
+    log_table_counts,
+    validate_db_env,
+    write_stats,
+)
+
+logger = logging.getLogger("expansion_advisor.parking_google")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Tightened bounding box covering built-up Riyadh (avoids the wide desert
+# fringe of the configured RIYADH_BBOX).
+RIYADH_BUILT_UP_BBOX: dict[str, float] = {
+    "min_lon": 46.55,
+    "min_lat": 24.55,
+    "max_lon": 46.95,
+    "max_lat": 24.85,
+}
+
+SPACING_M = 500
+RADIUS_M = 350
+NEARBY_PLACE_TYPE = "parking"
+
+DEFAULT_CHECKPOINT_PATH = "/tmp/google_parking_checkpoint.json"
+CHECKPOINT_FLUSH_INTERVAL = 100
+PROGRESS_LOG_INTERVAL = 500
+
+NAME_MAX_LEN = 256
+
+
+INSERT_SQL = text(
+    """
+    INSERT INTO expansion_parking_asset (
+        city, source, name, amenity_type, geom, capacity, covered,
+        public_access, walk_access_score, dropoff_score
+    ) VALUES (
+        :city, 'google_places', :name, 'unknown',
+        ST_SetSRID(ST_MakePoint(:lon, :lat), 4326),
+        NULL, NULL, NULL, 65.0, 55.0
+    )
+    """
+)
+
+
+# ---------------------------------------------------------------------------
+# Grid generation (cosine-corrected, mirrors scripts/google_places_grid_search.py)
+# ---------------------------------------------------------------------------
+
+def _meters_to_deg_lat(meters: float) -> float:
+    return meters / 111_320.0
+
+
+def _meters_to_deg_lon(meters: float, lat: float) -> float:
+    return meters / (111_320.0 * math.cos(math.radians(lat)))
+
+
+def generate_grid_points(
+    bbox: dict[str, float],
+    spacing_m: float,
+) -> list[tuple[float, float, str]]:
+    """Return ``(lat, lon, cell_key)`` tuples tiling *bbox* at *spacing_m*.
+
+    Uses a single mid-latitude longitude step so the grid is rectangular
+    in degree-space. ``cell_key`` is stable across reruns for checkpoint
+    resumability.
+    """
+    mid_lat = (bbox["min_lat"] + bbox["max_lat"]) / 2
+    step_lat = _meters_to_deg_lat(spacing_m)
+    step_lon = _meters_to_deg_lon(spacing_m, mid_lat)
+
+    cells: list[tuple[float, float, str]] = []
+    lat = bbox["min_lat"]
+    while lat <= bbox["max_lat"]:
+        lon = bbox["min_lon"]
+        while lon <= bbox["max_lon"]:
+            cell_key = f"{lat:.4f}_{lon:.4f}"
+            cells.append((lat, lon, cell_key))
+            lon += step_lon
+        lat += step_lat
+    return cells
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint helpers
+# ---------------------------------------------------------------------------
+
+def load_checkpoint(path: str) -> set[str]:
+    """Return the set of completed cell_keys from *path*, or empty set."""
+    if not os.path.exists(path):
+        return set()
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return set(data.get("completed_cells", []))
+    except Exception:
+        logger.warning("Failed to load checkpoint at %s, starting fresh", path, exc_info=True)
+        return set()
+
+
+def save_checkpoint(path: str, completed_cells: set[str]) -> None:
+    """Atomically write *completed_cells* to *path* as JSON."""
+    payload = {"completed_cells": sorted(completed_cells)}
+    tmp = f"{path}.tmp"
+    with open(tmp, "w") as f:
+        json.dump(payload, f)
+    os.replace(tmp, path)
+
+
+def delete_checkpoint(path: str) -> None:
+    """Remove the checkpoint file if present; tolerate failure."""
+    try:
+        if os.path.exists(path):
+            os.remove(path)
+    except Exception:
+        logger.warning("Failed to delete checkpoint at %s", path, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Per-cell processing
+# ---------------------------------------------------------------------------
+
+async def _process_cell(
+    client: AsyncGooglePlacesClient,
+    cell_key: str,
+    lat: float,
+    lon: float,
+    radius_m: int,
+    seen_place_ids: set[str],
+    stats: dict[str, int],
+) -> list[dict[str, Any]]:
+    """Query one grid cell and return deduped parameter dicts ready to INSERT.
+
+    Mutates *seen_place_ids* and *stats* in place. Returns ``[]`` on API
+    error or empty/dedupe results.
+    """
+    try:
+        response = await client.nearby_search(
+            lat=lat,
+            lon=lon,
+            radius_m=radius_m,
+            place_type=NEARBY_PLACE_TYPE,
+        )
+    except Exception as exc:
+        logger.warning("Nearby Search call raised for cell %s: %s", cell_key, exc)
+        stats["api_errors"] += 1
+        return []
+
+    status = response.get("status", "")
+    if status not in ("OK", "ZERO_RESULTS"):
+        logger.warning("Nearby Search status=%s for cell %s", status, cell_key)
+        stats["api_errors"] += 1
+        return []
+
+    stats["grid_points_queried_successfully"] += 1
+
+    results = response.get("results") or []
+    if results:
+        stats["grid_points_with_results"] += 1
+    else:
+        stats["grid_points_empty"] += 1
+
+    if len(results) >= 20:
+        stats["grid_points_saturated_at_20"] += 1
+
+    new_rows: list[dict[str, Any]] = []
+    for r in results:
+        place_id = r.get("place_id")
+        if not place_id or place_id in seen_place_ids:
+            continue
+        geo = (r.get("geometry") or {}).get("location") or {}
+        result_lat = geo.get("lat")
+        result_lng = geo.get("lng")
+        if result_lat is None or result_lng is None:
+            continue
+        seen_place_ids.add(place_id)
+        name = r.get("name") or "Unnamed parking"
+        new_rows.append({
+            "city": "riyadh",
+            "name": name[:NAME_MAX_LEN],
+            "lon": float(result_lng),
+            "lat": float(result_lat),
+        })
+    return new_rows
+
+
+# ---------------------------------------------------------------------------
+# Main async loop
+# ---------------------------------------------------------------------------
+
+async def run_ingest(
+    db,
+    *,
+    city: str = "riyadh",
+    replace: bool = True,
+    bbox: dict[str, float] | None = None,
+    spacing_m: float = SPACING_M,
+    radius_m: int = RADIUS_M,
+    checkpoint_path: str = DEFAULT_CHECKPOINT_PATH,
+    write_stats_path: str | None = None,
+) -> dict[str, Any]:
+    """Run the Google Places parking ingest end-to-end against *db*.
+
+    Returns the stats dict that gets serialised to *write_stats_path*.
+    """
+    bbox = bbox if bbox is not None else RIYADH_BUILT_UP_BBOX
+    grid = generate_grid_points(bbox, spacing_m)
+    logger.info(
+        "Generated %d grid points for bbox=%s spacing_m=%s",
+        len(grid), bbox, spacing_m,
+    )
+
+    completed_cells = load_checkpoint(checkpoint_path)
+    if completed_cells:
+        logger.info("Resuming from checkpoint: %d cells already completed", len(completed_cells))
+
+    if replace and not completed_cells:
+        db.execute(
+            text(
+                "DELETE FROM expansion_parking_asset "
+                "WHERE city = :city AND source = 'google_places'"
+            ),
+            {"city": city},
+        )
+        db.commit()
+        logger.info(
+            "Replace mode: deleted existing source='google_places' rows for city=%s",
+            city,
+        )
+
+    pending = [(lat, lon, ck) for lat, lon, ck in grid if ck not in completed_cells]
+    total_pending = len(pending)
+
+    stats: dict[str, Any] = {
+        "grid_points_total": len(grid),
+        "grid_points_queried_successfully": 0,
+        "grid_points_with_results": 0,
+        "grid_points_empty": 0,
+        "grid_points_saturated_at_20": 0,
+        "unique_pois_found": 0,
+        "pois_inserted": 0,
+        "api_errors": 0,
+        "total_api_calls_billed": 0,
+    }
+    seen_place_ids: set[str] = set()
+
+    async with AsyncGooglePlacesClient() as client:
+        for batch_start in range(0, total_pending, CHECKPOINT_FLUSH_INTERVAL):
+            batch = pending[batch_start:batch_start + CHECKPOINT_FLUSH_INTERVAL]
+            tasks = [
+                _process_cell(
+                    client, ck, lat, lon, radius_m, seen_place_ids, stats,
+                )
+                for lat, lon, ck in batch
+            ]
+            batch_rows = await asyncio.gather(*tasks)
+
+            insert_params = [row for sublist in batch_rows for row in sublist]
+            if insert_params:
+                db.execute(INSERT_SQL, insert_params)
+                stats["pois_inserted"] += len(insert_params)
+
+            for _lat, _lon, ck in batch:
+                completed_cells.add(ck)
+            db.commit()
+            save_checkpoint(checkpoint_path, completed_cells)
+
+            processed = batch_start + len(batch)
+            if processed % PROGRESS_LOG_INTERVAL == 0 or processed == total_pending:
+                logger.info(
+                    "Processed %d/%d cells, %d unique POIs found so far",
+                    processed, total_pending, len(seen_place_ids),
+                )
+
+        stats["total_api_calls_billed"] = client.api_calls
+
+    stats["unique_pois_found"] = len(seen_place_ids)
+    stats["row_counts"] = log_table_counts(db, ["expansion_parking_asset"])
+
+    delete_checkpoint(checkpoint_path)
+    logger.info(
+        "Ingest complete: %d unique POIs, %d rows inserted, %d API calls, %d errors",
+        stats["unique_pois_found"], stats["pois_inserted"],
+        stats["total_api_calls_billed"], stats["api_errors"],
+    )
+
+    if write_stats_path:
+        write_stats(write_stats_path, stats)
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Expansion Advisor — Google Places parking ingest",
+    )
+    parser.add_argument("--city", default="riyadh", help="City filter (default: riyadh)")
+    parser.add_argument(
+        "--replace",
+        type=lambda v: v.lower() in ("true", "1", "yes"),
+        default=True,
+        help="Replace existing rows when no checkpoint is present (default: true)",
+    )
+    parser.add_argument("--write-stats", type=str, default=None, help="Write JSON stats to path")
+    parser.add_argument(
+        "--checkpoint-path",
+        type=str,
+        default=DEFAULT_CHECKPOINT_PATH,
+        help=f"Resumability checkpoint path (default: {DEFAULT_CHECKPOINT_PATH})",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    validate_db_env()
+
+    db = get_session()
+    try:
+        asyncio.run(
+            run_ingest(
+                db,
+                city=args.city,
+                replace=args.replace,
+                checkpoint_path=args.checkpoint_path,
+                write_stats_path=args.write_stats,
+            )
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_business_status_competitor_filter.py
+++ b/tests/test_business_status_competitor_filter.py
@@ -293,3 +293,20 @@ def test_place_details_fields_includes_business_status_async():
     ).read_text()
     # The async get_place_details fields string must request the field.
     assert "formatted_address,business_status" in src
+
+
+def test_async_client_has_nearby_search():
+    """AsyncGooglePlacesClient must expose nearby_search as an async method.
+
+    Guards the contract relied on by the Google Places parking ingest in
+    ``app/ingest/expansion_advisor_parking_google.py``.
+    """
+    import inspect
+
+    from app.connectors.google_places_async import AsyncGooglePlacesClient
+
+    method = getattr(AsyncGooglePlacesClient, "nearby_search", None)
+    assert method is not None, "AsyncGooglePlacesClient.nearby_search is missing"
+    assert inspect.iscoroutinefunction(method), (
+        "AsyncGooglePlacesClient.nearby_search must be an async coroutine function"
+    )

--- a/tests/test_expansion_advisor_data_pipeline.py
+++ b/tests/test_expansion_advisor_data_pipeline.py
@@ -547,6 +547,18 @@ class TestParkingModule:
         assert hasattr(mod, "_ingest_from_points")
 
 
+class TestParkingGoogleModule:
+    def test_parking_google_module_import(self):
+        import app.ingest.expansion_advisor_parking_google as mod
+
+        assert hasattr(mod, "main")
+        assert hasattr(mod, "run_ingest")
+        assert hasattr(mod, "generate_grid_points")
+        assert hasattr(mod, "load_checkpoint")
+        assert hasattr(mod, "save_checkpoint")
+        assert hasattr(mod, "delete_checkpoint")
+
+
 # ---------------------------------------------------------------------------
 # Migration
 # ---------------------------------------------------------------------------

--- a/tests/test_expansion_advisor_parking_google_ingest.py
+++ b/tests/test_expansion_advisor_parking_google_ingest.py
@@ -1,0 +1,378 @@
+"""Tests for Expansion Advisor — Google Places parking ingest.
+
+Mirrors the structure of ``tests/test_expansion_advisor_parking_ingest.py``
+but mocks ``AsyncGooglePlacesClient.nearby_search`` rather than executing
+real HTTP requests, and uses a tiny synthetic bounding box so the grid
+generation cost stays bounded.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.ingest.expansion_advisor_parking_google import (
+    RIYADH_BUILT_UP_BBOX,
+    SPACING_M,
+    delete_checkpoint,
+    generate_grid_points,
+    load_checkpoint,
+    run_ingest,
+    save_checkpoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A small bbox keeps tests fast (~3-4 cells with 500m spacing).
+SMALL_BBOX = {
+    "min_lon": 46.60,
+    "min_lat": 24.60,
+    "max_lon": 46.61,
+    "max_lat": 24.61,
+}
+
+
+def _mock_db():
+    """Return a MagicMock DB session that captures all execute() calls.
+
+    Mirrors the pattern in ``tests/test_expansion_advisor_parking_ingest.py``.
+    """
+    db = MagicMock()
+    executed: list[tuple[str, object]] = []
+
+    def execute_side(stmt, params=None):
+        sql_str = str(stmt)
+        executed.append((sql_str, params))
+        result = MagicMock()
+        # Make scalar() always return 0 so log_table_counts can do int(...)
+        result.scalar.return_value = 0
+        result.rowcount = len(params) if isinstance(params, list) else 0
+        return result
+
+    db.execute.side_effect = execute_side
+    db._executed = executed
+    return db
+
+
+def _empty_ok():
+    return {"status": "OK", "results": []}
+
+
+def _ok_with_results(results):
+    return {"status": "OK", "results": results}
+
+
+def _single_result(place_id="p1", name="Lot A", lat=24.605, lng=46.605):
+    return _ok_with_results([
+        {
+            "place_id": place_id,
+            "name": name,
+            "geometry": {"location": {"lat": lat, "lng": lng}},
+        }
+    ])
+
+
+def _run(
+    db,
+    response,
+    *,
+    checkpoint_path,
+    replace=True,
+    write_stats_path=None,
+    bbox=None,
+    side_effect=None,
+):
+    """Run ``run_ingest`` with ``nearby_search`` patched to *response*."""
+    with patch(
+        "app.ingest.expansion_advisor_parking_google.AsyncGooglePlacesClient.nearby_search",
+        new_callable=AsyncMock,
+    ) as mock_search:
+        if side_effect is not None:
+            mock_search.side_effect = side_effect
+        else:
+            mock_search.return_value = response
+        stats = asyncio.run(
+            run_ingest(
+                db,
+                city="riyadh",
+                replace=replace,
+                bbox=bbox if bbox is not None else SMALL_BBOX,
+                spacing_m=500,
+                radius_m=350,
+                checkpoint_path=checkpoint_path,
+                write_stats_path=write_stats_path,
+            )
+        )
+        return stats, mock_search
+
+
+# ---------------------------------------------------------------------------
+# 1. Grid generation
+# ---------------------------------------------------------------------------
+
+class TestGridGeneration:
+    def test_grid_generation_produces_expected_count(self):
+        grid = generate_grid_points(RIYADH_BUILT_UP_BBOX, SPACING_M)
+        # ~67 rows x 81 cols = 5,427 (endpoint inclusion math; budget 5,200–5,500)
+        assert 5_200 <= len(grid) <= 5_500
+        cell_keys = [ck for _lat, _lon, ck in grid]
+        assert len(cell_keys) == len(set(cell_keys))
+
+    def test_cell_key_format(self):
+        grid = generate_grid_points(RIYADH_BUILT_UP_BBOX, SPACING_M)
+        for lat, lon, ck in grid[:5]:
+            assert ck == f"{lat:.4f}_{lon:.4f}"
+
+    def test_grid_lat_lon_in_bbox(self):
+        grid = generate_grid_points(RIYADH_BUILT_UP_BBOX, SPACING_M)
+        for lat, lon, _ck in grid:
+            assert RIYADH_BUILT_UP_BBOX["min_lat"] <= lat <= RIYADH_BUILT_UP_BBOX["max_lat"]
+            assert RIYADH_BUILT_UP_BBOX["min_lon"] <= lon <= RIYADH_BUILT_UP_BBOX["max_lon"]
+
+    def test_small_bbox(self):
+        grid = generate_grid_points(SMALL_BBOX, 500)
+        assert 4 <= len(grid) <= 25
+
+
+# ---------------------------------------------------------------------------
+# 2. Checkpoint helpers
+# ---------------------------------------------------------------------------
+
+class TestCheckpoint:
+    def test_load_missing_returns_empty_set(self, tmp_path):
+        p = str(tmp_path / "missing.json")
+        assert load_checkpoint(p) == set()
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        p = str(tmp_path / "cp.json")
+        cells = {"24.6000_46.6000", "24.6050_46.6050"}
+        save_checkpoint(p, cells)
+        assert load_checkpoint(p) == cells
+
+    def test_delete_checkpoint_removes_file(self, tmp_path):
+        p = str(tmp_path / "cp.json")
+        save_checkpoint(p, {"a"})
+        assert os.path.exists(p)
+        delete_checkpoint(p)
+        assert not os.path.exists(p)
+
+    def test_delete_checkpoint_tolerates_missing(self, tmp_path):
+        p = str(tmp_path / "never_existed.json")
+        # Should not raise
+        delete_checkpoint(p)
+
+
+# ---------------------------------------------------------------------------
+# 3. Dedup within run
+# ---------------------------------------------------------------------------
+
+class TestDedup:
+    def test_dedup_within_run(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        # Every cell returns the same place_id → only one row should be inserted
+        stats, mock_search = _run(db, _single_result("PID_SHARED"), checkpoint_path=cp)
+        assert stats["pois_inserted"] == 1
+        assert stats["unique_pois_found"] == 1
+        # Every cell was still queried
+        grid = generate_grid_points(SMALL_BBOX, 500)
+        assert mock_search.call_count == len(grid)
+
+
+# ---------------------------------------------------------------------------
+# 4. Checkpoint skips completed cells
+# ---------------------------------------------------------------------------
+
+class TestCheckpointSkip:
+    def test_checkpoint_skips_completed_cells(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        grid = generate_grid_points(SMALL_BBOX, 500)
+        all_keys = [ck for _lat, _lon, ck in grid]
+        # Pre-complete all but the last cell
+        save_checkpoint(cp, set(all_keys[:-1]))
+
+        _stats, mock_search = _run(db, _empty_ok(), checkpoint_path=cp)
+        assert mock_search.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Checkpoint deleted on success
+# ---------------------------------------------------------------------------
+
+class TestCheckpointDeletedOnSuccess:
+    def test_checkpoint_deleted_on_success(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        _run(db, _empty_ok(), checkpoint_path=cp)
+        assert not os.path.exists(cp)
+
+
+# ---------------------------------------------------------------------------
+# 6. Replace logic
+# ---------------------------------------------------------------------------
+
+class TestReplaceLogic:
+    def test_replace_true_with_no_checkpoint_deletes_existing_rows(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        _run(db, _empty_ok(), checkpoint_path=cp, replace=True)
+        delete_stmts = [
+            sql for sql, _ in db._executed
+            if sql.strip().upper().startswith("DELETE")
+        ]
+        assert any("source = 'google_places'" in s for s in delete_stmts), (
+            "Expected DELETE … source='google_places' to run with replace=True and no checkpoint"
+        )
+
+    def test_replace_true_with_checkpoint_does_not_delete(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        save_checkpoint(cp, {"24.6000_46.6000"})  # checkpoint exists → resume mode
+        _run(db, _empty_ok(), checkpoint_path=cp, replace=True)
+        delete_stmts = [
+            sql for sql, _ in db._executed
+            if sql.strip().upper().startswith("DELETE")
+        ]
+        assert not any("source = 'google_places'" in s for s in delete_stmts), (
+            "DELETE must be skipped when a checkpoint indicates a resumed run"
+        )
+
+    def test_replace_false_does_not_delete(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        _run(db, _empty_ok(), checkpoint_path=cp, replace=False)
+        delete_stmts = [
+            sql for sql, _ in db._executed
+            if sql.strip().upper().startswith("DELETE")
+        ]
+        assert not any("source = 'google_places'" in s for s in delete_stmts)
+
+
+# ---------------------------------------------------------------------------
+# 7. Stats payload keys
+# ---------------------------------------------------------------------------
+
+class TestStatsPayloadKeys:
+    def test_stats_payload_keys(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        stats_path = str(tmp_path / "stats.json")
+        with patch(
+            "app.ingest.expansion_advisor_parking_google.log_table_counts",
+            return_value={"expansion_parking_asset": 0},
+        ):
+            _run(db, _empty_ok(), checkpoint_path=cp, write_stats_path=stats_path)
+        with open(stats_path) as f:
+            payload = json.load(f)
+        required = [
+            "grid_points_total",
+            "grid_points_queried_successfully",
+            "grid_points_with_results",
+            "grid_points_empty",
+            "grid_points_saturated_at_20",
+            "unique_pois_found",
+            "pois_inserted",
+            "api_errors",
+            "total_api_calls_billed",
+        ]
+        for key in required:
+            assert key in payload, f"missing stats key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# 8. API error status increments counter
+# ---------------------------------------------------------------------------
+
+class TestApiErrorStatus:
+    def test_api_error_status_increments_counter(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        with patch(
+            "app.ingest.expansion_advisor_parking_google.log_table_counts",
+            return_value={},
+        ):
+            stats, _ = _run(
+                db, {"status": "OVER_QUERY_LIMIT", "results": []},
+                checkpoint_path=cp,
+            )
+        grid = generate_grid_points(SMALL_BBOX, 500)
+        assert stats["api_errors"] == len(grid)
+        assert stats["pois_inserted"] == 0
+        # No INSERT statements should have been executed
+        insert_stmts = [
+            sql for sql, _ in db._executed
+            if sql.strip().upper().startswith("INSERT")
+        ]
+        assert insert_stmts == []
+
+
+# ---------------------------------------------------------------------------
+# 9. Saturation at 20 tracked
+# ---------------------------------------------------------------------------
+
+class TestSaturation:
+    def test_saturation_at_20_tracked(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        results = [
+            {
+                "place_id": f"p{i}",
+                "name": f"Lot {i}",
+                "geometry": {"location": {"lat": 24.6 + i * 0.0001, "lng": 46.6 + i * 0.0001}},
+            }
+            for i in range(20)
+        ]
+        with patch(
+            "app.ingest.expansion_advisor_parking_google.log_table_counts",
+            return_value={},
+        ):
+            stats, _ = _run(db, _ok_with_results(results), checkpoint_path=cp)
+        grid = generate_grid_points(SMALL_BBOX, 500)
+        # Every cell returned 20 results → every cell counts as saturated
+        assert stats["grid_points_saturated_at_20"] == len(grid)
+
+
+# ---------------------------------------------------------------------------
+# 10. Module presence / shape
+# ---------------------------------------------------------------------------
+
+class TestModulePresence:
+    def test_module_exports(self):
+        import app.ingest.expansion_advisor_parking_google as mod
+
+        for attr in (
+            "main",
+            "run_ingest",
+            "generate_grid_points",
+            "load_checkpoint",
+            "save_checkpoint",
+            "delete_checkpoint",
+            "RIYADH_BUILT_UP_BBOX",
+            "SPACING_M",
+            "RADIUS_M",
+        ):
+            assert hasattr(mod, attr), f"missing module attribute: {attr}"
+
+
+# ---------------------------------------------------------------------------
+# 11. Empty-DB safety
+# ---------------------------------------------------------------------------
+
+class TestEmptyRunSafety:
+    def test_runs_clean_with_no_results_anywhere(self, tmp_path):
+        db = _mock_db()
+        cp = str(tmp_path / "cp.json")
+        stats_path = str(tmp_path / "stats.json")
+        with patch(
+            "app.ingest.expansion_advisor_parking_google.log_table_counts",
+            return_value={"expansion_parking_asset": 0},
+        ):
+            stats, _ = _run(db, _empty_ok(), checkpoint_path=cp, write_stats_path=stats_path)
+        assert stats["pois_inserted"] == 0
+        assert stats["unique_pois_found"] == 0
+        assert stats["api_errors"] == 0


### PR DESCRIPTION
## Summary

OSM coverage of Riyadh parking is sparse (~1,200 polygons + ~30 points). A 50-candidate Google Places probe showed Google has parking POIs for **~98% of OSM-empty candidates**, avg 12.28 POIs per query, with 50% saturating at the 20-result API cap. This PR adds a grid-driven Google Places parking ingest as a new source feeding into the existing `expansion_parking_asset` table.

## Architecture

- **Same table, new source.** `source='google_places'` rows in `expansion_parking_asset`. No new table, no schema change. `_parking_score` reads (`app/services/expansion_advisor.py:2136-2143` and `:8206-8211`) pick them up automatically — neither filters by `source`.
- **Grid-driven.** Tightened bbox `(46.55, 24.55) → (46.95, 24.85)` (built-up Riyadh, excludes desert fringe), 500m cosine-corrected spacing → **5,427 query points**. Cap at 20 results per call, no `next_page_token` pagination (saturation at 20 is itself a useful signal; `_parking_score` plateaus at count=6 anyway).
- **App-level dedup on `place_id`** via in-process `set[str]`. Many grid points see the same lot; only the first inserts it.
- **Resumable.** JSON checkpoint at `/tmp/google_parking_checkpoint.json` flushed every 100 cells. On startup, completed cells are skipped. Checkpoint is deleted on successful completion; uploaded as a workflow artifact on failure for safe restart.
- **Replace logic preserves resumed work.** `--replace=True` triggers `DELETE … source='google_places'` only when no checkpoint is present; resumed runs never wipe their own in-progress writes.
- **`AsyncGooglePlacesClient.nearby_search()` is new** — reuses the existing token-bucket (8 QPS), semaphore (20 concurrent), and 1.5×2^n retry logic. No new dependencies, no parallel rate-limit code.
- **Honest defaults for Google-unknown columns:** `amenity_type='unknown'`, `capacity=NULL`, `covered=NULL`, `public_access=NULL`. Flat `walk_access_score=65.0` and `dropoff_score=55.0` match the OSM ingest's `ELSE` branches. None of the EPA read queries filter on `public_access` or `covered`, so `NULL` is safe.
- **No cross-source dedup.** A lot mapped in both OSM and Google may count twice; impact is bounded because the parking-score curve saturates at count=6.

## Cost

- **Bootstrap run:** ~5,427 calls × ~$0.032/call ≈ **$174 one-shot.**
- **Steady-state:** 2 runs/year × 5,427 calls ≈ **$29/month amortised.**
- Runtime: ~11–15 min wall time at 8 QPS (well inside the 60-min workflow timeout).

## Resumability behaviour

| Scenario | What happens |
|---|---|
| First run, no checkpoint | DELETE existing `source='google_places'` rows (if `--replace=true`), query all 5,427 cells, write checkpoint every 100, delete checkpoint on completion |
| Crashes mid-run | Checkpoint persisted at last 100-cell flush. Workflow artifact `google-parking-checkpoint` is uploaded on failure |
| Restart after crash | Loads checkpoint, **skips the DELETE step** (so prior partial inserts are preserved), queries only the remaining cells |
| Clean completion | Checkpoint deleted, full run verified by stats artifact |

## Files

| Change | File |
|---|---|
| Modified | `app/connectors/google_places_async.py` — new `nearby_search()` method |
| New | `app/ingest/expansion_advisor_parking_google.py` — ingest module |
| New | `.github/workflows/expansion-advisor-data-parking-google.yml` — cron + manual workflow |
| New | `tests/test_expansion_advisor_parking_google_ingest.py` — 19 tests |
| Modified | `tests/test_business_status_competitor_filter.py` — adds `test_async_client_has_nearby_search` |
| Modified | `tests/test_expansion_advisor_data_pipeline.py` — adds `TestParkingGoogleModule` import-presence test |

## Test plan

- [x] `tests/test_expansion_advisor_parking_google_ingest.py` — 19 tests, all green locally. Cover: grid count (~5,427), checkpoint roundtrip, dedup within run, checkpoint skip on resume, checkpoint deletion on success, replace logic (with + without checkpoint, with `replace=False`), stats payload keys present, API-error status counted, saturation-at-20 tracked, empty-run safety, module shape.
- [x] `test_async_client_has_nearby_search` — guards the connector contract.
- [x] No regressions: `test_expansion_advisor_parking_ingest.py` (42 passed), `test_expansion_advisor_data_pipeline.py` (72 passed), `test_business_status_competitor_filter.py` (all passed).

## Rollout TODO (for the reviewer / Ahmed)

1. Add `GOOGLE_PLACES_API_KEY` to repo secrets (matches the env var name used by the existing connector).
2. Set a GCP billing alert at **$50 above current monthly baseline**.
3. Set GCP daily quota on Places API to **10,000 requests/day** (gives ~2× headroom over the 5,427-call bootstrap).
4. Trigger the workflow manually for the first bootstrap run via `workflow_dispatch`.
5. After successful bootstrap, run Codespace validation queries:
   ```sql
   SELECT source, COUNT(*) FROM expansion_parking_asset GROUP BY source;
   -- Expect: osm_polygon ≈ 1,197 | osm_point ≈ 30 | google_places ≈ 30,000+
   ```
6. Spot-check 3–5 candidates' `parking_score` after their next re-scoring run to confirm Google rows are being counted (expect a meaningful uplift on OSM-empty candidates).

## Risk

- **Low blast radius.** New ingest writes to existing table with a new `source` value; no service changes, no migrations.
- **API spend** is the main risk; quota cap (rollout step 3) bounds it.
- **No merge until reviewed.** Hold for explicit approval — Codespace validation runs after merge.

https://claude.ai/code/session_01W7M3TbsYDscydypE5KJx3Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7M3TbsYDscydypE5KJx3Z)_