### PR TITLE
fix(i18n-ar): on-screen Arabic cleanup for v2 (asset-class/component labels, FAR term, construction term, FAR rounding, parcel banner)

### DIFF
--- a/docs/arabic-cleanup-v2-report.md
+++ b/docs/arabic-cleanup-v2-report.md
@@ -1,0 +1,143 @@
+# On-screen Arabic cleanup (v2) — implementation report
+
+**Branch:** `claude/arabic-cleanup-v2-DXgiV`
+**Scope:** v2 surfaces only (`ExcelForm.tsx`, `main.tsx` / `ParcelInfoBar.tsx`, `i18n/*.json`). Dead `App.tsx` and its `ui.*` keys untouched. EN wording unchanged. Build clean.
+
+This PR deliberately **excludes** the digit/unit formatting pass (separate investigation): no number formatters or unit glyphs were changed here.
+
+---
+
+## Summary of changes
+
+| File | Change |
+|------|--------|
+| `frontend/src/i18n/en.json` | Additive keys only: `excel.componentBasement`, `app.landuseMethod.*` |
+| `frontend/src/i18n/ar.json` | Same additive keys (AR) + `FAR → معامل الكثافة` in 4 v2 values |
+| `frontend/src/components/ExcelForm.tsx` | `componentLabel()` helper + both render loops; FAR rounding (3 seeds); construction term + inline FAR strings |
+| `frontend/src/main.tsx` | Parcel banner: drop stray land-use code, localize land-use method |
+
+Diff stat: `4 files changed, 44 insertions(+), 24 deletions(-)`.
+
+---
+
+## Part 1 — Asset-class / component labels rendered English
+
+**What was wrong:** Both v2 loops rendered the raw data key.
+
+- Revenue **"إيرادات الإيجار حسب فئة الأصول"** — `ExcelForm.tsx:3478` rendered `prettifyRevenueKey(item?.label || key)`, where `item.label = key.replace(/_/g," ")` (i.e. the raw English key) → showed `residential` / `retail` / `office` / `basement`.
+- Parking **"المطلوب حسب المكوّن"** — `ExcelForm.tsx:3908` rendered `{key}` directly from `Object.entries(parking.requiredByComponent)`.
+
+**Why it happened:** Neither loop routed the component key through the translation layer; they printed the data key verbatim.
+
+**Fix:** Reused the existing component vocabulary already used by the Summary unit-mix cards / construction panel (`excel.componentResidential/Retail/Office`), added the one missing key `excel.componentBasement` (EN `Basement`, AR `قبو`), and added a small `componentLabel()` helper (`ExcelForm.tsx:1864`) that maps known keys and **passthrough-falls back** to the prettified key so an unknown component never blanks. Parking iterates the data type's keys (not a hardcoded four); the revenue fixed array now also routes through `componentLabel`.
+
+```ts
+const componentLabelKeys: Record<string, string> = {
+  residential: "excel.componentResidential",
+  retail: "excel.componentRetail",
+  office: "excel.componentOffice",
+  basement: "excel.componentBasement",
+};
+const componentLabel = (key: string) => {
+  const translationKey = componentLabelKeys[key];
+  return translationKey ? t(translationKey) : prettifyRevenueKey(key);
+};
+```
+
+Render sites updated: revenue label `:3479`, revenue infotip label `:3483`, parking label `:3909`.
+
+> **EN note:** EN rows now read `Residential / Retail / Office / Basement` (matching the summary cards) instead of the old lowercase raw key — a consistency alignment, not a wording change.
+
+---
+
+## Part 2 — `FAR` leak in the construction-cost panel
+
+**What was wrong:** The unit-cost panel showed `تكلفة وحدة الملحق العلوي (غير محسوب في FAR)` — Latin `FAR`, missed in the v2 `FAR → معامل الكثافة` standardization.
+
+**Fix:** Fixed the named key plus every other Latin `FAR` in **v2** AR values:
+
+| Location | Before → After |
+|----------|----------------|
+| `excel.unitCostUpperAnnexNonFar` (reported) | `…في FAR)` → `…في معامل الكثافة)` |
+| `excel.upperAnnexNonFarBua` | `…في FAR، +0.5 طابق)` → `…معامل الكثافة…` |
+| `excel.upperAnnexNonFarCost` | `…في FAR)` → `…في معامل الكثافة)` |
+| `excelNotes.coverageMassing` | `تُستخدم مع FAR…` → `تُستخدم مع معامل الكثافة…` |
+| inline `ExcelForm.tsx:2736` | `…غير محتسب في FAR)` → `…غير محتسب في معامل الكثافة)` |
+
+Grep confirms **0× Latin `FAR` left in v2 AR strings**.
+
+**Left untouched (correctly):** the 5 remaining `FAR` occurrences in `ar.json` —
+`ui.projectInputs.farLabel`, `ui.projectInputs.useAutoFar`, `ui.builtForm.subtitle`, `ui.builtForm.suggestedFar`, `ui.builtForm.potentialBua` — are referenced **only by dead `App.tsx`**, outside the v2-only scope.
+
+---
+
+## Part 3 — Construction term fork (decided)
+
+**What was wrong:** The financial-detail tab used `التنفيذ المباشر` while the calc panel + PDF use `الإنشاء (مباشر)` for the same "Construction (direct)" concept.
+
+**Fix (standardize on `الإنشاء (مباشر)`, matching the shipped PDF):**
+
+- `ExcelForm.tsx:2618` — `directConstructionLabel` AR fallback `التنفيذ المباشر` → `الإنشاء (مباشر)`.
+- `ExcelForm.tsx:2739` — sub-note `…مضمنة ضمن التنفيذ المباشر` → `…مضمنة ضمن الإنشاء (مباشر)`, so the same tab isn't internally forked.
+
+EN fallback `Direct construction` unchanged.
+
+---
+
+## Part 4 — Grep-verify two AR strings (trust bytes, not the screenshot)
+
+Both confirmed **correct at the byte level — no change made.**
+
+- **Revenue upper-annex allocated-to note** (`excel.revenueAllocatedTo`): committed bytes are `مخصّص إلى` =
+  م (U+0645) خ (U+062E) ص (U+0635) **ّ (U+0651 shadda)** ص (U+0635) + `إلى`.
+  → "allocated" — **not** `مختص` (which would carry a teh ت). ✅ left as-is.
+- **Effective-FAR label** (`excel.effectiveFar`): committed bytes are `الفعّال` =
+  …ف (U+0641) **ع (U+0639 AIN)** **ّ (U+0651 shadda)** ا ل.
+  → correct — **not** `الفقال` (no QAF). ✅ left as-is.
+- Whole-file hygiene: **0× U+06CC** (Farsi yeh), **0× U+06BE** (heh doachashmee). Yeh = U+064A, heh = U+0647 throughout.
+
+---
+
+## Part 5 — Effective-FAR value renders as a malformed float
+
+**Render site:** the editable field is bound to `farDraft` (input at `ExcelForm.tsx:2801`, label `excel.effectiveFarAboveGround`).
+
+**Why it happened:** `farDraft` was seeded with raw `String(displayedFar)` in three places, so an unrounded float like `1.5000000003` surfaced in the field:
+- `useEffect` at `:1324`
+- `resetFarDraft()` at `:1780`
+- `startFarEdit()` at `:1825`
+
+**Fix:** All three seeds now use `String(roundTo(Number(displayedFar), 2))` — **display-only**, locale-agnostic. The underlying computed `displayedFar` / area ratios are unchanged. (The read-only table cell at `:3180` was already rounded via `formatNumberValue(..., 3)`.)
+
+---
+
+## Part 6 — Parcel banner: stray `m` + English method
+
+**Render site:** `ui-v2/ParcelInfoBar.tsx` (estimator banner), fed `landUseLabel={codeLabel}` and `methodLabel` from `main.tsx:378`.
+
+- **Stray `m`:** `codeLabel` built the string via `app.landUseCodeLabel` = `"{{code}} — {{label}}"`, prefixing the bare land-use code (`m`/`s`) before the localized use → `m — مختلط/تجاري`. Fixed `codeLabel` to return just the localized label (`app.landUse.mixed` / `app.landUse.residential`), dropping the bare code on both banner sites and both locales.
+- **English method:** `formatLanduseMethod` returned hardcoded English (`ArcGIS parcel label`, `Suhail zoning`, `OSM overlay`). Localized via new `app.landuseMethod.*` keys:
+  - AR: `وسم قطعة ArcGIS`, `تقسيم مناطق Suhail`, `طبقة OSM` (brand names ArcGIS/Suhail/OSM kept Latin, matching existing AR vocabulary).
+  - EN values identical to the prior strings (no wording change).
+
+**Shared with Expansion Advisor?** **No.** `ParcelInfoBar` is imported only by `main.tsx`; `codeLabel` / `formatLanduseMethod` are local to the estimator `App`. EA pages (`ExpansionAdvisorPage`, `CompareOutcomeBanner`) don't use them — EA is not touched or regressed.
+
+---
+
+## Validation
+
+- `cd frontend && npm ci && npm run build` → **clean** (`tsc && vite build` ✓, 578 modules transformed).
+- No `*.test.ts(x)` references the changed surfaces (banner / labels / keys).
+- Grep: **0× Latin `FAR`** in v2 AR strings; AR byte hygiene **0× U+06CC / 0× U+06BE**.
+- EN locale strings unchanged (only additive keys: `componentBasement`, `landuseMethod.*`).
+
+**Risk: low.** Targeted, display-layer changes; no business-logic or computed-value changes.
+
+### AR walk checklist
+
+- [x] Revenue + Parking component rows now Arabic (سكني/تجاري/مكتبي/قبو)
+- [x] Construction panel + financial-detail FAR = `معامل الكثافة`
+- [x] Construction term consistent (`الإنشاء (مباشر)`)
+- [x] Effective-FAR shows a clean number
+- [x] Banner has no stray `m` and no raw English method
+- [x] EN locale unchanged; 0× Latin `FAR` left in v2 AR i18n values

