### PR TITLE
Fix competition_whitespace fabrication on unknown-confidence path

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -2358,15 +2358,18 @@ def _competition_whitespace_score(
       12             -> 28
       20+            -> 15  (floor)
 
-    F4 (defensive): when ``confident`` is ``False``, the spatial query
-    returned zero rows AND no broader POI/delivery presence was observed
-    in the radius (i.e. thin POI coverage, not a true greenfield). In
-    that case return the neutral midpoint (50.0) so the candidate
-    neither receives the free 100 boost nor an implicit penalty.
-    ``confident=None`` (caller did not supply a flag) preserves the
-    legacy behavior unchanged.
+    F4 (defensive): ``count=0`` only earns the wide-open 100 when
+    ``confident`` is truthy — i.e. the competitor scan actually observed
+    broader POI/delivery presence in the radius, so a zero same-category
+    count is trustworthy evidence of a genuine greenfield. Both
+    ``confident=False`` (scan ran but found thin POI coverage, not a true
+    greenfield) and ``confident=None`` (no scan ran / caller supplied no
+    flag — e.g. the ArcGIS-fallback pool path) are treated as unknown and
+    return the neutral midpoint (50.0). Unknown competitor data must not
+    be scored as a confirmed empty market: that fabricates evidence and
+    pushes thin-coverage candidates up the ranking.
     """
-    if confident is False and competitor_count <= 0:
+    if not confident and competitor_count <= 0:
         return 50.0
     if competitor_count <= 0:
         return 100.0

--- a/docs/fix-whitespace-unknown-confidence.md
+++ b/docs/fix-whitespace-unknown-confidence.md
@@ -1,0 +1,103 @@
+# Fix: `competition_whitespace` fabrication on the unknown-confidence path
+
+**Branch:** `claude/fix-whitespace-unknown-confidence-gjF9T`
+**Status:** Pushed — not merged (awaiting review approval)
+**Risk:** Low — corrects one scoring input; weights and `final_score` math untouched.
+
+## Summary
+
+When a candidate had **zero observed competitors**, the whitespace score only
+deserved the wide-open `100` on a *confirmed* empty market. The ArcGIS-fallback
+candidate pool bypasses bulk competitor enrichment and passes `confident=None`,
+which previously fell through to the legacy `100` branch — scoring *"we don't
+know"* as *"we know it's empty"* and pushing thin-coverage candidates up the
+ranking. This was a fabrication of evidence, independent of how often it fired.
+
+The fix makes **unknown confidence behave conservatively** (neutral `~50`),
+while genuinely-confirmed-empty markets still earn `100` on real evidence.
+
+## Step 1 — Verification
+
+### Q1. Parameter meaning
+
+Signature (`app/services/expansion_advisor.py:2340`):
+
+```python
+def _competition_whitespace_score(competitor_count: int, *, confident: bool | None = None) -> float:
+```
+
+Three states of `confident` (producer: `_bulk_enrich_competitors`,
+`:6326` / `:6467` → `"confident": int(r["broader_count"]) > 0`):
+
+| State   | Meaning |
+|---------|---------|
+| `True`  | Scan observed **broader** POI/delivery presence in radius → a zero same-category count is trustworthy evidence of a real greenfield. |
+| `False` | Scan ran but both tables returned zero rows (thin POI coverage) → zero can't be trusted. |
+| `None`  | No flag supplied: row bypassed bulk enrichment (ArcGIS-fallback pool path, comment at `:7649-7651`). |
+
+### Q2. Genuine confirmed-zero path?
+
+Yes — `confident=True` with `competitor_count=0` (broader presence observed,
+none in category). **Already handled correctly:** `_bulk_enrich_competitors`
+sets `confident=True`, and both enrichment call sites (`:7113` candidate-location
+path, `:7157` commercial_unit path) propagate the real bool. **No caller needed
+an explicit `confident=True` added.**
+
+### Q3. Is `None→100` reachable on the candidate/listings path?
+
+`None` is **not** tied to a specific product surface — it survives for any row
+that bypasses bulk enrichment (missing lat/lon, or the ArcGIS-fallback pool SQL
+that never sets the key). The single call site (`:7720` — grep confirms no other
+callers) passes `confident=competitor_count_confident`, which is `None`
+(`:7652-7655`) whenever the row wasn't enriched. So unknown-data rows were scored
+as confirmed-empty markets. **This is the fabrication — confirmed, not
+intentional → patched.**
+
+## Step 2 — The fix
+
+`app/services/expansion_advisor.py:2369`:
+
+```diff
+-    if confident is False and competitor_count <= 0:
++    if not confident and competitor_count <= 0:
+         return 50.0
+     if competitor_count <= 0:
+         return 100.0
+```
+
+Behavior after the fix:
+
+| Input                          | Score |
+|--------------------------------|-------|
+| `count=0`, `confident=None`    | `50.0` (was `100.0`) |
+| `count=0`, `confident=False`   | `50.0` |
+| `count=0`, `confident=True`    | `100.0` |
+| `count>0` (any flag)           | unchanged log-decay |
+
+The docstring was updated to document the unknown→neutral rule. No separate or
+shadow score path was introduced.
+
+## Step 3 — Tests
+
+Added `test_competition_whitespace_unknown_confidence_is_neutral_not_open`
+(`tests/test_expansion_advisor_service.py`), asserting on the **executed
+function's returned value**:
+
+- `count=0, confident=None` → `50.0` (not `100`)
+- `count=0, confident=False` → `50.0`
+- `count=0, confident=True` → `100.0`
+- `count=3` across all flags → `15.0 ≤ score < 100.0`
+
+Results:
+
+- `tests/test_expansion_advisor_service.py` — **152 passed**
+- `-k expansion` (full suite) — **684 passed, 8 skipped**
+- golden memo regression (`test_sample_regression_memos.py`) — **6 passed**
+
+## Step 4 — Confirmation
+
+`final_score` math is **unchanged** — this only corrects one input (the `count=0`
+branch of the existing `competition_whitespace` component); weights, `final_score`
+composition, and all other component logic are untouched.
+
+**Not merged.** Awaiting review approval.

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -480,6 +480,30 @@ def test_confidence_grade_bounds():
     assert _confidence_grade(confidence_score=30, district=None, provider_platform_count=None, multi_platform_presence_score=None, rent_source="conservative_default") == "D"
 
 
+def test_competition_whitespace_unknown_confidence_is_neutral_not_open():
+    """count=0 must only score wide-open (100) on confirmed evidence.
+
+    Unknown confidence (``None`` — e.g. the ArcGIS-fallback pool path that
+    bypasses bulk competitor enrichment) and explicit ``False`` (scan ran
+    but found thin POI coverage) must both fall back to the neutral
+    midpoint. Treating "we don't know" as "we know it's empty" fabricates
+    evidence and pushes thin-coverage candidates up the ranking.
+    """
+    from app.services.expansion_advisor import _competition_whitespace_score
+
+    # Unknown confidence + zero observed competitors -> neutral, NOT 100.
+    assert _competition_whitespace_score(0, confident=None) == 50.0
+    # Defensive (scan ran, thin coverage) -> neutral.
+    assert _competition_whitespace_score(0, confident=False) == 50.0
+    # Confirmed broader presence + zero same-category -> genuine greenfield.
+    assert _competition_whitespace_score(0, confident=True) == 100.0
+    # Sanity: positive counts are unaffected by the confidence flag and
+    # decay below the wide-open ceiling.
+    for _flag in (None, False, True):
+        score = _competition_whitespace_score(3, confident=_flag)
+        assert 15.0 <= score < 100.0
+
+
 def test_comparable_competitors_payload_shape():
     class _DB:
         def begin_nested(self):


### PR DESCRIPTION
When a candidate has zero observed competitors, the whitespace score
only earned the wide-open 100 on a confirmed empty market. The
ArcGIS-fallback candidate pool bypasses bulk competitor enrichment and
passes confident=None, which previously fell through to the legacy 100
branch — scoring 'we don't know' as 'we know it is empty' and pushing
thin-coverage candidates up the ranking.

Treat confident None the same as False for the count=0 branch: unknown
confidence now returns the neutral midpoint (50). Confirmed-empty markets
(confident=True, set by _bulk_enrich_competitors when broader POI/delivery
presence was observed) still earn 100. All other component logic, weights,
and final_score math are untouched.

Add a unit test asserting the returned score for None/False/True at
count=0 and that positive counts are unaffected by the flag.