### PR TITLE
osm-import: add highway key to Overpass query so roads are fetched

### DIFF
--- a/.github/workflows/osm-import.yml
+++ b/.github/workflows/osm-import.yml
@@ -85,6 +85,8 @@ jobs:
             relation["landcover"]({{bbox}});
             way["man_made"]({{bbox}});
             relation["man_made"]({{bbox}});
+            way["highway"]({{bbox}});
+            relation["highway"]({{bbox}});
           );
           (._;>;);
           out body;


### PR DESCRIPTION
The Overpass union requested building/landuse/amenity/leisure/shop/
tourism/natural/landcover/man_made but not highway, so road geometry
was never downloaded. This starved planet_osm_line (~596 rows) and, in
turn, expansion_advisor_roads.py (filters WHERE highway IS NOT NULL),
which produced only 4 rows in expansion_road_context.

Add way/relation highway to the union. No other key or setting changed;
the roads ingest is correct and untouched.