--- a/frontend/src/components/ExcelForm.tsx
+++ b/frontend/src/components/ExcelForm.tsx
@@ -1321,7 +1321,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
 
   useEffect(() => {
     if (!isEditingFar && displayedFar != null) {
-      setFarDraft(String(displayedFar));
+      setFarDraft(String(roundTo(Number(displayedFar), 2)));
     }
   }, [displayedFar, isEditingFar]);
 
@@ -1777,7 +1777,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
   };
 
   const resetFarDraft = () => {
-    setFarDraft(displayedFar != null ? String(displayedFar) : "");
+    setFarDraft(displayedFar != null ? String(roundTo(Number(displayedFar), 2)) : "");
   };
 
   const cancelFarEdit = () => {
@@ -1822,7 +1822,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
   const startFarEdit = () => {
     if (displayedFar == null) return;
     setFarEditError(null);
-    setFarDraft(String(displayedFar));
+    setFarDraft(String(roundTo(Number(displayedFar), 2)));
     setIsEditingFar(true);
   };
   const normalizedFarDraft = normalize2Decimals(farDraft);
@@ -1861,6 +1861,20 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
   });
   const includedBadge = <span className="ui-v2-pill">{isArabic ? "مُدرج" : "Included"}</span>;
   const prettifyRevenueKey = (key: string) => key.replace(/_/g, " ");
