### PR TITLE
chore: automate Google Places workflow cadence

### DIFF
--- a/.github/workflows/enrich-google-reviews.yml
+++ b/.github/workflows/enrich-google-reviews.yml
@@ -19,6 +19,8 @@ on:
         description: "Reset resume cursor before starting (recommended for full refresh)"
         type: boolean
         default: false
+  schedule:
+    - cron: "0 4 1 * *"   # monthly, 1st @ 04:00 UTC — keeps ratings fresh within the STALE_DAYS window
 
 concurrency:
   group: enrich-google-reviews
@@ -65,11 +67,18 @@ jobs:
       - name: Resolve inputs
         id: inputs
         run: |
+          # On schedule events workflow_dispatch input defaults do NOT apply, so
+          # github.event.inputs.* are empty. Resolve safe defaults here so the
+          # monthly run performs a full stale-refresh (no-only-missing) without
+          # changing manual-dispatch behavior (where inputs are already populated).
           LIMIT="${{ github.event.inputs.limit }}"
           echo "limit=${LIMIT:-500}" >> "$GITHUB_OUTPUT"
-          echo "force=${{ github.event.inputs.force }}" >> "$GITHUB_OUTPUT"
-          echo "only_missing=${{ github.event.inputs.only_missing }}" >> "$GITHUB_OUTPUT"
-          echo "reset_cursor=${{ github.event.inputs.reset_cursor }}" >> "$GITHUB_OUTPUT"
+          FORCE="${{ github.event.inputs.force }}"
+          echo "force=${FORCE:-false}" >> "$GITHUB_OUTPUT"
+          ONLY_MISSING="${{ github.event.inputs.only_missing }}"
+          echo "only_missing=${ONLY_MISSING:-false}" >> "$GITHUB_OUTPUT"
+          RESET_CURSOR="${{ github.event.inputs.reset_cursor }}"
+          echo "reset_cursor=${RESET_CURSOR:-false}" >> "$GITHUB_OUTPUT"
 
       - name: Enrich restaurant POIs with Google Reviews
         env:

--- a/.github/workflows/google-places-grid-search.yml
+++ b/.github/workflows/google-places-grid-search.yml
@@ -19,6 +19,8 @@ on:
         description: "Ignore previous progress, re-process all cells"
         type: boolean
         default: false
+  schedule:
+    - cron: "0 4 1 1,4,7,10 *"   # quarterly: Jan/Apr/Jul/Oct 1st @ 04:00 UTC
 
 concurrency:
   group: google-places-grid
@@ -63,7 +65,14 @@ jobs:
           GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY }}
           PYTHONPATH: ${{ github.workspace }}
         run: |
-          FLAGS="--types ${{ github.event.inputs.types }} --radius ${{ github.event.inputs.radius }}"
+          # workflow_dispatch input defaults do NOT apply to schedule events, so
+          # github.event.inputs.* are empty on the quarterly cron. Fall back to the
+          # dispatch defaults so the scheduled run uses valid types/radius and
+          # performs a REAL (non-dry-run) discovery pass. dry_run is left untouched:
+          # empty != "true", so the scheduled run never enters dry-run mode.
+          TYPES="${{ github.event.inputs.types || 'restaurant' }}"
+          RADIUS="${{ github.event.inputs.radius || '2000' }}"
+          FLAGS="--types ${TYPES} --radius ${RADIUS}"
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             FLAGS="${FLAGS} --dry-run"
           fi

--- a/app/ingest/google_reviews_enrich.py
+++ b/app/ingest/google_reviews_enrich.py
@@ -53,7 +53,10 @@ logger = logging.getLogger(__name__)
 RIYADH_LON_MIN, RIYADH_LON_MAX = 46.20, 47.30
 RIYADH_LAT_MIN, RIYADH_LAT_MAX = 24.20, 25.10
 
-STALE_DAYS = 30
+# 25 (not 30) so a monthly enrichment cron always refreshes a row inside a
+# 30-day window: a 30-day gate can skip a row sitting at ~28 days and let it
+# drift to ~59 days before the next monthly run.
+STALE_DAYS = 25
 DEFAULT_BATCH_SIZE = 200
 
 


### PR DESCRIPTION
- enrich-google-reviews: add monthly schedule (0 4 1 * *), keep workflow_dispatch;
  resolve safe input defaults so the scheduled (empty-input) run does a full
  stale-refresh without altering manual-dispatch behavior
- google_reviews_enrich: tighten STALE_DAYS 30 -> 25 so a monthly cron always
  refreshes each row inside a 30-day window
- google-places-grid-search: add quarterly schedule (Jan/Apr/Jul/Oct), keep
  workflow_dispatch; fall back to dispatch defaults for types/radius so the
  scheduled run is valid and runs a real (non-dry-run) discovery pass

https://claude.ai/code/session_01R8YfJvcFCJHN2pJXBmESJP