### PR TITLE
Converge AR on-screen digits/units to Arabic-Indic + Arabic units (v2 feasibility)

### DIFF
--- a/frontend/src/components/ExcelForm.tsx
+++ b/frontend/src/components/ExcelForm.tsx
@@ -245,6 +245,8 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
   const notAvailable = t("common.notAvailable");
   const providerLabel = t(`excel.providers.${provider}`);
   const isArabic = i18n.language?.toLowerCase().startsWith("ar");
+  // Scenario/scale notes below are debug instrumentation; only surface them in dev builds.
+  const isDevBuild = typeof import.meta !== "undefined" && Boolean((import.meta as any)?.env?.DEV);
   const scenarioProviders = PROVIDERS.map((item) => ({
     value: item.value,
     label: t(item.labelKey),
@@ -1204,8 +1206,9 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
   const showUpperAnnexHint =
     upperAnnexAreaM2 > 1e-6 &&
     (upperAnnexSink === "residential" || upperAnnexSink === "office");
-  const fmtM2 = (value: number) =>
-    new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+  // Route through the lang-aware formatter so digits are Arabic-Indic in AR.
+  // The unit (`م²`/`m²`) is supplied by the surrounding translation string.
+  const fmtM2 = (value: number) => formatNumberValue(value, 0);
   const upperAnnexHintText = showUpperAnnexHint
     ? t("excel.includesUpperAnnex", { area: fmtM2(upperAnnexAreaM2) }) +
       (upperAnnexNlaAddedM2 > 1e-6 ? t("excel.upperAnnexNla", { nla: fmtM2(upperAnnexNlaAddedM2) }) : "")
@@ -1351,7 +1354,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
 
   const buaNote = (key: string) => {
     const noteKey = `${key}_bua`;
-    const showScenarioScale = scenarioAreaRatio != null && key !== "basement";
+    const showScenarioScale = isDevBuild && scenarioAreaRatio != null && key !== "basement";
     if (explanationsDisplay[noteKey]) {
       return (
         <>
@@ -1404,7 +1407,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
       })
       : t("excelNotes.landCostFallback"));
   const landNote =
-    scenarioLandPrice != null
+    scenarioLandPrice != null && isDevBuild
       ? (
         <>
           <div>{landNoteBase}</div>
@@ -1418,7 +1421,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
   const farNote = (
     <>
       <div>{farNoteBase || t("excel.effectiveFarDefault")}</div>
-      {scenarioAreaRatio != null && (
+      {scenarioAreaRatio != null && isDevBuild && (
         <>
           {scenarioFar != null && (
             <div style={{ marginTop: 4 }}>
@@ -1432,9 +1435,8 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
       )}
     </>
   );
-  const floorsNoteBase =
-    "Used to scale above-ground area ratios when FAR is not manually overridden.";
-  const floorsDisabledNote = "Skipped because FAR was manually overridden.";
+  const floorsNoteBase = t("excelNotes.floorsScaling");
+  const floorsDisabledNote = t("excelNotes.floorsScalingDisabled");
   const farManuallyOverridden =
     inputsRef.current?.disable_floors_scaling === true &&
     resolveMassingLock(inputsRef.current?.massing_lock ?? null) === "far";
@@ -1497,7 +1499,10 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
   const upperAnnexCostNote =
     (typeof explanationsDisplay.upper_annex_non_far_cost === "string" && explanationsDisplay.upper_annex_non_far_cost.trim()) ||
     (upperAnnexArea != null
-      ? `${formatNumberValue(upperAnnexArea, 0)} m² × ${formatNumberValue(upperAnnexUnitCost, 0)} SAR/m².`
+      ? t("excelNotes.upperAnnexCost", {
+        area: formatNumberValue(upperAnnexArea, 0),
+        cost: formatNumberValue(upperAnnexUnitCost, 0),
+      })
       : null);
   const feasibilityNote = feasibilityExcluded
     ? t("excelNotes.feasibilityExcluded")
@@ -1982,7 +1987,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
             onBlur={(event) => commitUnitCostEdit(key, event)}
             onChange={(event) => handleUnitCostChange(key, event.target.value)}
           />
-          <span className="unit-cost-panel__value-unit">SAR</span>
+          <span className="unit-cost-panel__value-unit">{isArabic ? "ر.س" : "SAR"}</span>
           {isEdited && <span className="unit-cost-panel__edited">{t("excel.manualEdited")}</span>}
         </div>
       </div>
@@ -2550,7 +2555,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                       <div className="ui-v2-metric-grid" role="list" aria-label={isArabic ? "متوسط مساحة الوحدة" : "Average unit size"}>
                         {averageUnitSizeItems.map((item) => (
                           <div key={item.key} className="ui-v2-metric-grid__item" role="listitem">
-                            <div className="ui-v2-metric-grid__value">{formatNumberValue(item.value, 0)} m²</div>
+                            <div className="ui-v2-metric-grid__value">{formatArea(item.value)}</div>
                             <div className="ui-v2-metric-grid__label">{item.label}</div>
                           </div>
                         ))}
@@ -2784,7 +2789,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                                         aria-label={t("excel.coverage")}
                                         className="ui-v2-costInput"
                                       />
-                                      <span className="ui-v2-chip">%</span>
+                                      <span className="ui-v2-chip">{isArabic ? "٪" : "%"}</span>
                                       <Button type="button" size="sm" variant="secondary" onClick={commitCoverage}>
                                         {t("excel.apply")}
                                       </Button>
@@ -3122,7 +3127,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                           className="calc-input-coverage"
                           aria-label="Coverage ratio"
                         />
-                        <span>%</span>
+                        <span>{isArabic ? "٪" : "%"}</span>
                         <Button type="button" size="sm" variant="secondary" onClick={commitCoverage} disabled={coverageApplyDisabled}>
                           {t("common.apply")}
                         </Button>
@@ -3543,7 +3548,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                                 className="ui-v2-costInput"
                                 aria-label={t("excel.effectiveIncomePct")}
                               />
-                              <span className="ui-v2-chip">%</span>
+                              <span className="ui-v2-chip">{isArabic ? "٪" : "%"}</span>
                               <Button
                                 type="button"
                                 size="sm"
@@ -3586,7 +3591,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                                 className="ui-v2-costInput"
                                 aria-label={t("excel.opex")}
                               />
-                              <span className="ui-v2-chip">%</span>
+                              <span className="ui-v2-chip">{isArabic ? "٪" : "%"}</span>
                               <Button
                                 type="button"
                                 size="sm"
@@ -3712,7 +3717,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                             className="calc-input-coverage"
                             aria-label={t("excel.effectiveIncomePct")}
                           />
-                          <span>%</span>
+                          <span>{isArabic ? "٪" : "%"}</span>
                         </label>
                         <Button
                           type="button"
@@ -3759,7 +3764,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                             className="calc-input-coverage"
                             aria-label={t("excel.opex")}
                           />
-                          <span>%</span>
+                          <span>{isArabic ? "٪" : "%"}</span>
                           <Button
                             type="button"
                             size="sm"
@@ -3876,7 +3881,7 @@ export default function ExcelForm({ parcel, landUseOverride, mode = "legacy" }: 
                             {t("excel.parkingAutoAdjustmentIncrease", {
                               from: formatNumberValue(parking.baselineBasementAreaM2, 0),
                               to: formatNumberValue(parking.parkingAreaM2, 0),
-                              factor: parking.basementIncreaseFactor!.toFixed(3),
+                              factor: formatNumberValue(parking.basementIncreaseFactor, 3),
                             })}
                           </div>
                         ) : null}

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -183,8 +183,8 @@
     "investmentPerformance": "أداء الاستثمار",
     "yieldInfoBody": "العائد = صافي الدخل التشغيلي السنوي ÷ إجمالي النفقات الرأسمالية.",
     "noParkingWarnings": "لا توجد تنبيهات بشأن المواقف.",
-    "includesUpperAnnex": "يشمل الملحق العلوي: +{{area}} m²",
-    "upperAnnexNla": " (≈ {{nla}} m² NLA)",
+    "includesUpperAnnex": "يشمل الملحق العلوي: +{{area}} م²",
+    "upperAnnexNla": " (≈ {{nla}} م² NLA)",
     "revenueNotePrefix": "ملاحظة:",
     "revenueAllocatedTo": " — مخصّص إلى {{target}}",
     "labelInfo": "معلومات {{label}}",
@@ -202,7 +202,7 @@
     "parkingRequiredByComponent": "المطلوب حسب المكوّن",
     "parkingNotesWarnings": "الملاحظات / التنبيهات",
     "parkingAutoAdjustment": "تم تطبيق تعديل تلقائي: {{detail}}",
-    "parkingAutoAdjustmentIncrease": "تم تطبيق تعديل تلقائي: زيادة مساحة القبو/المواقف من {{from}} m² إلى {{to}} m² (×{{factor}})",
+    "parkingAutoAdjustmentIncrease": "تم تطبيق تعديل تلقائي: زيادة مساحة القبو/المواقف من {{from}} م² إلى {{to}} م² (×{{factor}})",
     "parkingWarnAvgM2Missing": "متوسط مساحة الوحدة غير متوفر لبعض أنواع الوحدات؛ تم تقدير مواقف السكني من إجمالي المساحة السكنية.",
     "parkingWarnUnitMixMissing": "مزيج الوحدات غير متوفر؛ تم تقدير مواقف السكني بموقف واحد لكل وحدة (بافتراض ~{{avg_unit_m2}} m² لكل وحدة).",
     "yieldBand": {
@@ -214,6 +214,9 @@
     }
   },
   "excelNotes": {
+    "upperAnnexCost": "{{area}} م² × {{cost}} ر.س/م².",
+    "floorsScaling": "يُستخدم لقياس نسب المساحة فوق الأرض عند عدم تجاوز معامل البناء يدويًا.",
+    "floorsScalingDisabled": "تم التخطي لأن معامل البناء تم تجاوزه يدويًا.",
     "siteAreaRatio": "مساحة الموقع {{area}} م² × نسبة المساحة {{ratio}}",
     "buaFallback": "مساحة البناء بناءً على النسب المُدخلة",
     "landCost": "مساحة الموقع {{area}} م² × {{price}} ر.س/م² ({{source}})",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -214,6 +214,9 @@
     }
   },
   "excelNotes": {
+    "upperAnnexCost": "{{area}} m² × {{cost}} SAR/m².",
+    "floorsScaling": "Used to scale above-ground area ratios when FAR is not manually overridden.",
+    "floorsScalingDisabled": "Skipped because FAR was manually overridden.",
     "siteAreaRatio": "{{area}} m² × ratio {{ratio}}",
     "buaFallback": "Built-up area from ratios",
     "landCost": "{{area}} m² × {{price}} SAR/m² ({{source}})",

--- a/frontend/src/i18n/format.ts
+++ b/frontend/src/i18n/format.ts
@@ -30,11 +30,22 @@ export const formatInteger = (value: number | string | null | undefined, fallbac
 export const formatCurrencySAR = (value: number | string | null | undefined, fallback = FALLBACK_VALUE) => {
   const num = parseNumber(value);
   if (num == null) return fallback;
-  return new Intl.NumberFormat(resolveNumberLocale(), {
+  const formatter = new Intl.NumberFormat(resolveNumberLocale(), {
     style: "currency",
     currency: "SAR",
     maximumFractionDigits: 0,
-  }).format(num);
+  });
+  if (!isArabicLocale(i18n.language)) {
+    return formatter.format(num);
+  }
+  // AR: keep Intl's Arabic-Indic digit shaping and the directional marks it
+  // injects for correct RTL ordering, but render the bare `ر.س` symbol instead
+  // of Intl's trailing-dot `ر.س.` form, for parity with the PDF and the unit
+  // strings (`ر.س/م²`).
+  return formatter
+    .formatToParts(num)
+    .map((part) => (part.type === "currency" ? "ر.س" : part.value))
+    .join("");
 };
 
 export const formatAreaM2 = (value: number | string | null | undefined, options?: Intl.NumberFormatOptions, fallback = FALLBACK_VALUE) => {


### PR DESCRIPTION
Route bypass sites back through the lang-aware formatters and normalize
units/symbols in the AR locale to match the shipped PDF:

- formatCurrencySAR: render bare ر.س (drop Intl trailing-dot form) in AR,
  keeping Arabic-Indic digits and RTL directional marks
- upper-annex note: format via lang-aware formatter (was browser-default locale)
- parking auto-adjust factor: format via lang-aware formatter (was toFixed)
- Average Unit Size cards + unit-cost chip + % chips: Arabic units/glyph in AR
- upper-annex cost fallback and floors notes moved to i18n keys
- ar.json: Latin m² -> م² in upper-annex / parking strings
- dev-gate scenario/scale debug notes (production-hidden, any locale)

Editable inputs and opex.ts parsing/storage unchanged (stay Latin). EN unchanged.

https://claude.ai/code/session_013cZADwTBtLyWj4ajNhKQyE