+  // Asset-class / parking component labels. Reuses the same component vocabulary
+  // as the summary unit-mix cards and construction panel so Revenue and Parking
+  // rows render سكني/تجاري/مكتبي/قبو instead of raw English keys. Any key not in
+  // the map falls back to the prettified key so an unknown component never blanks.
+  const componentLabelKeys: Record<string, string> = {
+    residential: "excel.componentResidential",
+    retail: "excel.componentRetail",
+    office: "excel.componentOffice",
+    basement: "excel.componentBasement",
+  };
+  const componentLabel = (key: string) => {
+    const translationKey = componentLabelKeys[key];
+    return translationKey ? t(translationKey) : prettifyRevenueKey(key);
+  };
   const V2InfoTip = ({ label, body }: { label: string; body: ReactNode }) => (
     <span className="ui-v2-info">
       <button type="button" className="ui-v2-info__icon" aria-label={label}>i</button>
@@ -2601,7 +2615,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                       const directConstructionLabel = i18n.exists("excel.directConstruction")
                         ? t("excel.directConstruction")
                         : isArabic
-                          ? "التنفيذ المباشر"
+                          ? "الإنشاء (مباشر)"
                           : "Direct construction";
                       const fitoutLabel = i18n.exists("excel.fitout")
                         ? t("excel.fitout")
@@ -2719,10 +2733,10 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                         directCostUpperAnnex != null ||
                         (upperAnnexConstruction != null && directConstruction >= upperAnnexConstruction && directConstruction > 0);
                       const upperAnnexConstructionLabel = isArabic
-                        ? "تكلفة إنشاء الملحق العلوي (غير محتسب في FAR)"
+                        ? "تكلفة إنشاء الملحق العلوي (غير محتسب في معامل الكثافة)"
                         : "Upper annex construction (non-FAR)";
                       const upperAnnexIncludedLabel = isArabic
-                        ? "↳ تكلفة الملحق العلوي (مضمنة ضمن التنفيذ المباشر)"
+                        ? "↳ تكلفة الملحق العلوي (مضمنة ضمن الإنشاء (مباشر))"
                         : "↳ Upper annex construction (included in Direct construction)";
 
                       return (
@@ -3462,11 +3476,11 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                             return (
                               <div key={key} className="ui-v2-row">
                                 <span className="ui-v2-row__label">
-                                  <span>{prettifyRevenueKey(item?.label || key)}</span>
+                                  <span>{componentLabel(key)}</span>
                                   {item?.key && !["residential", "retail", "office"].includes(item.key) && hasIncludedComponent(item.key) ? includedBadge : null}
                                 </span>
                                 <span className="ui-v2-row__val">{formatCurrencySAR(item?.amount || 0)}</span>
-                                <V2InfoTip label={t("excel.infoFor", { label: prettifyRevenueKey(item?.label || key) })} body={(item?.note || "").trim() || "—"} />
+                                <V2InfoTip label={t("excel.infoFor", { label: componentLabel(key) })} body={(item?.note || "").trim() || "—"} />
                               </div>
                             );
                           })}
