### PR TITLE
feat(schema): add platform and platform_listing_id columns to commercial_unit

### DIFF
--- a/alembic/versions/20260525_commercial_unit_platform_columns.py
+++ b/alembic/versions/20260525_commercial_unit_platform_columns.py
@@ -1,0 +1,86 @@
+"""Add platform and platform_listing_id columns to commercial_unit.
+
+PR2 of the multi-portal series. Additive widen so the table can hold
+rows from multiple portals (Aqar today, Bayut in PR4) while keeping
+every existing reader query unchanged.
+
+- ``platform``           VARCHAR(16)  NOT NULL — portal discriminator.
+                                                 Backfilled to ``'aqar'``
+                                                 for every existing row
+                                                 via the temporary
+                                                 server_default.
+- ``platform_listing_id`` VARCHAR(128) NOT NULL — portal-native listing
+                                                  id. Backfilled from
+                                                  ``aqar_id`` for every
+                                                  existing row, then
+                                                  tightened to NOT NULL.
+
+A unique index on ``(platform, platform_listing_id)`` enforces the
+"every (portal, portal_listing_id) pair is globally unique" invariant
+and will be the conflict target for Bayut rows in PR4. A separate
+non-unique index on ``platform`` alone supports cheap per-platform
+analytics.
+
+The server_default on ``platform`` is dropped after the column is
+populated so the application layer is authoritative going forward —
+matches the post-backfill pattern used elsewhere in this table's
+history.
+
+Revision ID: 20260525_cu_platform_cols
+Revises: 20260522_poi_business_status
+Create Date: 2026-05-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260525_cu_platform_cols"
+down_revision = "20260522_poi_business_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "commercial_unit",
+        sa.Column(
+            "platform",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'aqar'"),
+        ),
+    )
+    op.add_column(
+        "commercial_unit",
+        sa.Column("platform_listing_id", sa.String(length=128), nullable=True),
+    )
+    op.execute(
+        "UPDATE commercial_unit "
+        "SET platform_listing_id = aqar_id "
+        "WHERE platform_listing_id IS NULL"
+    )
+    op.alter_column("commercial_unit", "platform_listing_id", nullable=False)
+    op.create_index(
+        "ix_commercial_unit_platform_listing_id",
+        "commercial_unit",
+        ["platform", "platform_listing_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_commercial_unit_platform",
+        "commercial_unit",
+        ["platform"],
+        unique=False,
+    )
+    # Application layer is the source of truth from here on.
+    op.alter_column("commercial_unit", "platform", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_commercial_unit_platform", table_name="commercial_unit")
+    op.drop_index(
+        "ix_commercial_unit_platform_listing_id", table_name="commercial_unit"
+    )
+    op.drop_column("commercial_unit", "platform_listing_id")
+    op.drop_column("commercial_unit", "platform")

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -449,6 +449,8 @@ class CommercialUnit(Base):
     aqar_area_deed = Column(Numeric(10, 2))
     aqar_listing_source = Column(Text)
     aqar_detail_scraped_at = Column(DateTime(timezone=True))
+    platform = Column(String(16), nullable=False)
+    platform_listing_id = Column(String(128), nullable=False)
 
     __table_args__ = (
         Index("ix_commercial_unit_neighborhood", "neighborhood"),
@@ -479,6 +481,13 @@ class CommercialUnit(Base):
             "aqar_id",
             postgresql_where=text("aqar_detail_scraped_at IS NULL"),
         ),
+        Index(
+            "ix_commercial_unit_platform_listing_id",
+            "platform",
+            "platform_listing_id",
+            unique=True,
+        ),
+        Index("ix_commercial_unit_platform", "platform"),
     )
 
 

--- a/scripts/scrape_aqar.py
+++ b/scripts/scrape_aqar.py
@@ -1498,6 +1498,8 @@ def upsert_listing(db, listing: dict) -> str:
                 "aqar_area_deed = COALESCE(:aqar_area_deed, commercial_unit.aqar_area_deed), "
                 "aqar_listing_source = COALESCE(:aqar_listing_source, commercial_unit.aqar_listing_source), "
                 "aqar_detail_scraped_at = COALESCE(:aqar_detail_scraped_at, commercial_unit.aqar_detail_scraped_at), "
+                "platform = :platform, "
+                "platform_listing_id = :platform_listing_id, "
                 "status = 'active', last_seen_at = now() "
                 "WHERE aqar_id = :aqar_id"
             ),
@@ -1519,6 +1521,7 @@ def upsert_listing(db, listing: dict) -> str:
                 "aqar_created_at, aqar_updated_at, aqar_views, "
                 "aqar_advertisement_license, aqar_license_expiry, aqar_plan_parcel, "
                 "aqar_area_deed, aqar_listing_source, aqar_detail_scraped_at, "
+                "platform, platform_listing_id, "
                 "status, first_seen_at, last_seen_at) "
                 "VALUES (:aqar_id, :title, :description, :neighborhood, :listing_url, :image_url, "
                 ":price_sar_annual, :price_per_sqm, :area_sqm, :street_width_m, "
@@ -1531,6 +1534,7 @@ def upsert_listing(db, listing: dict) -> str:
                 ":aqar_created_at, :aqar_updated_at, :aqar_views, "
                 ":aqar_advertisement_license, :aqar_license_expiry, :aqar_plan_parcel, "
                 ":aqar_area_deed, :aqar_listing_source, :aqar_detail_scraped_at, "
+                ":platform, :platform_listing_id, "
                 "'active', now(), now())"
             ),
             _listing_params(listing),
@@ -1540,8 +1544,11 @@ def upsert_listing(db, listing: dict) -> str:
 
 def _listing_params(listing: dict) -> dict:
     """Build parameter dict for SQL statements from a listing dict."""
+    aqar_id = listing.get("aqar_id")
     return {
-        "aqar_id": listing.get("aqar_id"),
+        "aqar_id": aqar_id,
+        "platform": "aqar",
+        "platform_listing_id": aqar_id,
         "title": listing.get("title"),
         "description": listing.get("description"),
         "neighborhood": listing.get("neighborhood"),

--- a/tests/test_commercial_unit_platform_columns.py
+++ b/tests/test_commercial_unit_platform_columns.py
@@ -1,0 +1,161 @@
+"""Regression tests for PR2 — ``platform`` and ``platform_listing_id``
+on ``commercial_unit``.
+
+PR2 widens the table additively so it can hold rows from multiple
+portals (Aqar today, Bayut in PR4). These tests pin three invariants:
+
+1. Every Aqar upsert — INSERT and UPDATE branches — sets
+   ``platform='aqar'`` and ``platform_listing_id=aqar_id``.
+2. The unique index ``ix_commercial_unit_platform_listing_id`` exists
+   on the model with the correct shape so PR4's Bayut writer can rely
+   on it as a conflict target.
+3. The ORM exposes ``platform`` and ``platform_listing_id`` as
+   non-nullable attributes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class _FakeResult:
+    def __init__(self, scalar_value: Any = None, rowcount: int = 0) -> None:
+        self._scalar = scalar_value
+        self.rowcount = rowcount
+
+    def scalar(self) -> Any:
+        return self._scalar
+
+    def first(self) -> Any:
+        return self._scalar
+
+
+class _FakeDB:
+    """Records ``execute`` calls and returns canned results in order."""
+
+    def __init__(self, results: list[_FakeResult]) -> None:
+        self._results = list(results)
+        self.calls: list[tuple[str, dict]] = []
+
+    def execute(self, stmt, params=None):
+        self.calls.append((str(stmt), dict(params or {})))
+        return self._results.pop(0)
+
+
+_BASE_LISTING: dict[str, Any] = {
+    "aqar_id": "1234567",
+    "title": "Test store",
+    "description": "Some description",
+    "neighborhood": "olaya",
+    "listing_url": "https://aqar.fm/x/1234567",
+    "image_url": "https://aqar.fm/img.jpg",
+    "price_sar_annual": 240000,
+    "area_sqm": 200,
+    "street_width_m": 12,
+    "num_floors": 1,
+    "has_mezzanine": False,
+    "has_drive_thru": False,
+    "facade_direction": "north",
+    "contact_phone": "0500000000",
+    "listing_type": "store",
+    "property_type": "Commercial",
+    "is_furnished": False,
+    "apartments_count": None,
+    "num_rooms": None,
+    "lat": 24.7,
+    "lon": 46.7,
+    "restaurant_score": 80,
+    "restaurant_suitable": True,
+    "restaurant_signals": [],
+}
+
+
+class TestUpsertListingSetsPlatformColumns:
+    """upsert_listing writes platform='aqar' and platform_listing_id=aqar_id."""
+
+    def test_insert_branch_includes_platform_columns(self):
+        from scripts.scrape_aqar import upsert_listing
+
+        # First call: SELECT existing row → returns None (no match).
+        # Second call: INSERT.
+        select_result = _FakeResult(scalar_value=None)
+        select_result.first = lambda: None  # type: ignore[assignment]
+        db = _FakeDB([select_result, _FakeResult(rowcount=1)])
+
+        action = upsert_listing(db, dict(_BASE_LISTING))
+
+        assert action == "insert"
+        assert len(db.calls) == 2
+        insert_sql, insert_params = db.calls[1]
+        assert "INSERT INTO commercial_unit" in insert_sql
+        assert "platform" in insert_sql
+        assert "platform_listing_id" in insert_sql
+        assert ":platform" in insert_sql
+        assert ":platform_listing_id" in insert_sql
+        assert insert_params["platform"] == "aqar"
+        assert insert_params["platform_listing_id"] == "1234567"
+        assert insert_params["aqar_id"] == "1234567"
+
+    def test_update_branch_includes_platform_columns(self):
+        from scripts.scrape_aqar import upsert_listing
+
+        # First call: SELECT existing row → returns a truthy row.
+        select_result = _FakeResult(scalar_value=("1234567",))
+        select_result.first = lambda: ("1234567",)  # type: ignore[assignment]
+        db = _FakeDB([select_result, _FakeResult(rowcount=1)])
+
+        action = upsert_listing(db, dict(_BASE_LISTING))
+
+        assert action == "update"
+        assert len(db.calls) == 2
+        update_sql, update_params = db.calls[1]
+        assert "UPDATE commercial_unit SET" in update_sql
+        assert "platform = :platform" in update_sql
+        assert "platform_listing_id = :platform_listing_id" in update_sql
+        assert update_params["platform"] == "aqar"
+        assert update_params["platform_listing_id"] == "1234567"
+
+    def test_platform_listing_id_tracks_aqar_id(self):
+        """platform_listing_id is sourced from aqar_id, not a separate field."""
+        from scripts.scrape_aqar import _listing_params
+
+        params = _listing_params({"aqar_id": "99999999"})
+        assert params["platform"] == "aqar"
+        assert params["platform_listing_id"] == "99999999"
+        assert params["aqar_id"] == "99999999"
+
+
+class TestCommercialUnitModelAttributes:
+    """ORM exposes the new columns and the unique index."""
+
+    def test_model_has_platform_and_platform_listing_id_columns(self):
+        from app.models.tables import CommercialUnit
+
+        cols = CommercialUnit.__table__.columns
+        assert "platform" in cols
+        assert "platform_listing_id" in cols
+        assert cols["platform"].nullable is False
+        assert cols["platform_listing_id"].nullable is False
+        # VARCHAR length sanity — guards against accidental shrink.
+        assert cols["platform"].type.length == 16
+        assert cols["platform_listing_id"].type.length == 128
+
+    def test_unique_index_on_platform_listing_id_pair(self):
+        """PR4's Bayut writer will use this as a conflict target."""
+        from app.models.tables import CommercialUnit
+
+        indexes = {ix.name: ix for ix in CommercialUnit.__table__.indexes}
+        ix = indexes.get("ix_commercial_unit_platform_listing_id")
+        assert ix is not None, "missing unique index on (platform, platform_listing_id)"
+        assert ix.unique is True
+        col_names = [c.name for c in ix.columns]
+        assert col_names == ["platform", "platform_listing_id"]
+
+    def test_non_unique_index_on_platform_alone(self):
+        from app.models.tables import CommercialUnit
+
+        indexes = {ix.name: ix for ix in CommercialUnit.__table__.indexes}
+        ix = indexes.get("ix_commercial_unit_platform")
+        assert ix is not None
+        assert ix.unique is False
+        assert [c.name for c in ix.columns] == ["platform"]


### PR DESCRIPTION
PR2 of the multi-portal series — additive widen so the table can hold
rows from multiple portals (Aqar today, Bayut in PR4).

No reader changes: every SELECT against commercial_unit uses an explicit
column list, so the additive widen is invisible to readers.

Aqar writer (scripts/scrape_aqar.py::upsert_listing) updated to set the
new columns explicitly on both INSERT and UPDATE branches with
platform='aqar' and platform_listing_id=aqar_id.