### PR TITLE
feat(ingest): cross-portal REGA-license dedup at candidate_location stage

### DIFF
--- a/alembic/versions/20260526_candidate_location_rega_license.py
+++ b/alembic/versions/20260526_candidate_location_rega_license.py
@@ -1,0 +1,63 @@
+"""Add ``rega_advertisement_license`` to ``candidate_location``.
+
+PR3 of the multi-portal series. The dedup pass in
+``app/ingest/candidate_locations.py::_run_deduplication`` needs an
+on-row REGA-license signal so it can collapse two Tier 1 rows that
+describe the same physical unit on two different portals (Aqar today,
+Bayut in PR4). The license already lives on ``commercial_unit`` as
+``aqar_advertisement_license``; this migration denormalizes it onto
+``candidate_location`` so the dedup query is single-table.
+
+- ``rega_advertisement_license`` VARCHAR(64) NULL — sparse (~95.5%
+  coverage on active Tier 1 rows).
+- Backfill from ``commercial_unit.aqar_advertisement_license`` via the
+  existing ``(source_tier=1, source_id=aqar_id)`` mapping.
+- Partial index on the non-NULL subset because the column is sparse.
+
+No NOT NULL constraint — the column is genuinely optional (~4.5% of
+Aqar rows lack a license, and Bayut coverage will be measured in PR4).
+
+Revision ID: 20260526_cl_rega_license
+Revises: 20260525_cu_platform_cols
+Create Date: 2026-05-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260526_cl_rega_license"
+down_revision = "20260525_cu_platform_cols"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "candidate_location",
+        sa.Column("rega_advertisement_license", sa.String(length=64), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE candidate_location
+           SET rega_advertisement_license = cu.aqar_advertisement_license
+          FROM commercial_unit cu
+         WHERE candidate_location.source_tier = 1
+           AND candidate_location.source_id = cu.aqar_id
+           AND candidate_location.rega_advertisement_license IS NULL
+        """
+    )
+    op.create_index(
+        "ix_candidate_location_rega_license",
+        "candidate_location",
+        ["rega_advertisement_license"],
+        unique=False,
+        postgresql_where=sa.text("rega_advertisement_license IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_candidate_location_rega_license", table_name="candidate_location"
+    )
+    op.drop_column("candidate_location", "rega_advertisement_license")

--- a/app/ingest/candidate_locations.py
+++ b/app/ingest/candidate_locations.py
@@ -56,6 +56,7 @@ def _ingest_tier1_aqar(db: Session, run_id: str) -> int:
             listing_url, listing_type, image_url,
             is_vacant,
             street_width_m, has_drive_thru,
+            rega_advertisement_license,
             population_run_id
         )
         SELECT
@@ -72,6 +73,7 @@ def _ingest_tier1_aqar(db: Session, run_id: str) -> int:
             cu.listing_url, cu.listing_type, cu.image_url,
             TRUE,
             cu.street_width_m, cu.has_drive_thru,
+            cu.aqar_advertisement_license,
             :run_id
         FROM commercial_unit cu
         WHERE cu.status = 'active'
@@ -285,14 +287,156 @@ def _run_deduplication(db: Session, run_id: str) -> int:
     """), {"run_id": run_id})
 
     # Step 1: Mark ALL Tier 1 candidates as primary.
-    # Each real listing (Aqar, etc.) is a distinct rentable unit and must never
-    # be collapsed by spatial dedup — multiple units legitimately exist within 50m
-    # in dense commercial areas of Riyadh.
+    # Each real listing is a distinct rentable unit and must not be collapsed
+    # by spatial dedup — multiple units legitimately exist within 50m in
+    # dense commercial areas of Riyadh. The cross-portal collapses in Step
+    # 1a and Step 1b below DEMOTE the duplicates of a physical unit that
+    # appears on more than one portal (Aqar today, Bayut in PR4); they do
+    # not change the Aqar-only behavior because REGA licenses are unique
+    # per row when only one portal is present.
     db.execute(text("""
         UPDATE candidate_location
         SET is_cluster_primary = TRUE
         WHERE population_run_id = :run_id
           AND source_tier = 1