@@ -3892,7 +3906,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                                 <div className="ui-v2-rowList">
                                   {Object.entries(parking.requiredByComponent).map(([key, value]) => (
                                     <div key={key} className="ui-v2-row">
-                                      <span className="ui-v2-row__label">{key}</span>
+                                      <span className="ui-v2-row__label">{componentLabel(key)}</span>
                                       <span className="ui-v2-row__val">
                                         {toNumericOrNull(value) == null ? "—" : formatNumberValue(toNumericOrNull(value), 0)}
                                       </span>

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -27,6 +27,11 @@
       "residential": "سكني",
       "mixed": "مختلط/تجاري"
     },
+    "landuseMethod": {
+      "parcelLabel": "وسم قطعة ArcGIS",
+      "suhailZoning": "تقسيم مناطق Suhail",
+      "osmOverlay": "طبقة OSM"
+    },
     "modeExpansion": "مستشار التوسع",
     "modeFeasibility": "جدوى التطوير",
     "expansionSubtitle": "اعثر على أفضل فرع تالي لعلامتك التجارية"
@@ -79,6 +84,7 @@
     "componentResidential": "سكني",
     "componentRetail": "تجاري",
     "componentOffice": "مكتبي",
+    "componentBasement": "قبو",
     "financialBreakdown": "التفصيل المالي",
     "calculationsTitle": "الحسابات",
     "financialSummaryTitle": "الملخص المالي",
@@ -99,7 +105,7 @@
     "residentialBua": "مساحة البناء السكنية",
     "retailBua": "مساحة البناء التجارية",
     "officeBua": "مساحة البناء المكتبية",
-    "upperAnnexNonFarBua": "الملحق العلوي (غير محسوب في FAR، +0.5 طابق)",
+    "upperAnnexNonFarBua": "الملحق العلوي (غير محسوب في معامل الكثافة، +0.5 طابق)",
     "basementBua": "مساحة البناء للقبو",
     "landCost": "تكلفة الأرض",
     "constructionDirect": "الإنشاء (مباشر)",
@@ -109,8 +115,8 @@
     "unitCostRetail": "تجاري (ر.س/م²)",
     "unitCostOffice": "مكتبي (ر.س/م²)",
     "unitCostBasement": "قبو (ر.س/م²)",
-    "unitCostUpperAnnexNonFar": "تكلفة وحدة الملحق العلوي (غير محسوب في FAR)",
-    "upperAnnexNonFarCost": "تكلفة إنشاء الملحق العلوي (غير محسوب في FAR)",
+    "unitCostUpperAnnexNonFar": "تكلفة وحدة الملحق العلوي (غير محسوب في معامل الكثافة)",
+    "upperAnnexNonFarCost": "تكلفة إنشاء الملحق العلوي (غير محسوب في معامل الكثافة)",
     "fitout": "التجهيزات",
     "fitoutIncluded": "مشمولة",
     "fitoutExcluded": "مستبعدة",
@@ -231,7 +237,7 @@
     "revenueNoteDash": "—",
     "totalCapexFormula": "{{pct}} من صافي دخل السنة الأولى ÷ إجمالي النفقات الرأسمالية",
     "roiNoiFormula": "NOI للسنة الأولى ÷ إجمالي النفقات الرأسمالية",
-    "coverageMassing": "تُستخدم مع FAR لاستنتاج عدد الأدوار فوق الأرض.",
+    "coverageMassing": "تُستخدم مع معامل الكثافة لاستنتاج عدد الأدوار فوق الأرض.",
     "massingLocks": "اختر مُحرّكًا واحدًا فقط لتحديثات الكتلة."
   },
   "parking": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -27,6 +27,11 @@
       "residential": "Residential",
       "mixed": "Mixed/Commercial"
     },
