### PR TITLE
feat(expansion): L1 demand-generator index (PR-1, additive, emit-only)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -119,6 +119,25 @@ class Settings:
         os.getenv("EXPANSION_REALIZED_DEMAND_REFERENCE", "263.0")
     )
 
+    # --- Expansion Advisor L1 modeled demand-generator index (PR-1) ---
+    # Additive, emit-only feature: builds a per-candidate demand-generator
+    # index (catchment population + OSM trip generators + Overture building
+    # floor-density + free review_count-weighted F&B density) and writes it
+    # into feature_snapshot_json["demand_generator_index"] for validation.
+    # It is a demand NUMERATOR only and is NOT read by scoring in PR-1.
+    # Default OFF: when false the whole enrich path is inert and rankings /
+    # feature_snapshot_json are byte-for-byte unchanged.
+    EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED: bool = (
+        os.getenv("EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED", "false").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+    # Dine-in demand catchment radius (metres). Single configurable constant so
+    # validation can retune without a code change. Matches
+    # _CATCHMENT_RADII_M["dine_in"]["demand"] (3500 m).
+    EXPANSION_DEMAND_GENERATOR_RADIUS_M: int = int(
+        os.getenv("EXPANSION_DEMAND_GENERATOR_RADIUS_M", "3500")
+    )
+
     # --- Expansion Advisor structured decision memo (Phase 1) ---
     # Model/token/temperature controls for the new structured memo path in
     # ``app.services.llm_decision_memo``. When ``EXPANSION_MEMO_STRUCTURED_ENABLED``

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -1794,6 +1794,124 @@ def _foot_traffic_score(nearby_amenity_count: int) -> float:
     return min(90.0, max(30.0, raw))
 
 
+# ── L1 modeled demand-generator index (PR-1, emit-only) ─────────────────────
+# Per-candidate demand NUMERATOR built entirely from data we already own:
+# catchment population + OSM trip generators + Overture building floor-density +
+# a free review_count-weighted F&B-density term (the zero-cost stand-in for
+# BestTime busyness — it captures "venues people actually visit"; its only real
+# gap vs a paid busyness feed is temporal shape). For dine_in this replaces the
+# effectively-absent foot_traffic signal (_foot_traffic_score is a cafe-only
+# nudge today). PR-1 only EMITS it into feature_snapshot_json; nothing here is
+# read by scoring (that is PR-2).
+#
+# NET-OF-SUPPLY DISCIPLINE: this index is a demand numerator only. Competition /
+# POI density stays in _competition_whitespace_score as the denominator and is
+# NOT subtracted here. The F&B review-weighted term correlates with competitor
+# count by construction (busy venues ⇒ more nearby F&B); that correlation is
+# expected and is exactly why the denominator must stay separate — the index
+# must not double as a saturation signal.
+_DEMAND_GENERATOR_WEIGHTS_VERSION = "l1_v1_2026-06"
+
+# Per-generator-type weights for the OSM sub-score. Seeded from the heatmap
+# path's _ANCHOR_WEIGHTS (restaurant_scoring_factors.py:772-784), regrouped onto
+# the seven generator buckets enriched here; transit/mosque buckets (absent from
+# the anchor table) take conservative mid/low values. Used as Σ(count·weight) →
+# sigmoid, mirroring _demand_anchor_score. Module constant + emitted
+# weights_version so PR-2 can recalibrate without re-running enrich.
+_DEMAND_GENERATOR_OSM_WEIGHTS: dict[str, float] = {
+    "offices": 2.0,
+    "malls_retail": 4.0,
+    "transit": 2.0,
+    "mosques": 1.5,
+    "schools": 1.75,
+    "hospitals": 2.0,
+    "hotels": 2.5,
+}
+
+# Top-level composite weights over the four normalized sub-signals (sum 1.0).
+_DEMAND_GENERATOR_COMPOSITE_WEIGHTS: dict[str, float] = {
+    "population": 0.30,
+    "fnb_review_weighted": 0.25,
+    "osm_generators": 0.25,
+    "building_floors": 0.20,
+}
+
+
+def _demand_generator_osm_subscore(osm_counts: dict[str, int]) -> float:
+    """Σ(count·weight) over generator buckets → 0-100 via the _demand_anchor_score sigmoid."""
+    weighted_total = 0.0
+    for _kind, _w in _DEMAND_GENERATOR_OSM_WEIGHTS.items():
+        weighted_total += _w * float(osm_counts.get(_kind, 0) or 0)
+    # Same saturating curve as restaurant_scoring_factors._demand_anchor_score.
+    return _clamp(10.0 + 85.0 * (1.0 - math.exp(-weighted_total / 20.0)))
+
+
+def _demand_generator_index(
+    *,
+    population_reach: float,
+    osm_counts: dict[str, int],
+    building_floors_proxy_sum: float,
+    fnb_review_weighted: float,
+    fnb_venue_count: int,
+    radius_m: int,
+) -> dict[str, Any]:
+    """Compose the emit-only L1 demand-generator index for one candidate.
+
+    Each sub-signal is normalized to 0-100 with the same log/sqrt-scaled family
+    used by _population_score / _foot_traffic_score (so a single busy outlier
+    cannot dominate), then combined with the top-level composite weights. ALL raw
+    sub-values are retained in the returned dict so PR-2 can recalibrate weights
+    against real data without re-running the bulk enrich.
+
+    NOTE on review_count staleness: Google review enrichment is currently
+    disabled, so review_count is a stale snapshot. That is acceptable here — the
+    term is used only for RELATIVE cross-candidate ranking, not as a live count.
+    """
+    # Population: reuse the dine-in saturation reference (250k @ 3.5 km).
+    pop_sub = _population_score(_safe_float(population_reach), service_model="dine_in")
+    # OSM generators: weighted-count sigmoid.
+    osm_sub = _demand_generator_osm_subscore(osm_counts)
+    # Building floor-density daytime proxy (log-scaled; ref ~2000 floor-equiv).
+    _floors = max(0.0, _safe_float(building_floors_proxy_sum))
+    floors_sub = _clamp(math.log1p(_floors) / math.log1p(2000.0) * 100.0)
+    # Free F&B review-weighted density (log-scaled; ref ~5000 summed reviews).
+    _rw = max(0.0, _safe_float(fnb_review_weighted))
+    fnb_sub = _clamp(math.log1p(_rw) / math.log1p(5000.0) * 100.0)
+
+    w = _DEMAND_GENERATOR_COMPOSITE_WEIGHTS
+    composite = _clamp(
+        pop_sub * w["population"]
+        + fnb_sub * w["fnb_review_weighted"]
+        + osm_sub * w["osm_generators"]
+        + floors_sub * w["building_floors"]
+    )
+    return {
+        "composite_0_100": round(composite, 2),
+        "weights_version": _DEMAND_GENERATOR_WEIGHTS_VERSION,
+        "radius_m": int(radius_m),
+        "population_reach": int(round(_safe_float(population_reach))),
+        "osm_generators": {
+            "offices": int(osm_counts.get("offices", 0) or 0),
+            "malls_retail": int(osm_counts.get("malls_retail", 0) or 0),
+            "transit": int(osm_counts.get("transit", 0) or 0),
+            "mosques": int(osm_counts.get("mosques", 0) or 0),
+            "schools": int(osm_counts.get("schools", 0) or 0),
+            "hospitals": int(osm_counts.get("hospitals", 0) or 0),
+            "hotels": int(osm_counts.get("hotels", 0) or 0),
+        },
+        "building_floors_proxy_sum": round(_floors, 2),
+        "fnb_review_weighted_density": round(_rw, 2),
+        "fnb_venue_count": int(fnb_venue_count or 0),
+        # Derived 0-100 sub-scores retained for transparency / PR-2 calibration.
+        "subscores": {
+            "population": round(pop_sub, 2),
+            "osm_generators": round(osm_sub, 2),
+            "building_floors": round(floors_sub, 2),
+            "fnb_review_weighted": round(fnb_sub, 2),
+        },
+    }
+
+
 def _parking_score(*, area_m2: float, service_model: str, nearby_parking_count: int, access_score: float, parking_context_available: bool = True) -> float:
     area_signal = _clamp((area_m2 / 300.0) * 100.0)
     if not parking_context_available:
@@ -7406,6 +7524,11 @@ def run_expansion_search(
     # ── Bulk delivery enrichment (replaces per-candidate N+1 pattern) ──
     _bulk_delivery: dict[str, dict[str, int]] = {}
     _bulk_foot_traffic: dict[str, int] = {}
+    # L1 demand-generator index (PR-1, emit-only). Populated only when the
+    # feature flag is on; otherwise these stay empty and nothing is emitted.
+    _bulk_osm_generators: dict[str, dict[str, int]] = {}
+    _bulk_building_floors: dict[str, float] = {}
+    _bulk_fnb_density: dict[str, dict[str, float]] = {}
     if ea_delivery_populated:
         try:
             # Build a VALUES list of (parcel_id, lon, lat) for all candidates
@@ -8503,6 +8626,195 @@ def run_expansion_search(
         logger.info("expansion_search timing: bulk_foot_traffic=%.2fs search_id=%s",
                      t_ft_done - t_ft_start, search_id)
 
+    # ── L1 demand-generator index enrichment (PR-1, emit-only, flag-gated) ──
+    # Builds the per-candidate demand NUMERATOR signals for
+    # feature_snapshot_json["demand_generator_index"]. Coordinate-based (the
+    # _shortlist_coords / ST_MakePoint pattern), one bulk query per source (no
+    # per-candidate N+1), each independently guarded by _cached_table_available
+    # so a missing externally-imported table no-ops without affecting the rest.
+    # NOTHING here feeds scoring (PR-2 wires it in).
+    if settings.EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED and _shortlist_coords:
+        t_dg_start = time.monotonic()
+        _dg_radius = float(settings.EXPANSION_DEMAND_GENERATOR_RADIUS_M)
+        # Shared VALUES list of (parcel_id, lon, lat) for the whole shortlist.
+        _dg_value_parts: list[str] = []
+        _dg_coord_params: dict[str, Any] = {}
+        for _dgi, (_dg_pid, _dg_co) in enumerate(_shortlist_coords.items()):
+            _dg_value_parts.append(
+                f"(:dgp_{_dgi}, CAST(:dgx_{_dgi} AS double precision), CAST(:dgy_{_dgi} AS double precision))"
+            )
+            _dg_coord_params[f"dgp_{_dgi}"] = _dg_pid
+            _dg_coord_params[f"dgx_{_dgi}"] = _dg_co[0]
+            _dg_coord_params[f"dgy_{_dgi}"] = _dg_co[1]
+        _dg_values_sql = ", ".join(_dg_value_parts)
+
+        # 1) OSM trip generators (planet_osm_point + planet_osm_polygon; way=4326
+        #    via osm2pgsql --latlong, but ST_Transform(...,4326) is applied
+        #    defensively to mirror restaurant_scoring_factors._demand_anchor_score).
+        _dg_osm_point_ok = _cached_table_available(db, "public.planet_osm_point")
+        _dg_osm_poly_ok = _cached_table_available(db, "public.planet_osm_polygon")
+        if _dg_values_sql and (_dg_osm_point_ok or _dg_osm_poly_ok):
+            # CASE tags each feature with its generator bucket using the
+            # default.style dedicated columns the repo already relies on
+            # (amenity/shop/building) plus standard office/railway/tourism.
+            # TODO(L1): public_transport lives only in the hstore `tags` column;
+            # excluded here to avoid an hstore dependency. Add later via
+            # tags->'public_transport' behind an hstore-safe guard.
+            _dg_osm_case = """
+                CASE
+                  WHEN (lower(COALESCE(office,'')) <> '' OR lower(COALESCE(building,'')) IN ('office','commercial')) THEN 'offices'
+                  WHEN (lower(COALESCE(shop,'')) IN ('mall','supermarket','department_store','wholesale') OR lower(COALESCE(amenity,'')) = 'marketplace') THEN 'malls_retail'
+                  WHEN (lower(COALESCE(railway,'')) IN ('station','halt','tram_stop','subway_entrance','stop') OR lower(COALESCE(amenity,'')) IN ('bus_station')) THEN 'transit'
+                  WHEN (lower(COALESCE(amenity,'')) IN ('place_of_worship','mosque') OR lower(COALESCE(building,'')) = 'mosque') THEN 'mosques'
+                  WHEN (lower(COALESCE(amenity,'')) IN ('school','college','university','kindergarten') OR lower(COALESCE(building,'')) IN ('school','university')) THEN 'schools'
+                  WHEN (lower(COALESCE(amenity,'')) IN ('hospital','clinic','doctors')) THEN 'hospitals'
+                  WHEN (lower(COALESCE(tourism,'')) IN ('hotel','motel','hostel','guest_house') OR lower(COALESCE(building,'')) = 'hotel') THEN 'hotels'
+                  ELSE NULL
+                END
+            """
+            _dg_osm_union: list[str] = []
+            if _dg_osm_point_ok:
+                _dg_osm_union.append(f"""
+                    SELECT {_dg_osm_case} AS kind
+                    FROM planet_osm_point p
+                    WHERE p.way IS NOT NULL
+                      AND ST_DWithin(
+                          ST_Transform(p.way, 4326)::geography,
+                          ST_SetSRID(ST_MakePoint(c.lon, c.lat), 4326)::geography,
+                          :dg_radius)
+                """)
+            if _dg_osm_poly_ok:
+                _dg_osm_union.append(f"""
+                    SELECT {_dg_osm_case} AS kind
+                    FROM planet_osm_polygon pg
+                    WHERE pg.way IS NOT NULL
+                      AND ST_DWithin(
+                          ST_Transform(pg.way, 4326)::geography,
+                          ST_SetSRID(ST_MakePoint(c.lon, c.lat), 4326)::geography,
+                          :dg_radius)
+                """)
+            _dg_osm_query = f"""
+                WITH cand(parcel_id, lon, lat) AS (VALUES {_dg_values_sql})
+                SELECT c.parcel_id,
+                    COUNT(*) FILTER (WHERE g.kind = 'offices')      AS offices,
+                    COUNT(*) FILTER (WHERE g.kind = 'malls_retail') AS malls_retail,
+                    COUNT(*) FILTER (WHERE g.kind = 'transit')      AS transit,
+                    COUNT(*) FILTER (WHERE g.kind = 'mosques')      AS mosques,
+                    COUNT(*) FILTER (WHERE g.kind = 'schools')      AS schools,
+                    COUNT(*) FILTER (WHERE g.kind = 'hospitals')    AS hospitals,
+                    COUNT(*) FILTER (WHERE g.kind = 'hotels')       AS hotels
+                FROM cand c
+                LEFT JOIN LATERAL ({" UNION ALL ".join(_dg_osm_union)}) g
+                    ON g.kind IS NOT NULL
+                GROUP BY c.parcel_id
+            """
+            try:
+                with db.begin_nested():
+                    _dg_osm_rows = db.execute(
+                        text(_dg_osm_query),
+                        {**_dg_coord_params, "dg_radius": _dg_radius},
+                    ).mappings().all()
+                for _r in _dg_osm_rows:
+                    _bulk_osm_generators[str(_r["parcel_id"])] = {
+                        "offices": _safe_int(_r.get("offices")),
+                        "malls_retail": _safe_int(_r.get("malls_retail")),
+                        "transit": _safe_int(_r.get("transit")),
+                        "mosques": _safe_int(_r.get("mosques")),
+                        "schools": _safe_int(_r.get("schools")),
+                        "hospitals": _safe_int(_r.get("hospitals")),
+                        "hotels": _safe_int(_r.get("hotels")),
+                    }
+                logger.info("expansion_search L1 osm_generators: enriched=%d/%d search_id=%s",
+                            len(_bulk_osm_generators), len(_shortlist_coords), search_id)
+            except Exception:
+                logger.debug("expansion_search L1 osm_generators failed", exc_info=True)
+
+        # 2) Overture building floor-density (daytime-population proxy). geom is
+        #    declared SRID 32638; ST_Transform(...,4326) handles it either way.
+        #    floors_proxy mirrors overture_buildings_metrics.py:43-46; buildings
+        #    without floor/height tags contribute 1 (footprint presence).
+        if _dg_values_sql and _cached_table_available(db, "public.overture_buildings"):
+            _dg_floors_query = f"""
+                WITH cand(parcel_id, lon, lat) AS (VALUES {_dg_values_sql})
+                SELECT c.parcel_id, COALESCE(b.floors_sum, 0) AS floors_sum
+                FROM cand c
+                LEFT JOIN LATERAL (
+                    SELECT SUM(
+                        CASE
+                          WHEN o.num_floors IS NOT NULL AND o.num_floors > 0 THEN LEAST(60, GREATEST(1, round(o.num_floors)::int))
+                          WHEN o.height IS NOT NULL AND o.height > 0 THEN LEAST(60, GREATEST(1, round(o.height / 3.2)::int))
+                          ELSE 1
+                        END
+                    ) AS floors_sum
+                    FROM overture_buildings o
+                    WHERE o.geom IS NOT NULL
+                      AND ST_DWithin(
+                          ST_Transform(o.geom, 4326)::geography,
+                          ST_SetSRID(ST_MakePoint(c.lon, c.lat), 4326)::geography,
+                          :dg_radius)
+                ) b ON TRUE
+            """
+            try:
+                with db.begin_nested():
+                    _dg_fl_rows = db.execute(
+                        text(_dg_floors_query),
+                        {**_dg_coord_params, "dg_radius": _dg_radius},
+                    ).mappings().all()
+                for _r in _dg_fl_rows:
+                    _bulk_building_floors[str(_r["parcel_id"])] = _safe_float(_r.get("floors_sum"))
+                logger.info("expansion_search L1 building_floors: enriched=%d/%d search_id=%s",
+                            len(_bulk_building_floors), len(_shortlist_coords), search_id)
+            except Exception:
+                logger.debug("expansion_search L1 building_floors failed", exc_info=True)
+
+        # 3) Free review_count-weighted F&B density (zero-cost BestTime stand-in).
+        #    Uses the Advisor's own F&B category filter (keys from
+        #    _expand_category) and excludes permanently-closed venues. Numerator
+        #    only — competitor density stays in _competition_whitespace_score.
+        _dg_category_keys = list(_cat_expanded["keys"] or [])
+        if _dg_values_sql and _dg_category_keys and _cached_table_available(db, "public.restaurant_poi"):
+            _dg_fnb_query = f"""
+                WITH cand(parcel_id, lon, lat) AS (VALUES {_dg_values_sql})
+                SELECT c.parcel_id,
+                    COALESCE(f.review_weighted, 0) AS review_weighted,
+                    COALESCE(f.venue_count, 0) AS venue_count
+                FROM cand c
+                LEFT JOIN LATERAL (
+                    SELECT SUM(COALESCE(rp.review_count, 0)) AS review_weighted,
+                           COUNT(*) AS venue_count
+                    FROM restaurant_poi rp
+                    WHERE rp.geom IS NOT NULL
+                      AND rp.business_status IS DISTINCT FROM 'CLOSED_PERMANENTLY'
+                      AND lower(rp.category) = ANY(:dg_category_keys)
+                      AND ST_DWithin(
+                          rp.geom::geography,
+                          ST_SetSRID(ST_MakePoint(c.lon, c.lat), 4326)::geography,
+                          :dg_radius)
+                ) f ON TRUE
+            """
+            try:
+                with db.begin_nested():
+                    _dg_fnb_rows = db.execute(
+                        text(_dg_fnb_query),
+                        {
+                            **_dg_coord_params,
+                            "dg_radius": _dg_radius,
+                            "dg_category_keys": _dg_category_keys,
+                        },
+                    ).mappings().all()
+                for _r in _dg_fnb_rows:
+                    _bulk_fnb_density[str(_r["parcel_id"])] = {
+                        "review_weighted": _safe_float(_r.get("review_weighted")),
+                        "venue_count": _safe_int(_r.get("venue_count")),
+                    }
+                logger.info("expansion_search L1 fnb_density: enriched=%d/%d search_id=%s",
+                            len(_bulk_fnb_density), len(_shortlist_coords), search_id)
+            except Exception:
+                logger.debug("expansion_search L1 fnb_density failed", exc_info=True)
+
+        logger.info("expansion_search timing: bulk_demand_generator=%.2fs search_id=%s",
+                     time.monotonic() - t_dg_start, search_id)
+
     _bulk_competitors: dict[str, list[dict[str, Any]]] = {}
     t_comp_start = time.monotonic()
     if _shortlist_parcel_ids:
@@ -8939,6 +9251,20 @@ def run_expansion_search(
             bulk_roads=_bulk_roads.get(_pid_str),
             bulk_parking=_bulk_parking.get(_pid_str),
         )
+        # ── L1 demand-generator index (PR-1, emit-only; flag-gated) ──
+        # Numerator-only composite written for validation. NOT read by scoring;
+        # when the flag is off the bulk dicts are empty and no key is emitted,
+        # so feature_snapshot_json and rankings are byte-for-byte unchanged.
+        if settings.EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED:
+            _dg_fnb = _bulk_fnb_density.get(_pid_str, {})
+            feature_snapshot_json["demand_generator_index"] = _demand_generator_index(
+                population_reach=population_reach,
+                osm_counts=_bulk_osm_generators.get(_pid_str, {}),
+                building_floors_proxy_sum=_bulk_building_floors.get(_pid_str, 0.0),
+                fnb_review_weighted=_dg_fnb.get("review_weighted", 0.0),
+                fnb_venue_count=_dg_fnb.get("venue_count", 0),
+                radius_m=settings.EXPANSION_DEMAND_GENERATOR_RADIUS_M,
+            )
         # Compute the two raw ages independently so the pill logic on the
         # frontend and in _top_positives_and_risks can decide "New" vs
         # "Updated" without relying on which timestamp won the GREATEST()

--- a/scripts/diagnostics/PR1_l1_demand_generator_index.md
+++ b/scripts/diagnostics/PR1_l1_demand_generator_index.md
@@ -1,0 +1,64 @@
+# PR-1: L1 Demand-Generator Index (enrich, additive, emit-only)
+
+Branch: `feat/l1-demand-generator-index-enrich`
+
+## What this does
+Builds a per-candidate **`demand_generator_index`** from data we already own and **emits it into `feature_snapshot_json` for validation — without wiring it into the score** (that's PR-2). For `dine_in` this is the signal that replaces the effectively-absent `foot_traffic` proxy (which is a cafe-only nudge today). It deliberately includes a **free `review_count`-weighted F&B-density term** so we can measure how much observed dine-in activity it captures *before* deciding whether to pay for BestTime (L2).
+
+## Feature flag (default OFF)
+- `EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED` (default `false`) — entire path inert when off.
+- `EXPANSION_DEMAND_GENERATOR_RADIUS_M` (default `3500`) — single configurable dine-in catchment radius.
+
+## Files changed (all additive — 0 deletions in `expansion_advisor.py`)
+- `app/core/config.py:122-141` — the two settings above.
+- `app/services/expansion_advisor.py`:
+  - `:1797-1916` — `_DEMAND_GENERATOR_*` weight constants (seeded from `_ANCHOR_WEIGHTS`, regrouped), `_demand_generator_osm_subscore`, and `_demand_generator_index` (composite; reuses `_population_score` + the `_demand_anchor_score` sigmoid; retains every raw sub-value; documents net-of-supply + `review_count` staleness).
+  - `:7416-7421` — three new bulk dicts declared beside `_bulk_foot_traffic`.
+  - `:8649-8830` (after the foot-traffic block) — three coordinate-based bulk-enrich blocks (OSM generators / Overture floor-density / free F&B review-weighted density), flag-gated, each guarded by `_cached_table_available` and an independent statement so a missing externally-imported table no-ops without affecting the others. One bulk query per source (no N+1), keyed on `_shortlist_coords`.
+  - `:8949-8963` (in the second-pass loop, right after `_candidate_feature_snapshot`) — emits `feature_snapshot_json["demand_generator_index"]` only when the flag is on.
+- `tests/test_expansion_advisor_demand_generator.py` — new.
+- `scripts/diagnostics/l1_index_validation.sql` — new.
+
+## Confirmation: rankings unchanged when OFF
+- `expansion_advisor.py` diff is **326 insertions, 0 deletions** — no edits to `component_weights`, `_demand_blend_weights`, the `sum==100` invariant, any gate, or `final_score`.
+- Test `test_flag_off_emits_no_index_key` asserts no snapshot key when off; `test_flag_on_emits_index_without_changing_scores` runs the same search off→on and asserts `final_score` + ordering are **identical**, with the index present only as an extra snapshot key.
+- `test_demand_blend_weights_unchanged` pins the blend weights; `_normalize_feature_snapshot` (`:1219`) is non-destructive so the new key persists to `expansion_candidate.feature_snapshot_json`.
+- Full local run: **271 passed** (advisor service/unit/demand-generator), broader advisor suite **382 passed, 7 skipped** (the skips are the postgres-only radiance tests).
+
+## The composite (transparent, retains raw sub-values)
+Each sub-signal is normalized to 0–100 with the same log/sqrt family already used by `_population_score` / `_foot_traffic_score`, then combined:
+
+| Sub-signal | Source | Normalization | Top weight |
+|---|---|---|---|
+| population | `population_density` (reuses `population_reach`) | `_population_score(..., "dine_in")` (250k ref) | 0.30 |
+| fnb_review_weighted | `restaurant_poi` Σ`review_count` (F&B filter, excl. permanently closed) | log-scale (ref ~5000) | 0.25 |
+| osm_generators | `planet_osm_point` + `planet_osm_polygon` | Σ(count·weight) → `_demand_anchor_score` sigmoid | 0.25 |
+| building_floors | `overture_buildings` floors proxy sum | log-scale (ref ~2000) | 0.20 |
+
+OSM generator buckets + per-type weights (seeded from `_ANCHOR_WEIGHTS`): offices 2.0, malls_retail 4.0, transit 2.0, mosques 1.5, schools 1.75, hospitals 2.0, hotels 2.5. Emitted `weights_version` lets PR-2 recalibrate against real data without re-running enrich.
+
+## Net-of-supply discipline
+The index is a demand **numerator only** — it takes no competitor argument and never subtracts competition. Competitor/POI density stays in `_competition_whitespace_score`. The F&B review-weighted term correlates with competitor count by construction; that's expected and is exactly why the denominator stays separate (test `test_index_is_numerator_only_more_fnb_raises_score`).
+
+## Exclusions honored
+- **Radiance excluded** from the index (already an advisory tilt via `radiance_growth_pass`).
+- `public_transport` excluded from the transit bucket for now (it lives only in the hstore `tags` column) — `# TODO(L1)` left in code to add behind an hstore-safe guard.
+- `ms_buildings_raw` skipped (footprint only, no floors); Overture is the floor source.
+- `review_count` staleness documented in code (used for relative ranking only).
+
+## Validation plan (run in Codespace after deploy with the flag ON)
+`psql "$DATABASE_URL" -f scripts/diagnostics/l1_index_validation.sql` — reads the **most recent dine-in search**'s candidates and checks the three success criteria:
+1. **Populated** — index + all sub-components non-null for dine-in candidates.
+2. **Varies** — composite spread (min/avg/p50/max/stddev, n_nonzero, distinct values); not constant / not mostly-zero.
+3. **Diverges from competition** — Pearson `corr(composite, competitor_count)` and `corr(composite, whitespace)` well below 1 ⇒ independent demand signal, not a competitor proxy.
+
+Plus a `DISTINCT ON (district)` view to eyeball 3+ candidates in different districts.
+**Requires a fresh dine-in search after deploy** — old searches won't backfill the snapshot (their `demand_generator_index` is NULL and is filtered out).
+
+## Anchors that had drifted from the prompt
+The prompt's `path:line` anchors (from the read-only report) were all slightly shifted on `main` and I adapted:
+- `_bulk_foot_traffic` block is ~`:8540` (not `:8435`); `_shortlist_coords` ~`:8330`; `category_keys` does **not** exist in the main function — the in-scope variable is `_cat_expanded` (`:7291`), so the F&B filter uses `_cat_expanded["keys"]`.
+- `planet_osm.way` is **SRID 4326** (osm2pgsql `--latlong`), not 3857 as one source in the report claimed; `ST_Transform(...,4326)` is still applied defensively.
+
+## Risk
+**Low.** Additive + flag-gated + degrade-silently on missing tables; default-OFF means production behavior is byte-for-byte unchanged until you flip the flag for a validation search.

--- a/scripts/diagnostics/l1_index_validation.sql
+++ b/scripts/diagnostics/l1_index_validation.sql
@@ -1,0 +1,140 @@
+-- ============================================================================
+-- l1_index_validation.sql
+-- ----------------------------------------------------------------------------
+-- Validate the PR-1 L1 demand-generator index AFTER a fresh dine-in search was
+-- run with EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED=true.
+--
+-- It reads expansion_candidate.feature_snapshot_json->'demand_generator_index'
+-- for the MOST RECENT dine-in search and surfaces the composite + every
+-- sub-component alongside each candidate's district, competitor_count, and
+-- whitespace_score (the competition_whitespace input), so we can eyeball that:
+--
+--   1. the index + all sub-components are populated (non-null) for dine-in candidates,
+--   2. the composite VARIES across candidates (not mostly-zero, not constant), and
+--   3. the composite DIVERGES from competitor density — proving it carries
+--      independent demand signal, not just a competitor proxy.
+--
+-- IMPORTANT: validation requires a FRESH dine-in search after deploy with the
+-- flag ON. Old searches won't backfill the snapshot, so their candidates will
+-- have a NULL demand_generator_index and are filtered out below.
+--
+-- HOW TO RUN (iPad/Safari friendly — psql -f safe, no \set, no heredocs):
+--   psql "$DATABASE_URL" -f scripts/diagnostics/l1_index_validation.sql
+-- ============================================================================
+
+\timing on
+
+-- Stage the most-recent dine-in search's candidates with the index flattened.
+DROP TABLE IF EXISTS l1_val;
+CREATE TEMP TABLE l1_val AS
+WITH latest AS (
+    SELECT id, created_at
+    FROM expansion_search
+    WHERE service_model = 'dine_in'
+    ORDER BY created_at DESC
+    LIMIT 1
+)
+SELECT
+    ec.parcel_id,
+    ec.district,
+    ec.final_score,
+    ec.competitor_count,
+    ec.whitespace_score                                                   AS competition_whitespace,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'composite_0_100')::numeric AS dg_composite,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'population_reach')::numeric AS pop_reach,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'fnb_review_weighted_density')::numeric AS fnb_review_weighted,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'fnb_venue_count')::int      AS fnb_venue_count,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'building_floors_proxy_sum')::numeric AS building_floors_sum,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'offices')::int      AS osm_offices,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'malls_retail')::int AS osm_malls_retail,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'transit')::int      AS osm_transit,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'mosques')::int      AS osm_mosques,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'schools')::int      AS osm_schools,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'hospitals')::int    AS osm_hospitals,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'hotels')::int       AS osm_hotels,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'weights_version') AS weights_version,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'radius_m')::int   AS radius_m
+FROM expansion_candidate ec
+JOIN latest l ON ec.search_id = l.id
+WHERE ec.feature_snapshot_json -> 'demand_generator_index' IS NOT NULL;
+
+-- Which search are we validating, and how many candidates carry the index?
+SELECT
+    (SELECT id FROM expansion_search WHERE service_model = 'dine_in'
+      ORDER BY created_at DESC LIMIT 1)                       AS latest_dine_in_search_id,
+    (SELECT created_at FROM expansion_search WHERE service_model = 'dine_in'
+      ORDER BY created_at DESC LIMIT 1)                       AS created_at,
+    COUNT(*)                                                  AS candidates_with_index,
+    COUNT(DISTINCT district)                                  AS distinct_districts
+FROM l1_val;
+
+-- ── Criterion 1: index + all sub-components populated (non-null) ──
+SELECT
+    COUNT(*)                                              AS n,
+    COUNT(*) FILTER (WHERE dg_composite        IS NOT NULL) AS have_composite,
+    COUNT(*) FILTER (WHERE pop_reach           IS NOT NULL) AS have_population,
+    COUNT(*) FILTER (WHERE fnb_review_weighted IS NOT NULL) AS have_fnb,
+    COUNT(*) FILTER (WHERE building_floors_sum IS NOT NULL) AS have_building_floors,
+    COUNT(*) FILTER (WHERE osm_offices         IS NOT NULL) AS have_osm,
+    MIN(weights_version)                                  AS weights_version,
+    MIN(radius_m)                                         AS radius_m
+FROM l1_val;
+
+-- ── Criterion 2: the composite VARIES (spread, not constant / not mostly-zero) ──
+SELECT
+    COUNT(*)                                         AS n,
+    round(MIN(dg_composite), 2)                      AS min_composite,
+    round(AVG(dg_composite), 2)                      AS avg_composite,
+    round((percentile_cont(0.5) WITHIN GROUP (ORDER BY dg_composite))::numeric, 2) AS p50,
+    round(MAX(dg_composite), 2)                      AS max_composite,
+    round(STDDEV_POP(dg_composite), 2)              AS stddev,
+    COUNT(*) FILTER (WHERE dg_composite > 0)         AS n_nonzero,
+    COUNT(DISTINCT round(dg_composite, 1))           AS distinct_rounded_values
+FROM l1_val;
+
+-- ── Criterion 3: composite DIVERGES from competition (independent signal) ──
+-- Pearson correlation of the composite vs competitor_count and vs the
+-- competition_whitespace score. |corr| well below 1 ⇒ the index is not just a
+-- competitor proxy. (whitespace is inverse to competitor density, so a positive
+-- corr there is expected but should still be far from +1.)
+SELECT
+    round(corr(dg_composite, competitor_count::double precision)::numeric, 3)        AS corr_composite_vs_competitor_count,
+    round(corr(dg_composite, competition_whitespace::double precision)::numeric, 3)  AS corr_composite_vs_whitespace,
+    round(corr(dg_composite, final_score::double precision)::numeric, 3)             AS corr_composite_vs_final_score
+FROM l1_val
+WHERE dg_composite IS NOT NULL;
+
+-- ── Eyeball: top candidate per district (geographic spread, 3+ districts) ──
+SELECT DISTINCT ON (district)
+    district,
+    parcel_id,
+    dg_composite,
+    competitor_count,
+    competition_whitespace,
+    pop_reach,
+    fnb_review_weighted,
+    fnb_venue_count,
+    building_floors_sum,
+    osm_offices, osm_malls_retail, osm_transit, osm_mosques,
+    osm_schools, osm_hospitals, osm_hotels
+FROM l1_val
+ORDER BY district, dg_composite DESC NULLS LAST;
+
+-- ── Eyeball: overall top 25 by composite (full sub-component breakdown) ──
+SELECT
+    parcel_id,
+    district,
+    dg_composite,
+    competitor_count,
+    competition_whitespace,
+    pop_reach,
+    fnb_review_weighted,
+    fnb_venue_count,
+    building_floors_sum,
+    osm_offices, osm_malls_retail, osm_transit, osm_mosques,
+    osm_schools, osm_hospitals, osm_hotels
+FROM l1_val
+ORDER BY dg_composite DESC NULLS LAST
+LIMIT 25;
+
+DROP TABLE IF EXISTS l1_val;