+    """), {"run_id": run_id})
+
+    # Step 1a: Cross-portal REGA-license dedup.
+    # When two Tier 1 rows share the same REGA advertisement license
+    # (case-insensitive, whitespace-stripped), they describe the same
+    # physical unit. Keep one primary per license group; demote the rest.
+    # Tiebreak: Aqar wins → commercial_unit.last_seen_at DESC → id ASC.
+    db.execute(text("""
+        WITH license_groups AS (
+            SELECT
+                cl.id,
+                COUNT(*) OVER (
+                    PARTITION BY cl.population_run_id,
+                                 LOWER(TRIM(cl.rega_advertisement_license))
+                ) AS group_size,
+                ROW_NUMBER() OVER (
+                    PARTITION BY cl.population_run_id,
+                                 LOWER(TRIM(cl.rega_advertisement_license))
+                    ORDER BY (cl.source_type = 'aqar') DESC,
+                             cu.last_seen_at DESC NULLS LAST,
+                             cl.id ASC
+                ) AS rn
+            FROM candidate_location cl
+            LEFT JOIN commercial_unit cu
+                   ON cu.platform = cl.source_type
+                  AND cu.platform_listing_id = cl.source_id
+            WHERE cl.population_run_id = :run_id
+              AND cl.source_tier = 1
+              AND cl.rega_advertisement_license IS NOT NULL
+              AND TRIM(cl.rega_advertisement_license) <> ''
+        )
+        UPDATE candidate_location cl
+           SET is_cluster_primary = FALSE
+          FROM license_groups lg
+         WHERE cl.id = lg.id
+           AND lg.group_size > 1
+           AND lg.rn > 1
+    """), {"run_id": run_id})
+
+    # Step 1b: Fingerprint fallback for Tier 1 rows where the REGA license
+    # is missing on one or both sides. Two rows match the same physical
+    # unit if they are within 25 m AND area_sqm differs by ≤5% AND
+    # rent_sar_annual differs by ≤5%. NULL/zero on either side prevents
+    # any match (silent NULL-vs-NULL match would be a false positive).
+    #
+    # Resolution uses connected components: if A↔B and B↔C all match,
+    # the trio collapses to a single primary. The component representative
+    # is computed iteratively (each member adopts the minimum id in its
+    # match set until the set stabilises), then within each component the
+    # same Aqar-wins / last_seen_at / id-ASC tiebreak applies.
+    db.execute(text("""
+        WITH fingerprint_pairs AS (
+            SELECT cl1.id AS a_id, cl2.id AS b_id
+              FROM candidate_location cl1
+              JOIN candidate_location cl2
+                ON cl1.population_run_id = cl2.population_run_id
+               AND cl1.id < cl2.id
+             WHERE cl1.population_run_id = :run_id
+               AND cl1.source_tier = 1
+               AND cl2.source_tier = 1
+               AND cl1.is_cluster_primary = TRUE
+               AND cl2.is_cluster_primary = TRUE
+               AND cl1.geom IS NOT NULL
+               AND cl2.geom IS NOT NULL
+               AND ST_DWithin(cl1.geom::geography, cl2.geom::geography, 25.0)
+               AND cl1.area_sqm IS NOT NULL
+               AND cl2.area_sqm IS NOT NULL
+               AND cl1.area_sqm > 0
+               AND cl2.area_sqm > 0
+               AND ABS(cl1.area_sqm - cl2.area_sqm)
+                   / GREATEST(cl1.area_sqm, cl2.area_sqm) <= 0.05
+               AND cl1.rent_sar_annual IS NOT NULL
+               AND cl2.rent_sar_annual IS NOT NULL
+               AND cl1.rent_sar_annual > 0
+               AND cl2.rent_sar_annual > 0
+               AND ABS(cl1.rent_sar_annual - cl2.rent_sar_annual)
+                   / GREATEST(cl1.rent_sar_annual, cl2.rent_sar_annual) <= 0.05
+               -- Only fire when the REGA pass did NOT already own this pair:
+               -- skip when both sides have non-empty REGA licenses.
+               AND (cl1.rega_advertisement_license IS NULL
+                    OR TRIM(cl1.rega_advertisement_license) = ''
+                    OR cl2.rega_advertisement_license IS NULL
+                    OR TRIM(cl2.rega_advertisement_license) = '')
+        ),
+        edges AS (
+            -- Undirected edges as bidirectional rows so reachability is symmetric.
+            SELECT a_id AS src, b_id AS dst FROM fingerprint_pairs
+            UNION ALL
+            SELECT b_id AS src, a_id AS dst FROM fingerprint_pairs
+        ),
+        components AS (
+            -- Transitive closure: each candidate node's component label is
+            -- the minimum id reachable via edges (including itself). Caps
+            -- depth at 32 hops — Tier 1 fingerprint clusters are tiny in
+            -- practice (typically 2, rarely 3); the cap protects against
+            -- pathological input.
+            SELECT id AS node, id AS root, 0 AS depth
+              FROM candidate_location
+             WHERE population_run_id = :run_id
+               AND source_tier = 1
+               AND is_cluster_primary = TRUE
+            UNION
+            SELECT e.src, LEAST(c.root, e.dst), c.depth + 1
+              FROM components c
+              JOIN edges e ON e.src = c.node
+             WHERE c.depth < 32
+        ),
+        component_root AS (
+            SELECT node, MIN(root) AS root_id
+              FROM components
+             GROUP BY node
+        ),
+        ranked AS (
+            SELECT
+                cl.id,
+                cr.root_id,
+                COUNT(*) OVER (PARTITION BY cr.root_id) AS component_size,
+                ROW_NUMBER() OVER (
+                    PARTITION BY cr.root_id
+                    ORDER BY (cl.source_type = 'aqar') DESC,
+                             cu.last_seen_at DESC NULLS LAST,
+                             cl.id ASC
+                ) AS rn
+              FROM candidate_location cl
+              JOIN component_root cr ON cr.node = cl.id
+              LEFT JOIN commercial_unit cu
+                     ON cu.platform = cl.source_type
+                    AND cu.platform_listing_id = cl.source_id
+             WHERE cl.population_run_id = :run_id
+               AND cl.source_tier = 1
+               AND cl.is_cluster_primary = TRUE
+        )
+        UPDATE candidate_location cl
+           SET is_cluster_primary = FALSE
+          FROM ranked r
+         WHERE cl.id = r.id
+           AND r.component_size > 1
+           AND r.rn > 1
     """), {"run_id": run_id})
 
     # Step 2: For clusters with NO Tier 1 candidates, pick the best Tier 2/3

--- a/app/models/tables.py
+++ b/app/models/tables.py
@@ -553,6 +553,12 @@ class CandidateLocation(Base):
     cluster_id = Column(Integer)
     is_cluster_primary = Column(Boolean, server_default=text("TRUE"))
 
+    # Cross-portal dedup signal (PR3): same physical unit can appear on
+    # multiple portals (Aqar today, Bayut in PR4) with the same REGA
+    # license. Denormalized from commercial_unit.aqar_advertisement_license
+    # so _run_deduplication is a single-table query.
+    rega_advertisement_license = Column(String(64), nullable=True)
+
     # Profitability model
     profitability_score = Column(Numeric(5, 2))
     success_proxy = Column(Numeric(5, 2))
@@ -574,6 +580,11 @@ class CandidateLocation(Base):
         Index("ix_cl_current_category", "current_category"),
         Index("ix_cl_rent_confidence", "rent_confidence"),
         Index("ix_cl_profitability", "profitability_score"),
+        Index(
+            "ix_candidate_location_rega_license",
+            "rega_advertisement_license",
+            postgresql_where=text("rega_advertisement_license IS NOT NULL"),
+        ),
     )
 
 

--- a/tests/test_candidate_location_dedup.py
+++ b/tests/test_candidate_location_dedup.py
@@ -1,0 +1,303 @@
+"""Regression tests for PR3 — cross-portal REGA-license dedup at the
+candidate_location stage.
+
+These tests pin the SQL shape and model contract that the dedup logic
+relies on. They do NOT exercise a live PostGIS database — the existing
+pattern in tests/test_commercial_unit_platform_columns.py asserts on
+the emitted SQL strings, and that pattern is reused here.
+
+PR3 invariants pinned:
+
+1. ``candidate_location.rega_advertisement_license`` exists as
+   ``String(64)`` nullable with a partial index on the non-NULL subset.
+2. ``_ingest_tier1_aqar`` projects ``cu.aqar_advertisement_license`` into
+   the new column for every Tier 1 row.
+3. ``_run_deduplication`` emits the REGA-license collapse pass with the
+   correct normalisation (LOWER+TRIM), the Aqar-wins tiebreak ordering,
+   and the JOIN to ``commercial_unit`` for ``last_seen_at``.
+4. ``_run_deduplication`` emits the fingerprint fallback with 25 m +
+   ±5% area + ±5% rent thresholds, NULL/zero guards, and connected-
+   component resolution.
+5. The pre-existing Step 1 "mark every Tier 1 row primary" UPDATE is
+   preserved unchanged — both new passes only DEMOTE rows.
+6. The dedup SQL uses no clock or random functions (idempotency).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+class _FakeResult:
+    def __init__(self, scalar_value: Any = None, rowcount: int = 0) -> None:
+        self._scalar = scalar_value
+        self.rowcount = rowcount
+
+    def scalar(self) -> Any:
+        return self._scalar
+
+
+class _RecordingDB:
+    """Records every ``execute`` call. Returns a generic result so the
+    dedup function can run all four UPDATEs end-to-end.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def execute(self, stmt, params=None):
+        self.calls.append((str(stmt), dict(params or {})))
+        # Count primaries probe returns 0; nothing reads it.
+        return _FakeResult(scalar_value=0, rowcount=0)
+
+    def commit(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 1. Model shape
+# ---------------------------------------------------------------------------
+
+
+class TestCandidateLocationModel:
+    def test_has_rega_advertisement_license_column(self):
+        from app.models.tables import CandidateLocation
+
+        cols = CandidateLocation.__table__.columns
+        assert "rega_advertisement_license" in cols
+        col = cols["rega_advertisement_license"]
+        assert col.nullable is True
+        assert col.type.length == 64
+
+    def test_partial_index_on_rega_license_exists(self):
+        from app.models.tables import CandidateLocation
+
+        indexes = {ix.name: ix for ix in CandidateLocation.__table__.indexes}
+        ix = indexes.get("ix_candidate_location_rega_license")
+        assert ix is not None
+        assert ix.unique is False
+        assert [c.name for c in ix.columns] == ["rega_advertisement_license"]
+        where_sql = str(
+            ix.dialect_options.get("postgresql", {}).get("where", "")
+        )
+        assert "rega_advertisement_license IS NOT NULL" in where_sql
+
+
+# ---------------------------------------------------------------------------
+# 2. Ingest projection
+# ---------------------------------------------------------------------------
+
+
+class TestIngestTier1AqarProjection:
+    def test_insert_projects_rega_license_from_commercial_unit(self):
+        from app.ingest.candidate_locations import _ingest_tier1_aqar
+
+        db = _RecordingDB()
+        _ingest_tier1_aqar(db, run_id="abcd1234")
+
+        assert db.calls, "ingest must emit at least one SQL statement"
+        insert_sql, params = db.calls[0]
+        assert "INSERT INTO candidate_location" in insert_sql
+        # Column list must include the new column.
+        assert "rega_advertisement_license" in insert_sql
+        # SELECT projection must source it from commercial_unit's column.
+        assert "cu.aqar_advertisement_license" in insert_sql
+        assert params["run_id"] == "abcd1234"
+
+
+# ---------------------------------------------------------------------------
+# 3. Dedup SQL — structure
+# ---------------------------------------------------------------------------
+
+
+def _collect_dedup_sql(run_id: str = "deadbeef") -> list[str]:
+    from app.ingest.candidate_locations import _run_deduplication
+
+    db = _RecordingDB()
+    _run_deduplication(db, run_id=run_id)
+    return [sql for sql, _ in db.calls]
+
+
+class TestRunDeduplicationStructure:
+    def test_dbscan_step_unchanged(self):
+        sqls = _collect_dedup_sql()
+        # First statement is the DBSCAN clustering UPDATE.
+        assert "ST_ClusterDBSCAN" in sqls[0]
+        assert "eps := 0.00045" in sqls[0]
+        assert "minpoints := 1" in sqls[0]
+
+    def test_step1_marks_all_tier1_primary(self):
+        sqls = _collect_dedup_sql()
+        # Step 1 is the unconditional Tier-1-primary UPDATE.
+        step1 = next(
+            s for s in sqls
+            if "SET is_cluster_primary = TRUE" in s
+            and "source_tier = 1" in s
+            and "ST_ClusterDBSCAN" not in s
+            and "license_groups" not in s
+            and "fingerprint_pairs" not in s
+        )
+        assert "WHERE population_run_id = :run_id" in step1
+        assert "AND source_tier = 1" in step1
+
+
+class TestRegaLicenseCollapsePass:
+    def setup_method(self):
+        self.sqls = _collect_dedup_sql()
+        self.rega_sql = next(s for s in self.sqls if "license_groups" in s)
+
+    def test_filters_to_tier1_with_non_null_non_blank_license(self):
+        assert "cl.source_tier = 1" in self.rega_sql
+        assert "cl.rega_advertisement_license IS NOT NULL" in self.rega_sql
+        assert "TRIM(cl.rega_advertisement_license) <> ''" in self.rega_sql
+
+    def test_partitions_by_normalised_license(self):
+        # Both PARTITION BY clauses (in COUNT and ROW_NUMBER) must normalise.
+        normalised = "LOWER(TRIM(cl.rega_advertisement_license))"
+        assert self.rega_sql.count(normalised) >= 2
+
+    def test_tiebreak_order_aqar_first_then_last_seen_then_id(self):
+        # Order must be: Aqar-vs-non-Aqar, then last_seen_at DESC, then id ASC.
+        m = re.search(
+            r"ORDER BY\s+\(cl\.source_type = 'aqar'\) DESC,\s*"
+            r"cu\.last_seen_at DESC NULLS LAST,\s*"
+            r"cl\.id ASC",
+            self.rega_sql,
+        )
+        assert m is not None, "REGA tiebreak order must be aqar→last_seen→id"
+
+    def test_joins_commercial_unit_via_platform_listing_id(self):
+        # JOIN predicate must be (platform, platform_listing_id) so it works
+        # for both Aqar today and Bayut in PR4.
+        assert "LEFT JOIN commercial_unit cu" in self.rega_sql
+        assert "cu.platform = cl.source_type" in self.rega_sql
+        assert "cu.platform_listing_id = cl.source_id" in self.rega_sql
+
+    def test_demotes_non_primary_rows_in_groups_of_size_gt_1(self):
+        assert "SET is_cluster_primary = FALSE" in self.rega_sql
+        assert "lg.group_size > 1" in self.rega_sql
+        assert "lg.rn > 1" in self.rega_sql
+
+    def test_scoped_to_run_id(self):
+        assert "cl.population_run_id = :run_id" in self.rega_sql
+
+
+class TestFingerprintFallbackPass:
+    def setup_method(self):
+        self.sqls = _collect_dedup_sql()
+        self.fp_sql = next(s for s in self.sqls if "fingerprint_pairs" in s)
+
+    def test_distance_threshold_is_25_metres(self):
+        assert "ST_DWithin(cl1.geom::geography, cl2.geom::geography, 25.0)" in self.fp_sql
+
+    def test_area_threshold_5_percent_with_null_and_zero_guards(self):
+        assert "cl1.area_sqm IS NOT NULL" in self.fp_sql
+        assert "cl2.area_sqm IS NOT NULL" in self.fp_sql
+        assert "cl1.area_sqm > 0" in self.fp_sql
+        assert "cl2.area_sqm > 0" in self.fp_sql
+        assert (
+            "ABS(cl1.area_sqm - cl2.area_sqm)\n"
+            "                   / GREATEST(cl1.area_sqm, cl2.area_sqm) <= 0.05"
+        ) in self.fp_sql
+
+    def test_rent_threshold_5_percent_with_null_and_zero_guards(self):
+        assert "cl1.rent_sar_annual IS NOT NULL" in self.fp_sql
+        assert "cl2.rent_sar_annual IS NOT NULL" in self.fp_sql
+        assert "cl1.rent_sar_annual > 0" in self.fp_sql
+        assert "cl2.rent_sar_annual > 0" in self.fp_sql
+        assert (
+            "ABS(cl1.rent_sar_annual - cl2.rent_sar_annual)\n"
+            "                   / GREATEST(cl1.rent_sar_annual, cl2.rent_sar_annual) <= 0.05"
+        ) in self.fp_sql
+
+    def test_self_match_and_symmetric_pair_guard(self):
+        assert "cl1.id < cl2.id" in self.fp_sql
+
+    def test_only_fires_when_at_least_one_side_has_no_rega_license(self):
+        # The REGA pass owns same-license pairs; the fingerprint fallback
+        # only fires when at least one side has a NULL/blank license.
+        assert "cl1.rega_advertisement_license IS NULL" in self.fp_sql
+        assert "cl2.rega_advertisement_license IS NULL" in self.fp_sql
+
+    def test_only_considers_currently_primary_rows(self):
+        # Step 1a may have already demoted rows; don't second-guess it.
+        assert "cl1.is_cluster_primary = TRUE" in self.fp_sql
+        assert "cl2.is_cluster_primary = TRUE" in self.fp_sql
+
+    def test_connected_component_resolution(self):
+        # Recursive CTE → MIN(root) per node → ROW_NUMBER per component.
+        assert "WITH " in self.fp_sql or "components AS" in self.fp_sql
+        assert "components AS" in self.fp_sql
+        assert "component_root" in self.fp_sql
+        assert "MIN(root) AS root_id" in self.fp_sql
+
+    def test_fingerprint_tiebreak_order(self):
+        m = re.search(
+            r"ORDER BY\s+\(cl\.source_type = 'aqar'\) DESC,\s*"
+            r"cu\.last_seen_at DESC NULLS LAST,\s*"
+            r"cl\.id ASC",
+            self.fp_sql,
+        )
+        assert m is not None, "fingerprint tiebreak must be aqar→last_seen→id"
+
+    def test_demotes_non_winners_in_components_of_size_gt_1(self):
+        assert "SET is_cluster_primary = FALSE" in self.fp_sql
+        assert "r.component_size > 1" in self.fp_sql
+        assert "r.rn > 1" in self.fp_sql
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestDedupIdempotency:
+    def test_dedup_sql_has_no_clock_or_random_functions(self):
+        """No NOW(), CURRENT_TIMESTAMP, RANDOM(): two runs over identical
+        data must produce identical results.
+        """
+        sqls = _collect_dedup_sql()
+        joined = "\n".join(sqls).upper()
+        assert "NOW()" not in joined
+        assert "CURRENT_TIMESTAMP" not in joined
+        assert "RANDOM(" not in joined
+
+    def test_two_consecutive_runs_emit_identical_sql(self):
+        first = _collect_dedup_sql(run_id="run-1")
+        second = _collect_dedup_sql(run_id="run-1")
+        # SQL text must be byte-identical across runs (deterministic plan).
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# 5. Today's reality: Aqar-only data, unique licenses → no demotions
+# ---------------------------------------------------------------------------
+
+
+class TestPrePR3InvariantPreserved:
+    def test_step1_still_promotes_every_tier1_first(self):
+        """The pre-PR3 invariant — "every Tier 1 row starts as primary" —
+        is preserved. The new passes only DEMOTE rows. So against today's
+        Aqar-only data (no Bayut, no shared licenses), the dedup is a
+        no-op on the primary set."""
+        sqls = _collect_dedup_sql()
+
+        # Find the "mark every Tier 1 primary" step.
+        promote_idx = next(
+            i for i, s in enumerate(sqls)
+            if "SET is_cluster_primary = TRUE" in s
+            and "AND source_tier = 1" in s
+            and "ST_ClusterDBSCAN" not in s
+            and "license_groups" not in s
+            and "fingerprint_pairs" not in s
+        )
+
+        # All subsequent Tier 1 mutations are DEMOTIONS only.
+        for s in sqls[promote_idx + 1:]:
+            if "source_tier" not in s and "license_groups" not in s and "fingerprint_pairs" not in s:
+                continue
+            if "is_cluster_primary" in s and (
+                "license_groups" in s or "fingerprint_pairs" in s
+            ):
+                assert "SET is_cluster_primary = FALSE" in s


### PR DESCRIPTION
PR3 of the multi-portal listings series. Teaches `_run_deduplication`
in `app/ingest/candidate_locations.py` to collapse two Tier 1
candidate_location rows that describe the same physical unit on two
different portals (Aqar today, Bayut in PR4) into one cluster primary.

Primary signal: REGA advertisement license (case-insensitive,
whitespace-stripped, NULLs excluded). Denormalised onto
`candidate_location.rega_advertisement_license` so the dedup query
stays single-table; backfilled from
`commercial_unit.aqar_advertisement_license` via the existing
(source_tier=1, source_id=aqar_id) mapping.

Secondary signal: coordinate (25 m) + area (±5%) + rent (±5%)
fingerprint, fired only when the REGA license is missing on at least
one side. Connected-component resolution so transitive A↔B↔C matches
collapse to a single primary.

Tiebreak across both passes: Aqar wins → commercial_unit.last_seen_at
DESC → id ASC. Deterministic within a run and stable across reruns
over identical data.

No behaviour change against today's Aqar-only data — REGA licenses
are unique per row when only one portal is present, so the new passes
demote zero rows. Activates on the first PR4 Bayut INSERT.

Includes:
- Migration `20260526_cl_rega_license` (additive column + partial index
  + backfill) on top of PR2's `20260525_cu_platform_cols` head.
- Model: `CandidateLocation.rega_advertisement_license` (VARCHAR(64),
  nullable) plus the partial index.
- Ingest: `_ingest_tier1_aqar` projects `cu.aqar_advertisement_license`
  into the new column.
- Dedup: two new steps after the existing Tier-1-all-primary step;
  both DEMOTE only. DBSCAN, Step 1 promote, and Tier 2/3 fallback are
  unchanged.
- Tests: `tests/test_candidate_location_dedup.py` (23 tests) pinning
  model shape, ingest projection, REGA pass SQL, fingerprint pass SQL,
  Aqar-wins tiebreak, NULL/zero guards, idempotency, and the
  preserved Step 1 promote.

No reader changes. No frontend changes. No Bayut code (that's PR4).