### PR TITLE
fix(ingest): use WITH RECURSIVE for fingerprint CTE in _run_deduplication

### DIFF
--- a/app/ingest/candidate_locations.py
+++ b/app/ingest/candidate_locations.py
@@ -350,7 +350,7 @@ def _run_deduplication(db: Session, run_id: str) -> int:
     # match set until the set stabilises), then within each component the
     # same Aqar-wins / last_seen_at / id-ASC tiebreak applies.
     db.execute(text("""
-        WITH fingerprint_pairs AS (
+        WITH RECURSIVE fingerprint_pairs AS (
             SELECT cl1.id AS a_id, cl2.id AS b_id
               FROM candidate_location cl1
               JOIN candidate_location cl2

--- a/tests/test_candidate_location_dedup.py
+++ b/tests/test_candidate_location_dedup.py
@@ -227,7 +227,7 @@ class TestFingerprintFallbackPass:
 
     def test_connected_component_resolution(self):
         # Recursive CTE → MIN(root) per node → ROW_NUMBER per component.
-        assert "WITH " in self.fp_sql or "components AS" in self.fp_sql
+        assert "WITH RECURSIVE" in self.fp_sql
         assert "components AS" in self.fp_sql
         assert "component_root" in self.fp_sql
         assert "MIN(root) AS root_id" in self.fp_sql


### PR DESCRIPTION
PR3 hotfix: the fingerprint-fallback CTE's `components` step references
itself, so Postgres requires `WITH RECURSIVE`. The existing test only
asserted on string content, not executability — followup test work is parked.

Followup: add a live-DB integration test pattern for `_run_deduplication`
so SQL syntax errors surface before deploy.

Fixes failed `Refresh Candidate Locations` workflow run #65
(`relation "components" does not exist`).