--- a/tests/test_expansion_advisor_demand_generator.py
+++ b/tests/test_expansion_advisor_demand_generator.py
@@ -1,0 +1,257 @@
+"""PR-1 — L1 demand-generator index (additive, emit-only).
+
+Two layers of coverage:
+
+1. Pure-function tests for the composite math (no DB) — range, variation,
+   monotonicity, net-of-supply independence, and that the new module constants
+   did not perturb the scoring weights.
+2. FakeDB integration tests proving the feature is inert when the flag is OFF
+   (no snapshot key, scores unchanged) and additive-only when ON (key emitted,
+   final_score / ranking byte-for-byte unchanged). The FakeDB reports the
+   externally-imported tables as absent, so the ON test also exercises the
+   missing-table no-op path.
+"""
+
+from __future__ import annotations
+
+from app.services import expansion_advisor as expansion_service
+from app.services.expansion_advisor import (
+    _DEMAND_GENERATOR_COMPOSITE_WEIGHTS,
+    _DEMAND_GENERATOR_OSM_WEIGHTS,
+    _demand_blend_weights,
+    _demand_generator_index,
+    _demand_generator_osm_subscore,
+    clear_expansion_caches,
+    run_expansion_search as _run_expansion_search_raw,
+)
+
+from tests.test_expansion_advisor_service import FakeDB
+
+
+def run_expansion_search(*args, **kwargs):
+    result = _run_expansion_search_raw(*args, **kwargs)
+    return result["items"] if isinstance(result, dict) else result
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests
+# ---------------------------------------------------------------------------
+
+_FULL_OSM = {
+    "offices": 12,
+    "malls_retail": 3,
+    "transit": 2,
+    "mosques": 8,
+    "schools": 6,
+    "hospitals": 1,
+    "hotels": 4,
+}
+
+
+def _index(**overrides):
+    base = dict(
+        population_reach=120000.0,
+        osm_counts=_FULL_OSM,
+        building_floors_proxy_sum=850.0,
+        fnb_review_weighted=4200.0,
+        fnb_venue_count=70,
+        radius_m=3500,
+    )
+    base.update(overrides)
+    return _demand_generator_index(**base)
+
+
+def test_composite_in_range_and_all_subcomponents_present():
+    idx = _index()
+    assert 0.0 <= idx["composite_0_100"] <= 100.0
+    # raw sub-values retained for PR-2 recalibration
+    assert idx["population_reach"] == 120000
+    assert idx["building_floors_proxy_sum"] == 850.0
+    assert idx["fnb_review_weighted_density"] == 4200.0
+    assert idx["fnb_venue_count"] == 70
+    assert idx["radius_m"] == 3500
+    assert idx["weights_version"]  # non-empty
+    for k in (
+        "offices",
+        "malls_retail",
+        "transit",
+        "mosques",
+        "schools",
+        "hospitals",
+        "hotels",
+    ):
+        assert idx["osm_generators"][k] == _FULL_OSM[k]
+    for k in ("population", "osm_generators", "building_floors", "fnb_review_weighted"):
+        assert 0.0 <= idx["subscores"][k] <= 100.0
+
+
+def test_composite_varies_with_inputs():
+    low = _index(
+        population_reach=1000.0,
+        osm_counts={},
+        building_floors_proxy_sum=0.0,
+        fnb_review_weighted=0.0,
+        fnb_venue_count=0,
+    )
+    high = _index()
+    assert high["composite_0_100"] > low["composite_0_100"]
+    # not a constant / not mostly-zero across a realistic spread
+    assert high["composite_0_100"] > 0.0
+
+
+def test_zero_inputs_are_safe():
+    idx = _index(
+        population_reach=0.0,
+        osm_counts={},
+        building_floors_proxy_sum=0.0,
+        fnb_review_weighted=0.0,
+        fnb_venue_count=0,
+    )
+    assert idx["composite_0_100"] >= 0.0
+    assert idx["subscores"]["fnb_review_weighted"] == 0.0
+    assert idx["subscores"]["population"] == 0.0
+
+
+def test_osm_subscore_monotonic_and_bounded():
+    s0 = _demand_generator_osm_subscore({})
+    s1 = _demand_generator_osm_subscore({"malls_retail": 1})
+    s2 = _demand_generator_osm_subscore({"malls_retail": 10, "offices": 10})
+    assert 0.0 <= s0 <= s1 <= s2 <= 100.0
+    assert s1 > s0
+
+
+def test_index_is_numerator_only_more_fnb_raises_score():
+    """Net-of-supply: the index must NOT penalize density. Adding F&B venues
+    (which correlates with competition) raises the composite — proving the
+    index is a demand numerator, not a saturation signal. Competition stays in
+    _competition_whitespace_score (verified structurally: the index takes no
+    competitor argument)."""
+    sparse = _index(fnb_review_weighted=100.0, fnb_venue_count=2)
+    dense = _index(fnb_review_weighted=8000.0, fnb_venue_count=120)
+    assert dense["composite_0_100"] >= sparse["composite_0_100"]
+
+
+def test_composite_weights_sum_to_one():
+    assert abs(sum(_DEMAND_GENERATOR_COMPOSITE_WEIGHTS.values()) - 1.0) < 1e-9
+    assert set(_DEMAND_GENERATOR_OSM_WEIGHTS) == {
+        "offices",
+        "malls_retail",
+        "transit",
+        "mosques",
+        "schools",
+        "hospitals",
+        "hotels",
+    }
+
+
+def test_demand_blend_weights_unchanged():
+    # PR-1 must not touch the demand blend weights (that is PR-2 territory).
+    assert _demand_blend_weights("dine_in") == (0.75, 0.25)
+    assert _demand_blend_weights("cafe") == (0.55, 0.45)
+    assert _demand_blend_weights("qsr") == (0.60, 0.40)
+    assert _demand_blend_weights("delivery_first") == (0.40, 0.60)
+
+
+# ---------------------------------------------------------------------------
+# FakeDB integration tests — flag OFF vs ON
+# ---------------------------------------------------------------------------
+
+
+def _candidate_rows():
+    return [
+        {
+            "parcel_id": "p1",
+            "landuse_label": "Commercial",
+            "landuse_code": "C",
+            "area_m2": 220,
+            "lon": 46.69,
+            "lat": 24.69,
+            "district": "حي العليا",
+            "population_reach": 180000,
+            "competitor_count": 4,
+            "delivery_listing_count": 12,
+        },
+        {
+            "parcel_id": "p2",
+            "landuse_label": "Commercial",
+            "landuse_code": "C",
+            "area_m2": 240,
+            "lon": 46.64,
+            "lat": 24.75,
+            "district": "حي النخيل",
+            "population_reach": 90000,
+            "competitor_count": 2,
+            "delivery_listing_count": 6,
+        },
+    ]
+
+
+def _run(db):
+    return run_expansion_search(
+        db,
+        search_id="search-1",
+        brand_name="Brand X",
+        category="burger",
+        service_model="dine_in",
+        min_area_m2=100,
+        max_area_m2=400,
+        target_area_m2=220,
+        limit=10,
+    )
+
+
+def test_flag_off_emits_no_index_key(disable_market_viability_floors, monkeypatch):
+    monkeypatch.setattr(
+        expansion_service.settings, "EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED", False
+    )
+    clear_expansion_caches()
+    items = _run(FakeDB(candidate_rows=_candidate_rows()))
+    assert items
+    for it in items:
+        fs = it.get("feature_snapshot_json") or {}
+        assert "demand_generator_index" not in fs
+
+
+def test_flag_on_emits_index_without_changing_scores(
+    disable_market_viability_floors, monkeypatch
+):
+    # Baseline run with the flag OFF.
+    monkeypatch.setattr(
+        expansion_service.settings, "EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED", False
+    )
+    clear_expansion_caches()
+    baseline = _run(FakeDB(candidate_rows=_candidate_rows()))
+    baseline_scores = [(it["parcel_id"], it["final_score"]) for it in baseline]
+
+    # Same search with the flag ON.
+    monkeypatch.setattr(
+        expansion_service.settings, "EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED", True
+    )
+    clear_expansion_caches()
+    enriched = _run(FakeDB(candidate_rows=_candidate_rows()))
+    enriched_scores = [(it["parcel_id"], it["final_score"]) for it in enriched]
+
+    # Ranking + scores are byte-for-byte unchanged (emit-only).
+    assert enriched_scores == baseline_scores
+
+    # The index is emitted with all sub-components. FakeDB reports the
+    # externally-imported tables as absent, so this also covers the
+    # missing-table no-op (no exception; zero-filled sub-values).
+    for it in enriched:
+        fs = it.get("feature_snapshot_json") or {}
+        idx = fs.get("demand_generator_index")
+        assert idx is not None
+        assert 0.0 <= idx["composite_0_100"] <= 100.0
+        assert idx["radius_m"] == 3500
+        assert set(idx["osm_generators"]) == {
+            "offices",
+            "malls_retail",
+            "transit",
+            "mosques",
+            "schools",
+            "hospitals",
+            "hotels",
+        }
+        assert "fnb_review_weighted_density" in idx
+        assert "building_floors_proxy_sum" in idx
+        assert idx["weights_version"]


### PR DESCRIPTION
Build a per-candidate demand_generator_index from data already on hand
(catchment population + OSM trip generators + Overture building floor-density
+ a free review_count-weighted F&B density term) and EMIT it into
feature_snapshot_json for validation. Nothing is wired into scoring (PR-2).

- config: EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED (default OFF) +
  EXPANSION_DEMAND_GENERATOR_RADIUS_M (3500 m).
- Three coordinate-based bulk-enrich blocks mirroring _bulk_foot_traffic /
  _bulk_enrich_population, each guarded by _cached_table_available so a missing
  externally-imported table no-ops without affecting the others.
- Composite math reuses _population_score / the _demand_anchor_score sigmoid;
  all raw sub-values retained for PR-2 recalibration. Numerator only — net of
  supply stays in _competition_whitespace_score.
- Tests: pure-function + FakeDB flag on/off (key emitted; final_score and
  ranking byte-for-byte unchanged; missing-table no-op).
- scripts/diagnostics/l1_index_validation.sql for post-deploy validation.

Additive only: 0 deletions in expansion_advisor.py; weights, gates and the
sum==100 invariant untouched.