### PR TITLE
feat(expansion-advisor): raise candidate pool limit to 3500 ahead of Bayut

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -39,7 +39,8 @@ logger = logging.getLogger(__name__)
 ARCGIS_PARCELS_TABLE = "public.riyadh_parcels_arcgis_proxy"
 
 # Candidate pool limits
-_CANDIDATE_POOL_LIMIT = 2000         # max total candidates from SQL
+_CANDIDATE_POOL_LIMIT = 3500         # pre-filter ceiling for the multi-platform candidate pool;
+                                     # sized for ~2x current Aqar volume plus headroom for Bayut
 _PER_DISTRICT_MIN_CAP = 5            # minimum parcels per district in stratified mode
 _PER_DISTRICT_MAX_CAP = 200          # upper bound per district — raised for listings-only pool
 _PER_DISTRICT_HEADROOM_MULTIPLIER = 3  # pull 3x the fair share per district

--- a/tests/test_expansion_per_district_cap.py
+++ b/tests/test_expansion_per_district_cap.py
@@ -17,6 +17,7 @@ import pytest
 
 from app.services import expansion_advisor as expansion_service
 from app.services.expansion_advisor import (
+    _CANDIDATE_POOL_LIMIT,
     _PER_DISTRICT_HEADROOM_MULTIPLIER,
     _PER_DISTRICT_MAX_CAP,
     _PER_DISTRICT_MIN_CAP,
@@ -252,6 +253,13 @@ def test_city_wide_branch_unchanged(caplog: pytest.LogCaptureFixture) -> None:
 def test_headroom_multiplier_constant_value() -> None:
     # Locks the multiplier so future tweaks cause a visible test break.
     assert expansion_service._PER_DISTRICT_HEADROOM_MULTIPLIER == 3
+
+
+def test_candidate_pool_limit_is_3500() -> None:
+    # Locks the outer candidate-pool ceiling so an accidental revert is
+    # caught at test time. Raised from 2000 ahead of Bayut ingest so the
+    # combined Aqar+Bayut pool has comfortable headroom.
+    assert _CANDIDATE_POOL_LIMIT == 3500
 
 
 _CL_LOG_RE = re.compile(


### PR DESCRIPTION
Bumps _CANDIDATE_POOL_LIMIT from 2000 to 3500 so the outer SQL pool ceiling
has comfortable headroom for the combined Aqar+Bayut listing universe.

Rationale: today's Aqar-only active commercial_unit count is ~1,805; Bayut
adds ~1,729 Riyadh commercial-rent listings, and the deduped combined pool
is plausibly close to the existing 2000 ceiling. 3500 is ~2x current Aqar
volume with headroom — high enough to absorb Bayut without truncation, low
enough to still surface a real bug if the pool ever balloons.

No behavioral change today; enables PR4 (Bayut ingest).