### PR TITLE
PR-5a: Arabic PDF scaffolding (backend, EN-safe, AR latent)

### DIFF
--- a/app/api/estimates.py
+++ b/app/api/estimates.py
@@ -29,6 +29,7 @@ from app.services.explain import (
     to_comp_dict,
 )
 from app.services.pdf import build_memo_pdf
+from app.services.estimator_i18n import t as estimator_label
 from app.services.land_price_engine import quote_land_price_blended_v1
 from app.services.pricing import price_from_kaggle_hedonic, price_from_aqar
 from app.services.simulate import p_bands
@@ -2452,7 +2453,11 @@ def get_ledger(estimate_id: str, db: Session = Depends(get_db)) -> dict[str, Any
 
 
 @router.get("/estimates/{estimate_id}/memo.pdf")
-def export_pdf(estimate_id: str, db: Session = Depends(get_db)):
+def export_pdf(
+    estimate_id: str,
+    lang: Literal["en", "ar"] = "en",
+    db: Session = Depends(get_db),
+):
     base = get_estimate(estimate_id, db)
     comps_rows = top_sale_comps(db, city=None, district=None, asset_type="land", since=None, limit=8)
     comps = [to_comp_dict(r) for r in comps_rows]
@@ -2470,13 +2475,14 @@ def export_pdf(estimate_id: str, db: Session = Depends(get_db)):
                 cost_breakdown = nested_notes.get("cost_breakdown")
     try:
         pdf_bytes = build_memo_pdf(
-            title=f"Estimate {estimate_id}",
+            title=f"{estimator_label('doc_title_prefix', lang)} {estimate_id}",
             totals=base["totals"],
             assumptions=base.get("assumptions", []),
             top_comps=comps,
             excel_breakdown=excel_breakdown,
             cost_breakdown=cost_breakdown,
             notes=notes,
+            lang=lang,
         )
     except Exception as exc:
         logger.exception("PDF generation failed for estimate %s", estimate_id)

--- a/app/services/estimator_i18n.py
+++ b/app/services/estimator_i18n.py
@@ -1,0 +1,186 @@
+"""Server-side EN/AR labels for the feasibility (Estimator) PDF memo.
+
+The feasibility PDF is rendered on the backend (``app/services/pdf.py``) and
+therefore cannot reach the frontend i18next catalog at render time. This
+module mirrors ``app/services/expansion_advisor_i18n.py``: a single label
+table keyed by a stable token, each entry carrying ``{"en", "ar"}``, plus a
+``t(token, lang)`` accessor with graceful ``en`` fallback that never raises.
+
+Conventions (mirroring the EA module and the on-screen estimator catalog):
+
+  - **EN values are byte-identical to the literals currently hardcoded in
+    ``pdf.py``** (e.g. "Cost breakdown", "Total capex", "How calculated",
+    and "m2" stays "m2" — unit-glyph normalization is a later decision).
+    Routing the existing labels through ``t(token, "en")`` therefore keeps
+    the English PDF byte-for-byte identical.
+  - **AR values reuse the authored terminology** from
+    ``frontend/src/i18n/ar.json`` (the on-screen estimator surface) wherever a
+    concept already has an Arabic string — we do not fork terminology. The
+    estimator on-screen catalog uses "ر.س" and "م²" inline (not "SAR"/"m²"),
+    and Latin digits; the AR strings here follow the same conventions.
+  - Arabic byte hygiene: Arabic yeh is U+064A (ي) and heh is U+0647 (ه);
+    no Farsi yeh (U+06CC) or heh-doachashmee (U+06BE).
+
+This PR (5a) wires the labels and selects the persisted ``*_ar`` narratives,
+but leaves the ASCII gates in ``pdf.py`` untouched — so the AR path is latent
+(blank/garbled) and unexposed until PR-5b adds the font + shaping + BiDi.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+# token -> {"en": ..., "ar": ...}
+# EN values MUST match the current hardcoded literals in app/services/pdf.py.
+LABELS: Dict[str, Dict[str, str]] = {
+    # ── Document title (built in app/api/estimates.py) ──────────────
+    "doc_title_prefix": {"en": "Estimate", "ar": "تقدير"},
+
+    # ── Section titles ──────────────────────────────────────────────
+    "totals_section": {"en": "Totals (SAR)", "ar": "الإجماليات (ر.س)"},
+    "cost_breakdown_section": {"en": "Cost breakdown", "ar": "تفصيل التكاليف"},
+    "revenue_breakdown_section": {"en": "Revenue breakdown", "ar": "تفصيل الإيرادات"},
+    "parking_summary_section": {"en": "Parking summary", "ar": "ملخص المواقف"},
+    "executive_summary_section": {"en": "Executive summary", "ar": "الملخص التنفيذي"},
+    "key_assumptions_section": {"en": "Key assumptions", "ar": "الافتراضات الرئيسية"},
+    "appendix_calc_trace_section": {
+        "en": "Appendix: calculation trace",
+        "ar": "ملحق: أثر الحساب",
+    },
+    "appendix_top_comps_section": {
+        "en": "Appendix: top comps",
+        "ar": "ملحق: أبرز المقارنات",
+    },
+
+    # ── Totals metric labels ────────────────────────────────────────
+    "land_value": {"en": "Land value", "ar": "قيمة الأرض"},
+    "total_capex": {"en": "Total capex", "ar": "إجمالي النفقات الرأسمالية"},
+    "annual_net_revenue": {"en": "Annual net revenue", "ar": "صافي الإيراد السنوي"},
+    "annual_noi": {"en": "Annual NOI", "ar": "صافي الدخل التشغيلي السنوي"},
+    "unlevered_roi": {"en": "Unlevered ROI", "ar": "العائد غير الممول"},
+
+    # ── Table headers ───────────────────────────────────────────────
+    "header_item": {"en": "Item", "ar": "البند"},
+    "header_amount": {"en": "Amount", "ar": "القيمة"},
+    "header_how_calculated": {"en": "How calculated", "ar": "طريقة الحساب"},
+    "header_assumption": {"en": "Assumption", "ar": "الافتراض"},
+    "header_value": {"en": "Value", "ar": "القيمة"},
+    "header_source": {"en": "Source", "ar": "المصدر"},
+    "header_detail": {"en": "Detail", "ar": "التفاصيل"},
+    "header_id": {"en": "ID", "ar": "المعرّف"},
+    "header_date": {"en": "Date", "ar": "التاريخ"},
+    "header_location": {"en": "Location", "ar": "الموقع"},
+    "header_price_sar_m2": {"en": "Price (SAR/m2)", "ar": "السعر (ر.س/م²)"},
+
+    # ── Cost-breakdown row labels ───────────────────────────────────
+    "effective_far_above_ground": {
+        "en": "Effective FAR (above-ground)",
+        "ar": "معامل الكثافة الفعّال (فوق الأرض)",
+    },
+    "residential_bua": {"en": "Residential BUA", "ar": "مساحة البناء السكنية"},
+    "retail_bua": {"en": "Retail BUA", "ar": "مساحة البناء التجارية"},
+    "office_bua": {"en": "Office BUA", "ar": "مساحة البناء المكتبية"},
+    "basement_bua": {"en": "Basement BUA", "ar": "مساحة البناء للقبو"},
+    "upper_annex_non_far_bua": {
+        "en": "Upper annex (non-FAR, +0.5 floor)",
+        "ar": "الملحق العلوي (غير محسوب في FAR، +0.5 طابق)",
+    },
+    "land_cost": {"en": "Land cost", "ar": "تكلفة الأرض"},
+    "construction_direct": {"en": "Construction (direct)", "ar": "الإنشاء (مباشر)"},
+    "upper_annex_non_far_cost": {
+        "en": "Upper annex construction cost (non-FAR)",
+        "ar": "تكلفة إنشاء الملحق العلوي (غير محسوب في FAR)",
+    },
+    "fitout": {"en": "Fit-out", "ar": "التجهيزات"},
+    "contingency": {"en": "Contingency", "ar": "الاحتياطي"},
+    "consultants": {"en": "Consultants", "ar": "الاستشاريون"},
+    "feasibility_fee": {"en": "Feasibility fee", "ar": "رسوم الجدوى"},
+    "transaction_costs": {"en": "Transaction costs", "ar": "تكاليف المعاملة"},
+
+    # ── Revenue-breakdown labels ────────────────────────────────────
+    "annual_net_income": {"en": "Annual net income", "ar": "صافي الدخل السنوي"},
+    "opex": {"en": "OPEX", "ar": "المصاريف التشغيلية (OPEX)"},
+    # Revenue "how calculated" strings (hardcoded in pdf.py today).
+    "rev_nla_rent_rate": {"en": "NLA * rent rate", "ar": "NLA × معدل الإيجار"},
+    "rev_sum_income_components": {
+        "en": "Sum of income components",
+        "ar": "مجموع مكوّنات الدخل",
+    },
+    "rev_effective_suffix": {"en": "effective", "ar": "فعّال"},
+    "rev_of_annual_net_income": {
+        "en": "of annual net income",
+        "ar": "من صافي الدخل السنوي",
+    },
+    "rev_annual_net_income_minus_opex": {
+        "en": "Annual net income - OPEX",
+        "ar": "صافي الدخل السنوي − المصاريف التشغيلية",
+    },
+    "rev_noi_over_capex": {
+        "en": "NOI / total capex",
+        "ar": "NOI ÷ إجمالي النفقات الرأسمالية",
+    },
+
+    # ── Parking summary labels ──────────────────────────────────────
+    "parking_required_spaces": {"en": "Required spaces", "ar": "المواقف المطلوبة"},
+    "parking_provided_spaces": {"en": "Provided spaces", "ar": "المواقف المتوفرة"},
+    "parking_deficit": {"en": "Deficit", "ar": "العجز"},
+    "parking_compliant": {"en": "Compliant", "ar": "مطابق"},
+
+    # ── Boolean / empty-state values ────────────────────────────────
+    "yes": {"en": "Yes", "ar": "نعم"},
+    "no": {"en": "No", "ar": "لا"},
+    "na": {"en": "N/A", "ar": "غير متاح"},
+    "no_assumptions_available": {
+        "en": "No assumptions available.",
+        "ar": "لا توجد افتراضات متاحة.",
+    },
+
+    # ── Key-assumptions special labels ──────────────────────────────
+    "far_model_prior": {"en": "FAR (model prior)", "ar": "FAR (الأولوية النموذجية)"},
+
+    # ── Appendix: calculation trace ─────────────────────────────────
+    "income_prefix": {"en": "Income:", "ar": "الدخل:"},
+
+    # ── Assumption source_type enums ────────────────────────────────
+    "source_type.Model": {"en": "Model", "ar": "نموذج"},
+    "source_type.Observed": {"en": "Observed", "ar": "ملاحَظ"},
+    "source_type.GASTAT": {"en": "GASTAT", "ar": "الهيئة العامة للإحصاء (GASTAT)"},
+    "source_type.Riyadh Municipality": {
+        "en": "Riyadh Municipality",
+        "ar": "أمانة الرياض",
+    },
+    "source_type.Derived": {"en": "Derived", "ar": "مشتق"},
+    "source_type.Assumption": {"en": "Assumption", "ar": "افتراض"},
+    "source_type.Manual": {"en": "Manual", "ar": "يدوي"},
+}
+
+
+def t(token: str, lang: str = "en") -> str:
+    """Resolve a label token to ``lang``, falling back to ``en``.
+
+    Never raises: an unknown token is passed through unchanged, and a missing
+    AR (or unknown-lang) value degrades to the English string.
+    """
+    entry = LABELS.get(token)
+    if entry is None:
+        return token
+    value = entry.get(lang)
+    if value:
+        return value
+    return entry.get("en", token)
+
+
+def source_type_label(value: str | None, lang: str = "en") -> str:
+    """Translate an assumption ``source_type`` value (e.g. "GASTAT").
+
+    Unknown values pass through unchanged so unexpected source types are never
+    dropped. For ``lang="en"`` every known value maps to itself, keeping the
+    English PDF byte-identical.
+    """
+    if not value:
+        return value or ""
+    token = f"source_type.{value}"
+    if token in LABELS:
+        return t(token, lang)
+    return value

--- a/app/services/pdf.py
+++ b/app/services/pdf.py
@@ -1,6 +1,7 @@
 from typing import List, Dict, Any, Iterable
 
 from app.services.excel_method import DEFAULT_Y1_INCOME_EFFECTIVE_FACTOR, _normalize_y1_income_effective_factor
+from app.services.estimator_i18n import t as _label, source_type_label
 
 try:  # pragma: no cover - dependency availability handled at runtime
     from fpdf import FPDF
@@ -135,8 +136,16 @@ def _draw_table(
         pdf.ln(row_height)
 
 
-def _resolve_explanations(excel_breakdown: Dict[str, Any]) -> Dict[str, Any]:
-    explanations = excel_breakdown.get("explanations_en") or excel_breakdown.get("explanations") or {}
+def _resolve_explanations(excel_breakdown: Dict[str, Any], lang: str = "en") -> Dict[str, Any]:
+    if lang == "ar":
+        explanations = (
+            excel_breakdown.get("explanations_ar")
+            or excel_breakdown.get("explanations_en")
+            or excel_breakdown.get("explanations")
+            or {}
+        )
+    else:
+        explanations = excel_breakdown.get("explanations_en") or excel_breakdown.get("explanations") or {}
     return explanations if isinstance(explanations, dict) else {}
 
 
@@ -159,6 +168,7 @@ def _build_cost_breakdown_rows(
     excel_breakdown: Dict[str, Any],
     cost_breakdown: Dict[str, Any],
     explanations: Dict[str, Any],
+    lang: str = "en",
 ) -> List[Dict[str, Any]]:
     far_above_ground = excel_breakdown.get("far_above_ground")
     built_area = excel_breakdown.get("built_area")
@@ -176,20 +186,20 @@ def _build_cost_breakdown_rows(
         rows.append(
             {
                 "cells": [
-                    "Effective FAR (above-ground)",
+                    _label("effective_far_above_ground", lang),
                     _fmt_decimal(far_above_ground, 3),
                     _short_note(explanations.get("far_above_ground")),
                 ]
             }
         )
     built_rows = [
-        ("Residential BUA", "residential", "residential_bua"),
-        ("Retail BUA", "retail", "retail_bua"),
-        ("Office BUA", "office", "office_bua"),
-        ("Basement BUA", "basement", "basement_bua"),
-        ("Upper annex (non-FAR, +0.5 floor)", "upper_annex_non_far", "upper_annex_non_far_bua"),
+        ("residential_bua", "residential", "residential_bua"),
+        ("retail_bua", "retail", "retail_bua"),
+        ("office_bua", "office", "office_bua"),
+        ("basement_bua", "basement", "basement_bua"),
+        ("upper_annex_non_far_bua", "upper_annex_non_far", "upper_annex_non_far_bua"),
     ]
-    for label, key, explanation_key in built_rows:
+    for label_token, key, explanation_key in built_rows:
         if key not in built_area:
             continue
         amount = built_area.get(key)
@@ -198,7 +208,7 @@ def _build_cost_breakdown_rows(
         rows.append(
             {
                 "cells": [
-                    label,
+                    _label(label_token, lang),
                     _format_amount(amount, "m2"),
                     _short_note(explanations.get(explanation_key)),
                 ]
@@ -209,14 +219,14 @@ def _build_cost_breakdown_rows(
         [
             {
                 "cells": [
-                    "Land cost",
+                    _label("land_cost", lang),
                     _format_amount(cost_breakdown.get("land_cost"), "SAR"),
                     _short_note(explanations.get("land_cost")),
                 ]
             },
             {
                 "cells": [
-                    "Construction (direct)",
+                    _label("construction_direct", lang),
                     _format_amount(construction_direct, "SAR"),
                     _short_note(explanations.get("construction_direct")),
                 ]
@@ -228,7 +238,7 @@ def _build_cost_breakdown_rows(
         rows.append(
             {
                 "cells": [
-                    "Upper annex construction cost (non-FAR)",
+                    _label("upper_annex_non_far_cost", lang),
                     _format_amount(direct_cost.get("upper_annex_non_far"), "SAR"),
                     _short_note(explanations.get("upper_annex_non_far_cost")),
                 ]
@@ -238,42 +248,42 @@ def _build_cost_breakdown_rows(
         [
             {
                 "cells": [
-                    "Fit-out",
+                    _label("fitout", lang),
                     _format_amount(cost_breakdown.get("fitout_cost"), "SAR"),
                     _short_note(explanations.get("fitout")),
                 ]
             },
             {
                 "cells": [
-                    "Contingency",
+                    _label("contingency", lang),
                     _format_amount(cost_breakdown.get("contingency_cost"), "SAR"),
                     _short_note(explanations.get("contingency")),
                 ]
             },
             {
                 "cells": [
-                    "Consultants",
+                    _label("consultants", lang),
                     _format_amount(cost_breakdown.get("consultants_cost"), "SAR"),
                     _short_note(explanations.get("consultants")),
                 ]
             },
             {
                 "cells": [
-                    "Feasibility fee",
+                    _label("feasibility_fee", lang),
                     _format_amount(cost_breakdown.get("feasibility_fee"), "SAR"),
                     _short_note(explanations.get("feasibility_fee")),
                 ]
             },
             {
                 "cells": [
-                    "Transaction costs",
+                    _label("transaction_costs", lang),
                     _format_amount(cost_breakdown.get("transaction_cost"), "SAR"),
                     _short_note(explanations.get("transaction_cost")),
                 ]
             },
             {
                 "cells": [
-                    "Total capex",
+                    _label("total_capex", lang),
                     _format_amount(cost_breakdown.get("grand_total_capex"), "SAR"),
                     _short_note(explanations.get("grand_total_capex")),
                 ],
@@ -287,6 +297,7 @@ def _build_cost_breakdown_rows(
 def _build_revenue_breakdown_rows(
     excel_breakdown: Dict[str, Any],
     cost_breakdown: Dict[str, Any],
+    lang: str = "en",
 ) -> List[Dict[str, Any]]:
     income_components = excel_breakdown.get("y1_income_components")
     income_components = income_components if isinstance(income_components, dict) else {}
@@ -299,7 +310,7 @@ def _build_revenue_breakdown_rows(
                 "cells": [
                     label,
                     _format_amount(amount, "SAR"),
-                    "NLA * rent rate",
+                    _label("rev_nla_rent_rate", lang),
                 ]
             }
         )
@@ -330,37 +341,37 @@ def _build_revenue_breakdown_rows(
         [
             {
                 "cells": [
-                    "Annual net revenue",
+                    _label("annual_net_revenue", lang),
                     _format_amount(y1_income, "SAR"),
-                    "Sum of income components",
+                    _label("rev_sum_income_components", lang),
                 ]
             },
             {
                 "cells": [
-                    "Annual net income",
+                    _label("annual_net_income", lang),
                     _format_amount(y1_income_effective, "SAR"),
-                    f"{_fmt_percent(y1_income_effective_factor, 0)} effective",
+                    f"{_fmt_percent(y1_income_effective_factor, 0)} {_label('rev_effective_suffix', lang)}",
                 ]
             },
             {
                 "cells": [
-                    "OPEX",
+                    _label("opex", lang),
                     _format_amount(opex_cost, "SAR"),
-                    f"{_fmt_percent(opex_pct, 0)} of annual net income",
+                    f"{_fmt_percent(opex_pct, 0)} {_label('rev_of_annual_net_income', lang)}",
                 ]
             },
             {
                 "cells": [
-                    "Annual NOI",
+                    _label("annual_noi", lang),
                     _format_amount(y1_noi, "SAR"),
-                    "Annual net income - OPEX",
+                    _label("rev_annual_net_income_minus_opex", lang),
                 ]
             },
             {
                 "cells": [
-                    "Unlevered ROI",
+                    _label("unlevered_roi", lang),
                     _fmt_percent(roi, 1),
-                    "NOI / total capex",
+                    _label("rev_noi_over_capex", lang),
                 ],
                 "bold": True,
             },
@@ -369,7 +380,9 @@ def _build_revenue_breakdown_rows(
     return rows
 
 
-def _build_assumption_rows(assumptions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _build_assumption_rows(
+    assumptions: List[Dict[str, Any]], lang: str = "en"
+) -> List[Dict[str, Any]]:
     rows: List[Dict[str, Any]] = []
     for item in assumptions:
         if not isinstance(item, dict):
@@ -378,14 +391,14 @@ def _build_assumption_rows(assumptions: List[Dict[str, Any]]) -> List[Dict[str, 
         if not key:
             continue
         if key.lower() == "far":
-            key = "FAR (model prior)"
+            key = _label("far_model_prior", lang)
         value = item.get("value")
         unit = item.get("unit") or ""
         source_type = _resolve_ascii(item.get("source_type") or "")
         if isinstance(value, (int, float)):
             value_text = _fmt_number(value)
         else:
-            value_text = _resolve_ascii(value) or "N/A"
+            value_text = _resolve_ascii(value) or _label("na", lang)
         if unit:
             unit_text = _resolve_ascii(unit)
             if unit_text:
@@ -395,7 +408,7 @@ def _build_assumption_rows(assumptions: List[Dict[str, Any]]) -> List[Dict[str, 
                 "cells": [
                     key,
                     value_text,
-                    source_type or "N/A",
+                    source_type_label(source_type, lang) or _label("na", lang),
                 ]
             }
         )
@@ -405,50 +418,52 @@ def _build_assumption_rows(assumptions: List[Dict[str, Any]]) -> List[Dict[str, 
 def _build_appendix_rows(
     explanations: Dict[str, Any],
     excel_breakdown: Dict[str, Any],
+    lang: str = "en",
 ) -> List[Dict[str, Any]]:
     rows: List[Dict[str, Any]] = []
+    # explanation key -> estimator_i18n label token
     label_map = {
-        "residential_bua": "Residential BUA",
-        "retail_bua": "Retail BUA",
-        "office_bua": "Office BUA",
-        "basement_bua": "Basement BUA",
-        "land_cost": "Land cost",
-        "construction_direct": "Construction (direct)",
-        "fitout": "Fit-out",
-        "contingency": "Contingency",
-        "consultants": "Consultants",
-        "feasibility_fee": "Feasibility fee",
-        "transaction_cost": "Transaction costs",
-        "grand_total_capex": "Total capex",
-        "y1_income": "Annual net revenue",
-        "y1_income_effective": "Annual net income",
-        "opex": "OPEX",
-        "y1_noi": "Annual NOI",
+        "residential_bua": "residential_bua",
+        "retail_bua": "retail_bua",
+        "office_bua": "office_bua",
+        "basement_bua": "basement_bua",
+        "land_cost": "land_cost",
+        "construction_direct": "construction_direct",
+        "fitout": "fitout",
+        "contingency": "contingency",
+        "consultants": "consultants",
+        "feasibility_fee": "feasibility_fee",
+        "transaction_cost": "transaction_costs",
+        "grand_total_capex": "total_capex",
+        "y1_income": "annual_net_revenue",
+        "y1_income_effective": "annual_net_income",
+        "opex": "opex",
+        "y1_noi": "annual_noi",
     }
-    for key, label in label_map.items():
+    for key, token in label_map.items():
         note = explanations.get(key)
         note_text = _resolve_ascii(note)
         if not note_text:
             continue
         rows.append(
             {
-                "cells": [label, _ellipsize(note_text, 160)],
+                "cells": [_label(token, lang), _ellipsize(note_text, 160)],
             }
         )
 
     income_components = excel_breakdown.get("y1_income_components")
     if isinstance(income_components, dict):
         for key in income_components.keys():
-            label = f"Income: {str(key).replace('_', ' ')}"
+            label = f"{_label('income_prefix', lang)} {str(key).replace('_', ' ')}"
             rows.append(
                 {
-                    "cells": [label, "NLA * rent rate"],
+                    "cells": [label, _label("rev_nla_rent_rate", lang)],
                 }
             )
     return rows
 
 
-def _build_comps_rows(top_comps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _build_comps_rows(top_comps: List[Dict[str, Any]], lang: str = "en") -> List[Dict[str, Any]]:
     rows = []
     for comp in top_comps:
         if not isinstance(comp, dict):
@@ -470,8 +485,8 @@ def _build_comps_rows(top_comps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         rows.append(
             {
                 "cells": [
-                    comp_id or "N/A",
-                    comp_date or "N/A",
+                    comp_id or _label("na", lang),
+                    comp_date or _label("na", lang),
                     location or "",
                     f"{price} SAR/m2",
                 ]
@@ -496,6 +511,7 @@ def build_memo_pdf(
     excel_breakdown: Dict[str, Any] | None = None,
     cost_breakdown: Dict[str, Any] | None = None,
     notes: Dict[str, Any] | None = None,
+    lang: str = "en",
 ) -> bytes:
     if FPDF is None:
         raise RuntimeError("fpdf library is not installed")
@@ -516,13 +532,13 @@ def build_memo_pdf(
     pdf.set_font(FONT_FAMILY, "B", 16)
     pdf.cell(0, 10, _pdf_safe_text(title), ln=True)
 
-    _draw_section_title(pdf, "Totals (SAR)")
+    _draw_section_title(pdf, _label("totals_section", lang))
     metrics = [
-        ("Land value", _fmt_money(cost_breakdown.get("land_cost") or totals.get("land_value"))),
-        ("Total capex", _fmt_money(cost_breakdown.get("grand_total_capex"))),
-        ("Annual net revenue", _fmt_money(cost_breakdown.get("y1_income") or totals.get("revenues"))),
-        ("Annual NOI", _fmt_money(cost_breakdown.get("y1_noi"))),
-        ("Unlevered ROI", _fmt_percent(cost_breakdown.get("roi"), 1)),
+        (_label("land_value", lang), _fmt_money(cost_breakdown.get("land_cost") or totals.get("land_value"))),
+        (_label("total_capex", lang), _fmt_money(cost_breakdown.get("grand_total_capex"))),
+        (_label("annual_net_revenue", lang), _fmt_money(cost_breakdown.get("y1_income") or totals.get("revenues"))),
+        (_label("annual_noi", lang), _fmt_money(cost_breakdown.get("y1_noi"))),
+        (_label("unlevered_roi", lang), _fmt_percent(cost_breakdown.get("roi"), 1)),
     ]
     metric_width = (pdf.w - pdf.l_margin - pdf.r_margin) / len(metrics)
     pdf.set_font(FONT_FAMILY, "", 8)
@@ -531,15 +547,19 @@ def build_memo_pdf(
         pdf.cell(metric_width, 5, _pdf_safe_text(label), border=1, align="C", fill=True)
     pdf.ln(5)
     pdf.set_font(FONT_FAMILY, "B", 10)
-    for _label, value in metrics:
+    for _name, value in metrics:
         pdf.cell(metric_width, 7, _pdf_safe_text(value), border=1, align="C")
     pdf.ln(10)
 
-    explanations = _resolve_explanations(excel_breakdown)
+    explanations = _resolve_explanations(excel_breakdown, lang)
 
-    _draw_section_title(pdf, "Cost breakdown")
-    cost_rows = _build_cost_breakdown_rows(excel_breakdown, cost_breakdown, explanations)
-    cost_headers = ["Item", "Amount", "How calculated"]
+    _draw_section_title(pdf, _label("cost_breakdown_section", lang))
+    cost_rows = _build_cost_breakdown_rows(excel_breakdown, cost_breakdown, explanations, lang)
+    cost_headers = [
+        _label("header_item", lang),
+        _label("header_amount", lang),
+        _label("header_how_calculated", lang),
+    ]
     table_width = pdf.w - pdf.l_margin - pdf.r_margin
     cost_col_widths = [55, 35, table_width - 90]
     _draw_table(
@@ -552,8 +572,8 @@ def build_memo_pdf(
     )
     pdf.ln(SECTION_SPACING)
 
-    _draw_section_title(pdf, "Revenue breakdown")
-    revenue_rows = _build_revenue_breakdown_rows(excel_breakdown, cost_breakdown)
+    _draw_section_title(pdf, _label("revenue_breakdown_section", lang))
+    revenue_rows = _build_revenue_breakdown_rows(excel_breakdown, cost_breakdown, lang)
     revenue_col_widths = [55, 35, table_width - 90]
     _draw_table(
         pdf,
@@ -580,15 +600,22 @@ def build_memo_pdf(
         if compliant is None:
             compliant = parking_notes.get("compliant")
         parking_summary = [
-            ("Required spaces", _fmt_number(required)),
-            ("Provided spaces", _fmt_number(provided)),
-            ("Deficit", _fmt_number(deficit)),
-            ("Compliant", "Yes" if compliant is True else "No" if compliant is False else "N/A"),
+            (_label("parking_required_spaces", lang), _fmt_number(required)),
+            (_label("parking_provided_spaces", lang), _fmt_number(provided)),
+            (_label("parking_deficit", lang), _fmt_number(deficit)),
+            (
+                _label("parking_compliant", lang),
+                _label("yes", lang)
+                if compliant is True
+                else _label("no", lang)
+                if compliant is False
+                else _label("na", lang),
+            ),
         ]
 
-    if any(value for _label, value in parking_summary if value != "N/A"):
+    if any(value for _name, value in parking_summary if value != _label("na", lang)):
         pdf.ln(SECTION_SPACING)
-        _draw_section_title(pdf, "Parking summary")
+        _draw_section_title(pdf, _label("parking_summary_section", lang))
         box_width = pdf.w - pdf.l_margin - pdf.r_margin
         pdf.set_fill_color(245, 248, 247)
         pdf.set_draw_color(200, 220, 214)
@@ -599,18 +626,27 @@ def build_memo_pdf(
             pdf.cell(box_width * 0.6, ROW_HEIGHT, _pdf_safe_text(label), align="L")
             pdf.cell(box_width * 0.35, ROW_HEIGHT, _pdf_safe_text(value), align="R", ln=True)
 
-    summary_text = _resolve_ascii(notes.get("summary_en") or notes.get("summary") or "")
+    if lang == "ar":
+        summary_text = _resolve_ascii(
+            notes.get("summary_ar") or notes.get("summary_en") or notes.get("summary") or ""
+        )
+    else:
+        summary_text = _resolve_ascii(notes.get("summary_en") or notes.get("summary") or "")
     if summary_text:
         pdf.ln(SECTION_SPACING)
-        _draw_section_title(pdf, "Executive summary")
+        _draw_section_title(pdf, _label("executive_summary_section", lang))
         pdf.set_font(FONT_FAMILY, "", 9)
         pdf.multi_cell(0, 5, _pdf_safe_text(summary_text))
 
     pdf.add_page()
-    _draw_section_title(pdf, "Key assumptions")
-    assumption_rows = _build_assumption_rows(assumptions)
+    _draw_section_title(pdf, _label("key_assumptions_section", lang))
+    assumption_rows = _build_assumption_rows(assumptions, lang)
     if assumption_rows:
-        assumption_headers = ["Assumption", "Value", "Source"]
+        assumption_headers = [
+            _label("header_assumption", lang),
+            _label("header_value", lang),
+            _label("header_source", lang),
+        ]
         assumption_col_widths = [60, 60, table_width - 120]
         _draw_table(
             pdf,
@@ -622,13 +658,13 @@ def build_memo_pdf(
         )
     else:
         pdf.set_font(FONT_FAMILY, "", 9)
-        pdf.cell(0, ROW_HEIGHT, "No assumptions available.", ln=True)
+        pdf.cell(0, ROW_HEIGHT, _label("no_assumptions_available", lang), ln=True)
 
-    appendix_rows = _build_appendix_rows(explanations, excel_breakdown)
+    appendix_rows = _build_appendix_rows(explanations, excel_breakdown, lang)
     if appendix_rows:
         pdf.ln(SECTION_SPACING)
-        _draw_section_title(pdf, "Appendix: calculation trace")
-        appendix_headers = ["Item", "Detail"]
+        _draw_section_title(pdf, _label("appendix_calc_trace_section", lang))
+        appendix_headers = [_label("header_item", lang), _label("header_detail", lang)]
         appendix_col_widths = [60, table_width - 60]
         _draw_table(
             pdf,
@@ -639,11 +675,16 @@ def build_memo_pdf(
             max_chars=[30, 120],
         )
 
-    comps_rows = _build_comps_rows(top_comps)
+    comps_rows = _build_comps_rows(top_comps, lang)
     if comps_rows:
         pdf.ln(SECTION_SPACING)
-        _draw_section_title(pdf, "Appendix: top comps")
-        comps_headers = ["ID", "Date", "Location", "Price (SAR/m2)"]
+        _draw_section_title(pdf, _label("appendix_top_comps_section", lang))
+        comps_headers = [
+            _label("header_id", lang),
+            _label("header_date", lang),
+            _label("header_location", lang),
+            _label("header_price_sar_m2", lang),
+        ]
         comps_col_widths = [30, 30, 60, table_width - 120]
         _draw_table(
             pdf,

--- a/tests/test_estimator_i18n.py
+++ b/tests/test_estimator_i18n.py
@@ -1,0 +1,141 @@
+"""Tests for the Estimator PDF EN/AR label table (PR-5a).
+
+Mirrors the Expansion Advisor i18n parity tests. Guards three things:
+
+  1. Parity: every token has a non-empty ``en`` and ``ar`` value.
+  2. Graceful fallback: ``t`` never raises, falls back to ``en``, and passes
+     unknown tokens through unchanged.
+  3. EN byte-identity: every ``en`` value equals the literal that was hardcoded
+     in ``app/services/pdf.py`` before PR-5a, so routing labels through
+     ``t(token, "en")`` keeps the English PDF byte-for-byte identical.
+  4. Arabic byte hygiene: yeh is U+064A and heh is U+0647; no Farsi yeh
+     (U+06CC) or heh-doachashmee (U+06BE).
+"""
+
+import pytest
+
+from app.services.estimator_i18n import LABELS, t, source_type_label
+
+
+# ── 1. Parity ───────────────────────────────────────────────────────
+@pytest.mark.parametrize("token", sorted(LABELS.keys()))
+def test_every_token_has_nonempty_en(token: str) -> None:
+    assert LABELS[token].get("en"), token
+
+
+@pytest.mark.parametrize("token", sorted(LABELS.keys()))
+def test_every_token_has_nonempty_ar(token: str) -> None:
+    assert LABELS[token].get("ar"), token
+
+
+# ── 2. Fallback behavior ────────────────────────────────────────────
+def test_t_resolves_requested_lang() -> None:
+    assert t("land_cost", "ar") == LABELS["land_cost"]["ar"]
+    assert t("land_cost", "en") == LABELS["land_cost"]["en"]
+
+
+def test_t_falls_back_to_en_for_unknown_lang() -> None:
+    assert t("land_cost", "fr") == LABELS["land_cost"]["en"]
+
+
+def test_t_passes_through_unknown_token() -> None:
+    assert t("__does_not_exist__", "ar") == "__does_not_exist__"
+
+
+def test_source_type_label_translates_known_and_passes_unknown() -> None:
+    assert source_type_label("GASTAT", "ar") == LABELS["source_type.GASTAT"]["ar"]
+    # EN is identity for known values (byte-identity guarantee).
+    assert source_type_label("GASTAT", "en") == "GASTAT"
+    # Unknown source types pass through unchanged in both langs.
+    assert source_type_label("Bespoke", "ar") == "Bespoke"
+    assert source_type_label("", "ar") == ""
+
+
+# ── 3. EN byte-identity lock (vs the pre-PR-5a pdf.py literals) ──────
+EXPECTED_EN = {
+    "doc_title_prefix": "Estimate",
+    "totals_section": "Totals (SAR)",
+    "cost_breakdown_section": "Cost breakdown",
+    "revenue_breakdown_section": "Revenue breakdown",
+    "parking_summary_section": "Parking summary",
+    "executive_summary_section": "Executive summary",
+    "key_assumptions_section": "Key assumptions",
+    "appendix_calc_trace_section": "Appendix: calculation trace",
+    "appendix_top_comps_section": "Appendix: top comps",
+    "land_value": "Land value",
+    "total_capex": "Total capex",
+    "annual_net_revenue": "Annual net revenue",
+    "annual_noi": "Annual NOI",
+    "unlevered_roi": "Unlevered ROI",
+    "header_item": "Item",
+    "header_amount": "Amount",
+    "header_how_calculated": "How calculated",
+    "header_assumption": "Assumption",
+    "header_value": "Value",
+    "header_source": "Source",
+    "header_detail": "Detail",
+    "header_id": "ID",
+    "header_date": "Date",
+    "header_location": "Location",
+    "header_price_sar_m2": "Price (SAR/m2)",
+    "effective_far_above_ground": "Effective FAR (above-ground)",
+    "residential_bua": "Residential BUA",
+    "retail_bua": "Retail BUA",
+    "office_bua": "Office BUA",
+    "basement_bua": "Basement BUA",
+    "upper_annex_non_far_bua": "Upper annex (non-FAR, +0.5 floor)",
+    "land_cost": "Land cost",
+    "construction_direct": "Construction (direct)",
+    "upper_annex_non_far_cost": "Upper annex construction cost (non-FAR)",
+    "fitout": "Fit-out",
+    "contingency": "Contingency",
+    "consultants": "Consultants",
+    "feasibility_fee": "Feasibility fee",
+    "transaction_costs": "Transaction costs",
+    "annual_net_income": "Annual net income",
+    "opex": "OPEX",
+    "rev_nla_rent_rate": "NLA * rent rate",
+    "rev_sum_income_components": "Sum of income components",
+    "rev_effective_suffix": "effective",
+    "rev_of_annual_net_income": "of annual net income",
+    "rev_annual_net_income_minus_opex": "Annual net income - OPEX",
+    "rev_noi_over_capex": "NOI / total capex",
+    "parking_required_spaces": "Required spaces",
+    "parking_provided_spaces": "Provided spaces",
+    "parking_deficit": "Deficit",
+    "parking_compliant": "Compliant",
+    "yes": "Yes",
+    "no": "No",
+    "na": "N/A",
+    "no_assumptions_available": "No assumptions available.",
+    "far_model_prior": "FAR (model prior)",
+    "income_prefix": "Income:",
+    "source_type.Model": "Model",
+    "source_type.Observed": "Observed",
+    "source_type.GASTAT": "GASTAT",
+    "source_type.Riyadh Municipality": "Riyadh Municipality",
+    "source_type.Derived": "Derived",
+    "source_type.Assumption": "Assumption",
+    "source_type.Manual": "Manual",
+}
+
+
+def test_en_values_match_pre_pr5a_literals() -> None:
+    # Every label routed through t(...,"en") must equal the prior hardcoded
+    # literal — this is the EN byte-identity contract.
+    for token, expected in EXPECTED_EN.items():
+        assert t(token, "en") == expected, token
+
+
+def test_no_unexpected_tokens_without_en_lock() -> None:
+    # If a token is added, add it to EXPECTED_EN too, so EN byte-identity
+    # stays explicitly asserted.
+    assert set(LABELS.keys()) == set(EXPECTED_EN.keys())
+
+
+# ── 4. Arabic byte hygiene ──────────────────────────────────────────
+@pytest.mark.parametrize("token", sorted(LABELS.keys()))
+def test_ar_byte_hygiene(token: str) -> None:
+    ar = LABELS[token]["ar"]
+    assert "ی" not in ar, f"{token}: Farsi yeh U+06CC present"
+    assert "ھ" not in ar, f"{token}: heh-doachashmee U+06BE present"


### PR DESCRIPTION
Thread a `lang` param through the feasibility PDF export and route every
hardcoded English label through a new server-side EN/AR table, without
changing the English output and without exposing Arabic yet.

- app/services/estimator_i18n.py (new): EN/AR label table mirroring
  expansion_advisor_i18n.py. EN values are byte-identical to the prior
  pdf.py literals; AR values reuse the authored terminology from
  frontend/src/i18n/ar.json. `t(token, lang)` falls back to EN and never
  raises; `source_type_label` translates known enums, passes others through.
- app/services/pdf.py: build_memo_pdf gains `lang="en"`; section titles,
  headers, row labels, parking labels, enums and empty-states route through
  the table; _resolve_explanations selects explanations_ar and the summary
  picker selects summary_ar when lang=="ar" (persisted in notes_json).
  ASCII gates are intentionally left untouched (AR latent until PR-5b).
- app/api/estimates.py: export_pdf gains `lang: Literal["en","ar"]="en"`,
  passes it to build_memo_pdf and localizes the title prefix.
- tests/test_estimator_i18n.py: EN/AR parity, EN byte-identity lock,
  fallback behavior and Arabic byte hygiene (U+064A/U+0647; 0x U+06CC/06BE).

EN PDF verified byte-identical (metadata-normalized). AR path renders a
valid PDF (blank/garbled by design pre-5b). Out of scope: font embed,
arabic_reshaper/python-bidi, RTL, digit/unit policy, frontend ?lang.

https://claude.ai/code/session_017MFTYZd3GgZbeHQLkgeR8o