+    "landuseMethod": {
+      "parcelLabel": "ArcGIS parcel label",
+      "suhailZoning": "Suhail zoning",
+      "osmOverlay": "OSM overlay"
+    },
     "modeExpansion": "Expansion Advisor",
     "modeFeasibility": "Development Feasibility",
     "expansionSubtitle": "Find the best next branch for your F&B brand"
@@ -79,6 +84,7 @@
     "componentResidential": "Residential",
     "componentRetail": "Retail",
     "componentOffice": "Office",
+    "componentBasement": "Basement",
     "financialBreakdown": "Financial breakdown",
     "calculationsTitle": "Calculations",
     "financialSummaryTitle": "Financial Summary",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -92,11 +92,11 @@ function App() {
   const formatLanduseMethod = (method?: string | null): string => {
     switch (method) {
       case "parcel_label":
-        return "ArcGIS parcel label";
+        return t("app.landuseMethod.parcelLabel");
       case "suhail_overlay":
-        return "Suhail zoning";
+        return t("app.landuseMethod.suhailZoning");
       case "osm_overlay":
-        return "OSM overlay";
+        return t("app.landuseMethod.osmOverlay");
       default:
         return "—";
     }
@@ -105,16 +105,10 @@ function App() {
   const codeLabel = (() => {
     const selectedLandUse = parcel?.landuse_code?.trim().toLowerCase();
     if (selectedLandUse === "s") {
-      return t("app.landUseCodeLabel", {
-        code: "s",
-        label: t("app.landUse.residential"),
-      });
+      return t("app.landUse.residential");
     }
     if (selectedLandUse === "m") {
-      return t("app.landUseCodeLabel", {
-        code: "m",
-        label: t("app.landUse.mixed"),
-      });
+      return t("app.landUse.mixed");
     }
     return t("common.notAvailable");
   })();


### PR DESCRIPTION
- Revenue & Parking component rows now render سكني/تجاري/مكتبي/قبو via a
  shared componentLabel() map (adds excel.componentBasement) with passthrough
  fallback so unknown keys never blank.
- Standardize Latin FAR -> معامل الكثافة across v2 AR i18n values and the
  inline construction-panel strings.
- Standardize construction term on الإنشاء (مباشر) in the financial-detail tab.
- Round the effective-FAR draft to 2 decimals for display (both locales);
  underlying computed value unchanged.
- Parcel banner: drop the stray bare land-use code and localize the
  land-use method (no raw English on the AR surface).

EN wording unchanged.