### PR TITLE
Localize parking warnings and fix v2 display path

### DIFF
--- a/app/services/parking.py
+++ b/app/services/parking.py
@@ -279,6 +279,9 @@ def required_spaces_riyadh(
       - meta (dict) with rule provenance and warnings
     """
     warnings: List[str] = []
+    # Structured, presentation-agnostic mirror of `warnings` (Option C hybrid).
+    # Codes are semantic only; i18n key mapping/rendering happens on the frontend.
+    warning_items: List[Dict[str, Any]] = []
     by_component: Dict[str, int] = {}
 
     rule_map = {**DEFAULT_COMPONENT_RULE_MAP, **(component_rule_map or {})}
@@ -319,6 +322,7 @@ def required_spaces_riyadh(
                 if avg_m2 <= 0:
                     avg_m2 = approx_avg
                     warnings.append("unit_mix.avg_m2 missing; approximated from residential GFA ÷ total units")
+                    warning_items.append({"code": "avg_m2_missing", "params": {}})
                 if rule.get("type") == "apartments_size_threshold":
                     thr = _float(rule.get("threshold_m2"), 180.0)
                     spaces_per_unit = int(rule.get("spaces_large") if avg_m2 >= thr else rule.get("spaces_small"))
@@ -334,6 +338,9 @@ def required_spaces_riyadh(
             warnings.append(
                 "unit_mix missing/empty; residential parking approximated as 1 space per estimated unit "
                 f"(units≈ceil(residential_gfa/avg_unit_m2) with avg_unit_m2={avg_unit:g})"
+            )
+            warning_items.append(
+                {"code": "unit_mix_missing", "params": {"avg_unit_m2": avg_unit}}
             )
 
     # --- Non-residential components (per m2 GFA) ---
@@ -366,6 +373,7 @@ def required_spaces_riyadh(
         "ruleset_name": RIYADH_PARKING_RULESET_NAME,
         "source_url": RIYADH_PARKING_RULESET_SOURCE_URL,
         "warnings": warnings,
+        "warning_items": warning_items,
     }
     return total_required, by_component, meta
 

--- a/frontend/src/components/ExcelForm.tsx
+++ b/frontend/src/components/ExcelForm.tsx
@@ -1595,7 +1595,15 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
     const totals = (result?.totals ?? {}) as Record<string, unknown>;
     const resultNotes = (result?.notes ?? {}) as Record<string, unknown>;
     const breakdown = (resultNotes?.excel_breakdown ?? {}) as Record<string, unknown>;
-    const parkingMeta = (resultNotes?.parking ?? {}) as Record<string, unknown>;
+    // GET /estimates/{id} double-wraps as { notes: { ...actual notes... } }; POST is flat.
+    // Unwrap so parking lookups work for both shapes (mirrors ParkingSummary.unwrapNotes).
+    const nestedNotes =
+      resultNotes && typeof (resultNotes as any).notes === "object" && (resultNotes as any).notes
+        ? ((resultNotes as any).notes as Record<string, unknown>)
+        : undefined;
+    const parkingMeta = (resultNotes?.parking ??
+      nestedNotes?.parking ??
+      {}) as Record<string, unknown>;
 
     const firstString = (...vals: unknown[]): string | null => {
       for (const v of vals) {
@@ -1703,16 +1711,55 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
         ? (breakdown.parking_required_by_component as Record<string, unknown>)
         : null;
 
-    const warningCandidates = [
-      parkingMeta.warnings,
-      parkingMeta.warning,
-      resultNotes.parking_warnings,
-      breakdown.parking_warnings,
-      breakdown.warnings,
-    ];
-    const warnings = warningCandidates
-      .flatMap((candidate) => (Array.isArray(candidate) ? candidate : [candidate]))
-      .filter((candidate): candidate is string => typeof candidate === "string" && candidate.trim().length > 0);
+    // Warnings live at parking.requirement_meta. Prefer structured warning_items
+    // (code → localized t()), fall back to the retained English `warnings` strings
+    // for legacy persisted rows or unknown codes. Never blank/crash.
+    const requirementMeta =
+      parkingMeta.requirement_meta && typeof parkingMeta.requirement_meta === "object"
+        ? (parkingMeta.requirement_meta as Record<string, unknown>)
+        : {};
+
+    const warningCodeKeyMap: Record<string, string> = {
+      avg_m2_missing: "excel.parkingWarnAvgM2Missing",
+      unit_mix_missing: "excel.parkingWarnUnitMixMissing",
+    };
+
+    const warningItems = Array.isArray(requirementMeta.warning_items)
+      ? (requirementMeta.warning_items as Array<Record<string, unknown>>)
+      : [];
+    const rawWarnings = Array.isArray(requirementMeta.warnings)
+      ? (requirementMeta.warnings as unknown[])
+      : [];
+
+    let resolvedWarnings: string[];
+    if (warningItems.length) {
+      resolvedWarnings = warningItems
+        .map((item, idx) => {
+          const code = typeof item?.code === "string" ? item.code : "";
+          const key = warningCodeKeyMap[code];
+          if (key) {
+            const params =
+              item?.params && typeof item.params === "object"
+                ? ({ ...(item.params as Record<string, unknown>) } as Record<string, unknown>)
+                : {};
+            // Match the parking tab's area formatting (integer, locale-aware).
+            if (typeof params.avg_unit_m2 === "number") {
+              params.avg_unit_m2 = formatNumberValue(params.avg_unit_m2, 0);
+            }
+            return t(key, params as Record<string, unknown>);
+          }
+          // Unknown code → raw English entry at the same index, if present; else skip.
+          const raw = rawWarnings[idx];
+          return typeof raw === "string" && raw.trim().length ? raw : null;
+        })
+        .filter((s): s is string => typeof s === "string" && s.trim().length > 0);
+    } else {
+      resolvedWarnings = rawWarnings.filter(
+        (s): s is string => typeof s === "string" && s.trim().length > 0,
+      );
+    }
+    // De-duplicate identical entries (producer :321 can append duplicates per unit row).
+    const warnings = Array.from(new Set(resolvedWarnings));
 
     return {
       required,

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -197,6 +197,8 @@
     "parkingNotesWarnings": "الملاحظات / التنبيهات",
     "parkingAutoAdjustment": "تم تطبيق تعديل تلقائي: {{detail}}",
     "parkingAutoAdjustmentIncrease": "تم تطبيق تعديل تلقائي: زيادة مساحة القبو/المواقف من {{from}} m² إلى {{to}} m² (×{{factor}})",
+    "parkingWarnAvgM2Missing": "متوسط مساحة الوحدة غير متوفر لبعض أنواع الوحدات؛ تم تقدير مواقف السكني من إجمالي المساحة السكنية.",
+    "parkingWarnUnitMixMissing": "مزيج الوحدات غير متوفر؛ تم تقدير مواقف السكني بموقف واحد لكل وحدة (بافتراض ~{{avg_unit_m2}} m² لكل وحدة).",
     "yieldBand": {
       "negative": "سلبي",
       "lowSingleDigit": "أحادي الرقم منخفض",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -197,6 +197,8 @@
     "parkingNotesWarnings": "Notes / warnings",
     "parkingAutoAdjustment": "Auto-adjustment applied: {{detail}}",
     "parkingAutoAdjustmentIncrease": "Auto-adjustment applied: increased basement/parking area from {{from}} m² to {{to}} m² (×{{factor}})",
+    "parkingWarnAvgM2Missing": "Average unit size missing for some unit types; residential parking approximated from total residential area.",
+    "parkingWarnUnitMixMissing": "Unit mix not provided; residential parking approximated at one space per unit (assuming ~{{avg_unit_m2}} m² per unit).",
     "yieldBand": {
       "negative": "Negative",
       "lowSingleDigit": "Low single digit",


### PR DESCRIPTION
Emit structured warning_items ({code, params}) alongside the retained
English warnings list in required_spaces_riyadh(); add EN/AR i18n keys;
fix v2 resolveParking to read parking.requirement_meta, prefer localized
warning_items, fall back to legacy English strings, and de-duplicate.