### PR TITLE
feat(expansion): recalibrate L1 demand-generator index (PR-1a, still emit-only)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -137,6 +137,15 @@ class Settings:
     EXPANSION_DEMAND_GENERATOR_RADIUS_M: int = int(
         os.getenv("EXPANSION_DEMAND_GENERATOR_RADIUS_M", "3500")
     )
+    # Population sub-term catchment radius (metres) for the L1 index (PR-1a).
+    # At the 3500 m demand radius the population term is near-constant in dense
+    # Riyadh (~250k everywhere) and barely discriminates, so the index's
+    # population SUB-SCORE is computed at a tighter radius where it actually
+    # varies. The full 3500 m population_reach is still retained raw in the
+    # snapshot for continuity. Default 1500 m.
+    EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M: int = int(
+        os.getenv("EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M", "1500")
+    )
 
     # --- Expansion Advisor structured decision memo (Phase 1) ---
     # Model/token/temperature controls for the new structured memo path in

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -1844,32 +1844,28 @@ _DEMAND_GENERATOR_OSM_WEIGHTS: dict[str, float] = {
 # linearly. Mapping the top anchor to p95 (not the max) leaves headroom so dense
 # areas land ~80-90 instead of all pegging at 100.
 #
-# PROVISIONAL — these are seeded from the 15-row validation sample plus the task's
-# hints (fnb p95≈150k, floors p95≈32k, offices p95≈1400, pop@1500m unknown). REPLACE
-# from scripts/diagnostics/l1_signal_distributions.sql (Phase A) before trusting the
-# absolute spread. The OSM anchors are on the SAME Σ(count·weight) the Phase A probe
-# reports, so they drop in directly.
+# Set from the Phase A probe (scripts/diagnostics/l1_signal_distributions.sql,
+# 538 city-wide Tier-1 primary candidates). The OSM anchors are on the SAME
+# Σ(count·weight) the probe reports, so they drop in directly.
 _DEMAND_GENERATOR_NORM_ANCHORS: dict[str, tuple[float, float, float, bool]] = {
-    #  signal                 p5        p95         p99        log
-    "fnb_review_weighted": (2000.0, 150000.0, 200000.0, True),
-    "building_floors":     (3000.0,  32000.0,  40000.0, True),
-    "osm_weighted_total":  (150.0,    3500.0,   6000.0, True),
+    #  signal                 p5         p95         p99        log
+    "fnb_review_weighted": (4210.0, 224576.0, 241965.0, True),
+    "building_floors":     (6805.0,  35612.0,  40102.0, True),
+    "osm_weighted_total":  (3.4,      3351.0,   3943.0, True),
     # Population at the tighter EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M (~1500 m).
-    # Provisional: ~250k at 3.5 km scaled by the (1500/3500)^2 area ratio plus a
-    # density spread. Fill p5/p95 from the Phase A pop_reach_1500 column.
-    "population_local":    (8000.0,   80000.0, 120000.0, False),
+    "population_local":    (8281.0,   52010.0,  53393.0, False),
 }
 
 # Top-level composite weights over the four normalized sub-signals (sum 1.0).
 # PR-1a rebalance: the discriminating signals (OSM trip generators + free F&B
-# review density) drive the spread; population — even at the tighter radius — is
-# the weakest discriminator in dense Riyadh, so it carries the least weight (down
-# from v1's top weight of 0.30).
+# review density) drive the spread. Phase A showed the 1500 m population radius
+# does NOT discriminate (spread_ratio_1500=1.108 ≈ spread_ratio_3500=1.109), so
+# population is cut to a token 0.05 and its weight redistributed to OSM + F&B.
 _DEMAND_GENERATOR_COMPOSITE_WEIGHTS: dict[str, float] = {
-    "osm_generators": 0.35,
-    "fnb_review_weighted": 0.30,
+    "osm_generators": 0.40,
+    "fnb_review_weighted": 0.35,
     "building_floors": 0.20,
-    "population": 0.15,
+    "population": 0.05,
 }
 
 
@@ -1880,7 +1876,7 @@ def _demand_generator_normalize(signal: str, value: float) -> float:
     outlier cannot dominate (winsorized at p99) and the dense end keeps headroom
     (top anchor is p95, not the max). Wide-spread signals are log-transformed so
     the bulk of the distribution spreads instead of bunching near zero. Anchors
-    live in _DEMAND_GENERATOR_NORM_ANCHORS (PR-1a, provisional until Phase A).
+    live in _DEMAND_GENERATOR_NORM_ANCHORS (PR-1a, set from the Phase A probe).
     """
     p5, p95, p99, use_log = _DEMAND_GENERATOR_NORM_ANCHORS[signal]
     v = min(max(0.0, _safe_float(value)), p99)  # winsorize the top tail at p99

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -1810,14 +1810,23 @@ def _foot_traffic_score(nearby_amenity_count: int) -> float:
 # count by construction (busy venues ⇒ more nearby F&B); that correlation is
 # expected and is exactly why the denominator must stay separate — the index
 # must not double as a saturation signal.
-_DEMAND_GENERATOR_WEIGHTS_VERSION = "l1_v1_2026-06"
+#
+# PR-1a RECALIBRATION (l1_v2_2026-06): the v1 index pinned at the ceiling — every
+# normalization reference sat far below real Riyadh catchment values, so all four
+# sub-scores saturated and the composite barely varied (stddev 1.92, 5 distinct
+# values; competitor_count 60 scored the same as competitor_count 270). The fix is
+# pure calibration: re-anchor every sub-signal to the REAL city-wide distribution
+# (winsorize at p99, map p5→p95 onto 0-100, log-transform the wide-spread signals),
+# compute the population sub-term at a tighter radius where it actually varies, and
+# rebalance the composite onto the discriminating signals. No new sub-signals, no
+# new data sources, still emit-only.
+_DEMAND_GENERATOR_WEIGHTS_VERSION = "l1_v2_2026-06"
 
 # Per-generator-type weights for the OSM sub-score. Seeded from the heatmap
 # path's _ANCHOR_WEIGHTS (restaurant_scoring_factors.py:772-784), regrouped onto
 # the seven generator buckets enriched here; transit/mosque buckets (absent from
-# the anchor table) take conservative mid/low values. Used as Σ(count·weight) →
-# sigmoid, mirroring _demand_anchor_score. Module constant + emitted
-# weights_version so PR-2 can recalibrate without re-running enrich.
+# the anchor table) take conservative mid/low values. Combined as Σ(count·weight)
+# then normalized against the city-wide weighted-total anchors below.
 _DEMAND_GENERATOR_OSM_WEIGHTS: dict[str, float] = {
     "offices": 2.0,
     "malls_retail": 4.0,
@@ -1828,22 +1837,75 @@ _DEMAND_GENERATOR_OSM_WEIGHTS: dict[str, float] = {
     "hotels": 2.5,
 }
 
+# ── PR-1a NORMALIZATION ANCHORS (one clearly-marked, versioned block) ──────────
+# Each raw sub-signal is winsorized at p99 then mapped p5→p95 onto 0-100. Tuple is
+# (p5, p95, p99, log?). Wide-spread signals (F&B reviews, building floors, the OSM
+# weighted total) are log-transformed; the tighter-radius population is mapped
+# linearly. Mapping the top anchor to p95 (not the max) leaves headroom so dense
+# areas land ~80-90 instead of all pegging at 100.
+#
+# PROVISIONAL — these are seeded from the 15-row validation sample plus the task's
+# hints (fnb p95≈150k, floors p95≈32k, offices p95≈1400, pop@1500m unknown). REPLACE
+# from scripts/diagnostics/l1_signal_distributions.sql (Phase A) before trusting the
+# absolute spread. The OSM anchors are on the SAME Σ(count·weight) the Phase A probe
+# reports, so they drop in directly.
+_DEMAND_GENERATOR_NORM_ANCHORS: dict[str, tuple[float, float, float, bool]] = {
+    #  signal                 p5        p95         p99        log
+    "fnb_review_weighted": (2000.0, 150000.0, 200000.0, True),
+    "building_floors":     (3000.0,  32000.0,  40000.0, True),
+    "osm_weighted_total":  (150.0,    3500.0,   6000.0, True),
+    # Population at the tighter EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M (~1500 m).
+    # Provisional: ~250k at 3.5 km scaled by the (1500/3500)^2 area ratio plus a
+    # density spread. Fill p5/p95 from the Phase A pop_reach_1500 column.
+    "population_local":    (8000.0,   80000.0, 120000.0, False),
+}
+
 # Top-level composite weights over the four normalized sub-signals (sum 1.0).
+# PR-1a rebalance: the discriminating signals (OSM trip generators + free F&B
+# review density) drive the spread; population — even at the tighter radius — is
+# the weakest discriminator in dense Riyadh, so it carries the least weight (down
+# from v1's top weight of 0.30).
 _DEMAND_GENERATOR_COMPOSITE_WEIGHTS: dict[str, float] = {
-    "population": 0.30,
-    "fnb_review_weighted": 0.25,
-    "osm_generators": 0.25,
+    "osm_generators": 0.35,
+    "fnb_review_weighted": 0.30,
     "building_floors": 0.20,
+    "population": 0.15,
 }
 
 
+def _demand_generator_normalize(signal: str, value: float) -> float:
+    """Winsorize at p99 then map the p5→p95 anchor band onto 0-100.
+
+    Robust 0-100 normalization shared by every L1 sub-signal: a single busy
+    outlier cannot dominate (winsorized at p99) and the dense end keeps headroom
+    (top anchor is p95, not the max). Wide-spread signals are log-transformed so
+    the bulk of the distribution spreads instead of bunching near zero. Anchors
+    live in _DEMAND_GENERATOR_NORM_ANCHORS (PR-1a, provisional until Phase A).
+    """
+    p5, p95, p99, use_log = _DEMAND_GENERATOR_NORM_ANCHORS[signal]
+    v = min(max(0.0, _safe_float(value)), p99)  # winsorize the top tail at p99
+    if use_log:
+        v = math.log1p(v)
+        lo = math.log1p(p5)
+        hi = math.log1p(p95)
+    else:
+        lo, hi = p5, p95
+    if hi <= lo:
+        return 0.0
+    return _clamp((v - lo) / (hi - lo) * 100.0)
+
+
 def _demand_generator_osm_subscore(osm_counts: dict[str, int]) -> float:
-    """Σ(count·weight) over generator buckets → 0-100 via the _demand_anchor_score sigmoid."""
+    """Σ(count·weight) over generator buckets → 0-100 against the city-wide anchor.
+
+    PR-1a: the v1 sigmoid (ref /20) saturated to ~95 for every candidate because
+    real Riyadh catchments hold hundreds of offices. The weighted total is now
+    log-normalized against the empirical p5→p95 band so offices/retail — the
+    strongest raw discriminators — actually drive spread."""
     weighted_total = 0.0
     for _kind, _w in _DEMAND_GENERATOR_OSM_WEIGHTS.items():
         weighted_total += _w * float(osm_counts.get(_kind, 0) or 0)
-    # Same saturating curve as restaurant_scoring_factors._demand_anchor_score.
-    return _clamp(10.0 + 85.0 * (1.0 - math.exp(-weighted_total / 20.0)))
+    return _demand_generator_normalize("osm_weighted_total", weighted_total)
 
 
 def _demand_generator_index(
@@ -1854,29 +1916,44 @@ def _demand_generator_index(
     fnb_review_weighted: float,
     fnb_venue_count: int,
     radius_m: int,
+    population_local_reach: float | None = None,
+    pop_radius_m: int | None = None,
 ) -> dict[str, Any]:
     """Compose the emit-only L1 demand-generator index for one candidate.
 
-    Each sub-signal is normalized to 0-100 with the same log/sqrt-scaled family
-    used by _population_score / _foot_traffic_score (so a single busy outlier
-    cannot dominate), then combined with the top-level composite weights. ALL raw
-    sub-values are retained in the returned dict so PR-2 can recalibrate weights
-    against real data without re-running the bulk enrich.
+    PR-1a: each sub-signal is normalized to 0-100 against the real city-wide
+    distribution (winsorize at p99, map p5→p95, log-transform wide signals) via
+    _demand_generator_normalize, then combined with the top-level composite
+    weights. ALL raw sub-values are retained in the returned dict — including BOTH
+    the full ``population_reach`` (radius_m) and the tighter ``population_local_reach``
+    (pop_radius_m) used for the sub-score — so the next calibration never needs a
+    re-enrich.
+
+    The population sub-score uses ``population_local_reach`` at the tighter
+    pop_radius_m (default 1500 m): at 3.5 km every dense-Riyadh catchment holds
+    ~250k people, so the wide-radius value barely discriminates by construction.
+    When the tighter value is not supplied the wide ``population_reach`` is used as
+    a fallback so the function stays self-contained.
 
     NOTE on review_count staleness: Google review enrichment is currently
     disabled, so review_count is a stale snapshot. That is acceptable here — the
     term is used only for RELATIVE cross-candidate ranking, not as a live count.
     """
-    # Population: reuse the dine-in saturation reference (250k @ 3.5 km).
-    pop_sub = _population_score(_safe_float(population_reach), service_model="dine_in")
-    # OSM generators: weighted-count sigmoid.
+    # Population: normalize the tighter-radius reach (falls back to the wide one).
+    _pop_local = (
+        _safe_float(population_local_reach)
+        if population_local_reach is not None
+        else _safe_float(population_reach)
+    )
+    pop_sub = _demand_generator_normalize("population_local", _pop_local)
+    # OSM generators: log-normalized weighted count.
     osm_sub = _demand_generator_osm_subscore(osm_counts)
-    # Building floor-density daytime proxy (log-scaled; ref ~2000 floor-equiv).
+    # Building floor-density daytime proxy (log-normalized).
     _floors = max(0.0, _safe_float(building_floors_proxy_sum))
-    floors_sub = _clamp(math.log1p(_floors) / math.log1p(2000.0) * 100.0)
-    # Free F&B review-weighted density (log-scaled; ref ~5000 summed reviews).
+    floors_sub = _demand_generator_normalize("building_floors", _floors)
+    # Free F&B review-weighted density (log-normalized).
     _rw = max(0.0, _safe_float(fnb_review_weighted))
-    fnb_sub = _clamp(math.log1p(_rw) / math.log1p(5000.0) * 100.0)
+    fnb_sub = _demand_generator_normalize("fnb_review_weighted", _rw)
 
     w = _DEMAND_GENERATOR_COMPOSITE_WEIGHTS
     composite = _clamp(
@@ -1890,6 +1967,8 @@ def _demand_generator_index(
         "weights_version": _DEMAND_GENERATOR_WEIGHTS_VERSION,
         "radius_m": int(radius_m),
         "population_reach": int(round(_safe_float(population_reach))),
+        "pop_radius_m": int(pop_radius_m) if pop_radius_m is not None else int(radius_m),
+        "population_local_reach": int(round(_pop_local)),
         "osm_generators": {
             "offices": int(osm_counts.get("offices", 0) or 0),
             "malls_retail": int(osm_counts.get("malls_retail", 0) or 0),
@@ -7529,6 +7608,7 @@ def run_expansion_search(
     _bulk_osm_generators: dict[str, dict[str, int]] = {}
     _bulk_building_floors: dict[str, float] = {}
     _bulk_fnb_density: dict[str, dict[str, float]] = {}
+    _bulk_dg_pop_local: dict[str, float] = {}
     if ea_delivery_populated:
         try:
             # Build a VALUES list of (parcel_id, lon, lat) for all candidates
@@ -8812,6 +8892,57 @@ def run_expansion_search(
             except Exception:
                 logger.debug("expansion_search L1 fnb_density failed", exc_info=True)
 
+        # 4) Tighter-radius catchment population (PR-1a). The index's population
+        #    SUB-SCORE is computed at EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M
+        #    (~1500 m) where population actually varies; at the 3500 m demand
+        #    radius every dense-Riyadh catchment holds ~250k people and the term
+        #    barely discriminates. Mirrors _bulk_enrich_population's SQL but reuses
+        #    the shared coord VALUES list. The full 3500 m population_reach is still
+        #    retained raw in the snapshot.
+        _dg_pop_radius = float(settings.EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M)
+        if _dg_values_sql and _cached_table_available(db, "public.population_density"):
+            # population_density may be stored as a geom column or as lat/lon.
+            _dg_pd_has_geom = False
+            try:
+                _dg_pd_has_geom = bool(db.execute(text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_name = 'population_density' AND column_name = 'geom' LIMIT 1"
+                )).scalar())
+            except Exception:
+                pass
+            if _dg_pd_has_geom:
+                _dg_pd_geo = "pd.geom::geography"
+                _dg_pd_where = "pd.geom IS NOT NULL"
+            else:
+                _dg_pd_geo = "ST_SetSRID(ST_MakePoint(pd.lon::double precision, pd.lat::double precision), 4326)::geography"
+                _dg_pd_where = "pd.lat IS NOT NULL AND pd.lon IS NOT NULL"
+            _dg_pop_query = f"""
+                WITH cand(parcel_id, lon, lat) AS (VALUES {_dg_values_sql})
+                SELECT c.parcel_id, COALESCE(p.population_reach, 0) AS population_reach
+                FROM cand c
+                LEFT JOIN LATERAL (
+                    SELECT COALESCE(SUM(pd.population), 0) AS population_reach
+                    FROM population_density pd
+                    WHERE {_dg_pd_where}
+                      AND ST_DWithin(
+                          ST_SetSRID(ST_MakePoint(c.lon, c.lat), 4326)::geography,
+                          {_dg_pd_geo},
+                          :dg_pop_radius)
+                ) p ON TRUE
+            """
+            try:
+                with db.begin_nested():
+                    _dg_pop_rows = db.execute(
+                        text(_dg_pop_query),
+                        {**_dg_coord_params, "dg_pop_radius": _dg_pop_radius},
+                    ).mappings().all()
+                for _r in _dg_pop_rows:
+                    _bulk_dg_pop_local[str(_r["parcel_id"])] = _safe_float(_r.get("population_reach"))
+                logger.info("expansion_search L1 pop_local: enriched=%d/%d search_id=%s",
+                            len(_bulk_dg_pop_local), len(_shortlist_coords), search_id)
+            except Exception:
+                logger.debug("expansion_search L1 pop_local failed", exc_info=True)
+
         logger.info("expansion_search timing: bulk_demand_generator=%.2fs search_id=%s",
                      time.monotonic() - t_dg_start, search_id)
 
@@ -9259,11 +9390,13 @@ def run_expansion_search(
             _dg_fnb = _bulk_fnb_density.get(_pid_str, {})
             feature_snapshot_json["demand_generator_index"] = _demand_generator_index(
                 population_reach=population_reach,
+                population_local_reach=_bulk_dg_pop_local.get(_pid_str),
                 osm_counts=_bulk_osm_generators.get(_pid_str, {}),
                 building_floors_proxy_sum=_bulk_building_floors.get(_pid_str, 0.0),
                 fnb_review_weighted=_dg_fnb.get("review_weighted", 0.0),
                 fnb_venue_count=_dg_fnb.get("venue_count", 0),
                 radius_m=settings.EXPANSION_DEMAND_GENERATOR_RADIUS_M,
+                pop_radius_m=settings.EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M,
             )
         # Compute the two raw ages independently so the pill logic on the
         # frontend and in _top_positives_and_risks can decide "New" vs

--- a/scripts/diagnostics/PR1a_l1_demand_generator_index_recalibrate.md
+++ b/scripts/diagnostics/PR1a_l1_demand_generator_index_recalibrate.md
@@ -35,49 +35,51 @@ wide-spread signals. Anchors live in one clearly-marked, versioned block
 
 | signal | p5 | p95 | p99 | transform |
 |---|---|---|---|---|
-| `fnb_review_weighted` | 2,000 | 150,000 | 200,000 | log |
-| `building_floors` | 3,000 | 32,000 | 40,000 | log |
-| `osm_weighted_total` | 150 | 3,500 | 6,000 | log |
-| `population_local` (1500 m) | 8,000 | 80,000 | 120,000 | linear |
+| `fnb_review_weighted` | 4,210 | 224,576 | 241,965 | log |
+| `building_floors` | 6,805 | 35,612 | 40,102 | log |
+| `osm_weighted_total` | 3.4 | 3,351 | 3,943 | log |
+| `population_local` (1500 m) | 8,281 | 52,010 | 53,393 | linear |
 
-**These anchors are PROVISIONAL** — seeded from the 15-row validation sample plus the task's hints
-(fnb p95≈150k, floors p95≈32k, offices p95≈1400; pop@1500 m estimated from the (1500/3500)² area
-ratio + a density spread). **Replace them from Phase A** (`l1_signal_distributions.sql`) before
-trusting the absolute spread. The OSM anchors are on the *same* `Σ(count·weight)` the Phase A probe
-reports, so they drop in directly.
+**These anchors are SET from Phase A** — `scripts/diagnostics/l1_signal_distributions.sql` run over
+**538 city-wide Tier-1 primary candidates**. The OSM anchors are on the *same* `Σ(count·weight)` the
+Phase A probe reports, so they dropped in directly.
 
 The OSM sub-score (`_demand_generator_osm_subscore`) now log-normalizes the weighted total against
 those anchors instead of the saturating `/20` sigmoid. Per-generator weights are unchanged
 (offices 2.0, malls_retail 4.0, transit 2.0, mosques 1.5, schools 1.75, hospitals 2.0, hotels 2.5).
 
-### 2. Population term — decision: **(a) tighter radius**
-Chosen **(a)** over (b) because the data we need already exists and re-deriving it is cheap: the L1
-enrich block already has the candidate coords, and `population_density` is the same table
-`_bulk_enrich_population` uses. Cutting the weight (option b) would have discarded a usable signal;
-recomputing at a radius where it varies *keeps* the signal and is the cleaner fix.
+### 2. Population term — implemented **(a) tighter radius**, then Phase A demoted it
+Implemented **(a)** (recompute population at a tighter radius) because the data already exists and
+re-deriving it is cheap: the L1 enrich block already has the candidate coords, and
+`population_density` is the same table `_bulk_enrich_population` uses.
 
 - New setting `EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M` (default **1500**).
 - New 4th bulk-enrich block (block "4)" in the L1 section) computes catchment population at the
   tighter radius via the shared coord VALUES list, guarded by `_cached_table_available` and a
   geom-vs-lat/lon column probe (mirrors `_bulk_enrich_population`). One bulk query, no N+1.
-- The population **sub-score** now normalizes this tighter `population_local_reach`; the full
-  3500 m `population_reach` is **still retained raw** in the snapshot for continuity.
-- Phase A reports `pop_reach` at 1000/1500/3500 m + a `p95/p50` spread ratio so we can confirm the
-  tighter radius actually discriminates before locking the anchors.
+- The population **sub-score** normalizes this tighter `population_local_reach`; the full 3500 m
+  `population_reach` is **still retained raw** in the snapshot for continuity.
+
+**Phase A verdict: 1500 m did NOT help.** The probe's spread ratios came back
+`spread_ratio_1500 = 1.108 ≈ spread_ratio_3500 = 1.109` — population is near-constant at *both*
+radii in dense Riyadh, so the tighter catchment buys no discrimination. We keep computing it (the
+plumbing is cheap and the raw value stays in the snapshot), but in the weight rebalance below
+population is cut to a **token 0.05** and that weight redistributed to the signals that actually
+discriminate (effectively the fall-back of option **b**, now justified by data rather than assumed).
 
 ### 3. Rebalanced composite weights onto the discriminators
 Same versioned constants block; the *number* of sub-signals is unchanged.
 
 | sub-signal | v1 | v2 |
 |---|---|---|
-| osm_generators | 0.25 | **0.35** |
-| fnb_review_weighted | 0.25 | **0.30** |
+| osm_generators | 0.25 | **0.40** |
+| fnb_review_weighted | 0.25 | **0.35** |
 | building_floors | 0.20 | 0.20 |
-| population | **0.30** | **0.15** |
+| population | **0.30** | **0.05** |
 
-OSM trip generators + free F&B review density (the strong raw discriminators) now drive the spread;
-population — weakest discriminator even at the tighter radius in dense Riyadh — carries the least.
-Sum still 1.0 (`test_composite_weights_sum_to_one`).
+OSM trip generators + free F&B review density (the strong raw discriminators) drive the spread;
+population — shown by Phase A to be near-constant at every radius in dense Riyadh — carries a token
+weight only. Sum still 1.0 (`test_composite_weights_sum_to_one`).
 
 ### 4. Raw sub-values still fully retained
 Every raw sub-value stays in the snapshot (unchanged) **plus** the new `population_local_reach` and
@@ -108,9 +110,10 @@ Every raw sub-value stays in the snapshot (unchanged) **plus** the new `populati
   `tests/test_expansion_advisor_service.py` **156 passed**.
 
 ## Validation (Ahmed, Codespace, after diff review)
-1. Run **Phase A** first: `psql "$DATABASE_URL" -f scripts/diagnostics/l1_signal_distributions.sql`
-   and replace the provisional anchors in `_DEMAND_GENERATOR_NORM_ANCHORS` with the reported
-   p5/p95 (and `population_local` from the `pop_reach_1500` column).
+1. **Phase A is done** — `scripts/diagnostics/l1_signal_distributions.sql` was run over 538 city-wide
+   Tier-1 primaries and `_DEMAND_GENERATOR_NORM_ANCHORS` is now set from those p5/p95/p99 (the
+   `population_local` anchors come from the `pop_reach_1500` column). Re-run it only if the candidate
+   universe shifts materially.
 2. Re-run `scripts/diagnostics/l1_index_validation.sql` against a **fresh dine-in search** (flag on;
    old searches won't backfill). Success criteria:
    - **Spread:** composite stddev materially up; uses most of 0–100; **≥10 distinct rounded values**

--- a/scripts/diagnostics/PR1a_l1_demand_generator_index_recalibrate.md
+++ b/scripts/diagnostics/PR1a_l1_demand_generator_index_recalibrate.md
@@ -1,0 +1,139 @@
+# PR-1a: Recalibrate L1 Demand-Generator Index (still emit-only)
+
+Branch: `feat/l1-demand-generator-index-recalibrate` (off the merged PR-1 work)
+
+## Why
+
+PR-1 deployed and emitted cleanly (15/15 candidates, 8 districts, flag live), but the composite
+**failed the "varies" check**: min 91.18, avg 97.99, p50 98.75, max 98.75, **stddev 1.92, only 5
+distinct values**. المربع (competitor_count 60, low everything) scored the **same 98.75** as الورود
+(competitor_count 270, near-max everything). The index was pinned at the ceiling.
+
+**Root cause = normalization, not data.** The raw sub-values vary hugely and correctly; every v1
+normalization reference sat far below real Riyadh catchment values, so all four sub-scores saturated:
+
+- `fnb_review_weighted` ~12,998 → 151,145 (≈12×) vs a ~5,000 ref → all max out.
+- `building_floors_sum` ~17,146 → 32,259 vs a ~2,000 ref → all max out.
+- `pop_reach` ~210,936 → 279,192 (tight) vs the 250k dine-in ref → all near-max. At 3.5 km in dense
+  Riyadh **every** catchment holds ~250k+ people, so population barely discriminates by construction.
+- The OSM weighted-count sigmoid (`/20` ref) saturated to ~95 for everyone — offices alone run into
+  the hundreds, so `1 - exp(-total/20)` ≈ 1 for every candidate. The strongest raw discriminators
+  were flattened.
+
+This is calibration, not a data failure. Still **emit-only** — nothing wired into `final_score`.
+
+## What changed (all additive / in-place tuning; still flag-gated, default OFF)
+
+`weights_version` bumped `l1_v1_2026-06` → **`l1_v2_2026-06`** so runs are distinguishable in the snapshot.
+
+### 1. Re-anchored every sub-signal to the real distribution
+New shared helper `_demand_generator_normalize(signal, value)` (`app/services/expansion_advisor.py`):
+**winsorize at p99, then map the city-wide p5→p95 band onto 0–100**, log-transforming the
+wide-spread signals. Anchors live in one clearly-marked, versioned block
+`_DEMAND_GENERATOR_NORM_ANCHORS` — `(p5, p95, p99, log?)` per signal. Mapping the top anchor to p95
+(not the max) leaves headroom so dense areas land ~80–90 instead of pegging at 100.
+
+| signal | p5 | p95 | p99 | transform |
+|---|---|---|---|---|
+| `fnb_review_weighted` | 2,000 | 150,000 | 200,000 | log |
+| `building_floors` | 3,000 | 32,000 | 40,000 | log |
+| `osm_weighted_total` | 150 | 3,500 | 6,000 | log |
+| `population_local` (1500 m) | 8,000 | 80,000 | 120,000 | linear |
+
+**These anchors are PROVISIONAL** — seeded from the 15-row validation sample plus the task's hints
+(fnb p95≈150k, floors p95≈32k, offices p95≈1400; pop@1500 m estimated from the (1500/3500)² area
+ratio + a density spread). **Replace them from Phase A** (`l1_signal_distributions.sql`) before
+trusting the absolute spread. The OSM anchors are on the *same* `Σ(count·weight)` the Phase A probe
+reports, so they drop in directly.
+
+The OSM sub-score (`_demand_generator_osm_subscore`) now log-normalizes the weighted total against
+those anchors instead of the saturating `/20` sigmoid. Per-generator weights are unchanged
+(offices 2.0, malls_retail 4.0, transit 2.0, mosques 1.5, schools 1.75, hospitals 2.0, hotels 2.5).
+
+### 2. Population term — decision: **(a) tighter radius**
+Chosen **(a)** over (b) because the data we need already exists and re-deriving it is cheap: the L1
+enrich block already has the candidate coords, and `population_density` is the same table
+`_bulk_enrich_population` uses. Cutting the weight (option b) would have discarded a usable signal;
+recomputing at a radius where it varies *keeps* the signal and is the cleaner fix.
+
+- New setting `EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M` (default **1500**).
+- New 4th bulk-enrich block (block "4)" in the L1 section) computes catchment population at the
+  tighter radius via the shared coord VALUES list, guarded by `_cached_table_available` and a
+  geom-vs-lat/lon column probe (mirrors `_bulk_enrich_population`). One bulk query, no N+1.
+- The population **sub-score** now normalizes this tighter `population_local_reach`; the full
+  3500 m `population_reach` is **still retained raw** in the snapshot for continuity.
+- Phase A reports `pop_reach` at 1000/1500/3500 m + a `p95/p50` spread ratio so we can confirm the
+  tighter radius actually discriminates before locking the anchors.
+
+### 3. Rebalanced composite weights onto the discriminators
+Same versioned constants block; the *number* of sub-signals is unchanged.
+
+| sub-signal | v1 | v2 |
+|---|---|---|
+| osm_generators | 0.25 | **0.35** |
+| fnb_review_weighted | 0.25 | **0.30** |
+| building_floors | 0.20 | 0.20 |
+| population | **0.30** | **0.15** |
+
+OSM trip generators + free F&B review density (the strong raw discriminators) now drive the spread;
+population — weakest discriminator even at the tighter radius in dense Riyadh — carries the least.
+Sum still 1.0 (`test_composite_weights_sum_to_one`).
+
+### 4. Raw sub-values still fully retained
+Every raw sub-value stays in the snapshot (unchanged) **plus** the new `population_local_reach` and
+`pop_radius_m`, so the next calibration never needs a re-enrich.
+
+## Files changed
+- `app/core/config.py` — `EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M` (default 1500).
+- `app/services/expansion_advisor.py`:
+  - `_DEMAND_GENERATOR_WEIGHTS_VERSION` → `l1_v2_2026-06`; new `_DEMAND_GENERATOR_NORM_ANCHORS`
+    block; rebalanced `_DEMAND_GENERATOR_COMPOSITE_WEIGHTS`; new `_demand_generator_normalize`;
+    `_demand_generator_osm_subscore` re-anchored; `_demand_generator_index` gains
+    `population_local_reach` / `pop_radius_m` params + emits both.
+  - L1 enrich section: new `_bulk_dg_pop_local` dict + 4th bulk-enrich block; call site passes the
+    tighter-radius population and `pop_radius_m`.
+- `scripts/diagnostics/l1_signal_distributions.sql` — **new** Phase A probe.
+- `tests/test_expansion_advisor_demand_generator.py` — fixtures rescaled to the calibrated band;
+  new `test_recalibrated_index_spreads_across_a_fixture` (asserts ≥30-pt spread, all-distinct
+  rounded values, low-activity << high-activity, ordered); flag-off / emit-only / weights-unchanged
+  assertions retained.
+
+## Still emit-only — rankings byte-for-byte unchanged when OFF
+- No edits to `component_weights`, `_demand_blend_weights`, the `sum==100` invariant, any gate, or
+  `final_score`. `test_demand_blend_weights_unchanged` and `test_flag_on_emits_index_without_changing_scores`
+  (same search off→on, identical `final_score` + ordering) both still pass.
+- When the flag is OFF the whole L1 path (including the new population block) is inert and no snapshot
+  key is emitted (`test_flag_off_emits_no_index_key`).
+- Local: `tests/test_expansion_advisor_demand_generator.py` **10 passed**;
+  `tests/test_expansion_advisor_service.py` **156 passed**.
+
+## Validation (Ahmed, Codespace, after diff review)
+1. Run **Phase A** first: `psql "$DATABASE_URL" -f scripts/diagnostics/l1_signal_distributions.sql`
+   and replace the provisional anchors in `_DEMAND_GENERATOR_NORM_ANCHORS` with the reported
+   p5/p95 (and `population_local` from the `pop_reach_1500` column).
+2. Re-run `scripts/diagnostics/l1_index_validation.sql` against a **fresh dine-in search** (flag on;
+   old searches won't backfill). Success criteria:
+   - **Spread:** composite stddev materially up; uses most of 0–100; **≥10 distinct rounded values**
+     across 15 candidates; lowest-activity district (e.g. طويق) clearly below highest (e.g. الورود).
+   - **Ordering sanity:** high-activity districts rank above low; المربع must no longer tie الورود.
+   - **Divergence:** report `corr(composite, competitor_count)` — low corr ⇒ the free F&B term is
+     independent demand signal (lean skip-L2); high corr ⇒ it echoes competitor density (L2 may earn
+     its cost).
+
+## Out of scope — flagged for later
+- **`competition_whitespace = 15.00` constant** observed in the PR-1 run is a **separate denominator
+  issue (pre-existing, not introduced by PR-1/PR-1a)** — a stuck/clamped denominator, unrelated to
+  this index's normalization. **Not touched here.** Worth a dedicated look afterward.
+
+## Drift vs the prompt's `path:line`
+- The prompt's references were against the read-only report; against the live tree the L1 enrich
+  block sits after the foot-traffic block (~`:8629`), the call site is ~`:9258`, and the constants
+  block is ~`:1813`. The F&B filter uses `_cat_expanded["keys"]` (no `category_keys` in scope), as in
+  PR-1. Phase A reuses the candidate_location Tier-1 primary fields (`is_cluster_primary`,
+  `source_tier=1`, `lon`/`lat`, `district_ar`) from `_query_candidate_location_pool`.
+
+## Risk
+**Low.** Tuning-only + flag-gated + degrade-silently on missing tables; default-OFF means production
+is byte-for-byte unchanged until the flag is flipped for a validation search. The one behavioral
+addition (4th bulk population query) only runs under the flag and no-ops if `population_density` is
+absent.

--- a/scripts/diagnostics/l1_signal_distributions.sql
+++ b/scripts/diagnostics/l1_signal_distributions.sql
@@ -1,0 +1,358 @@
+-- ============================================================================
+-- l1_signal_distributions.sql  (PR-1a, Phase A — distribution probe)
+-- ----------------------------------------------------------------------------
+-- The v1 L1 demand-generator index pinned at the ceiling: every normalization
+-- reference sat far below real Riyadh catchment values, so all four sub-scores
+-- saturated and the composite barely varied. Before re-anchoring (Phase B) we
+-- measure the REAL city-wide distribution of every raw sub-signal so the anchors
+-- are set empirically instead of guessed.
+--
+-- This probe samples Tier-1 cluster-primary candidate_location rows city-wide and,
+-- reusing the SAME ST_MakePoint(lon, lat) catchment logic as the enrich blocks in
+-- app/services/expansion_advisor.py (the "L1 demand-generator index enrichment"
+-- section), reports for each raw sub-signal:
+--     p5 / p25 / p50 / p75 / p90 / p95 / p99 / max  and  the count of zeros.
+--
+-- Signals (mirroring _demand_generator_index inputs):
+--   * fnb_review_weighted  — Σ review_count over open F&B venues in radius
+--   * building_floors_sum   — Overture building floor-equivalent sum in radius
+--   * osm_weighted_total    — Σ(osm_count · weight) using _DEMAND_GENERATOR_OSM_WEIGHTS
+--                             (offices 2.0, malls_retail 4.0, transit 2.0, mosques 1.5,
+--                              schools 1.75, hospitals 2.0, hotels 2.5) — this is the
+--                             exact quantity the OSM sub-score normalizes, so its
+--                             percentiles drop straight into the anchor block.
+--   * each osm_* generator  — raw per-bucket counts (offices, malls_retail, ...)
+--   * pop_reach @ 1000 / 1500 / 3500 m — to see whether a tighter population
+--                             catchment actually discriminates (it is near-constant
+--                             at 3500 m by construction in dense Riyadh).
+--
+-- HOW TO RUN (iPad/Safari friendly — psql -f safe, no \set, no heredocs):
+--   psql "$DATABASE_URL" -f scripts/diagnostics/l1_signal_distributions.sql
+--
+-- NOTES
+--   * Sampled (LIMIT 1500 candidates) so it runs fast; raise/lower the LIMIT in
+--     the `sample` CTE if you want a wider/narrower probe.
+--   * F&B filter uses the default dine-in 4-key category set
+--     (burger/pizza/chicken/fast_food). If you validate a NARROWER category, the
+--     live fnb_review_weighted will be a fraction of these numbers — adjust the
+--     fnb p5/p95 anchors down accordingly.
+--   * The radius for the OSM / floors / F&B metrics is the 3500 m demand radius
+--     (EXPANSION_DEMAND_GENERATOR_RADIUS_M); population is probed at three radii.
+-- ============================================================================
+
+\timing on
+
+-- ── Sample of Tier-1 cluster-primary candidates, city-wide ──
+DROP TABLE IF EXISTS l1_sample;
+CREATE TEMP TABLE l1_sample AS
+SELECT
+    COALESCE(cl.source_id, cl.id::text) AS parcel_id,
+    cl.lon::double precision            AS lon,
+    cl.lat::double precision            AS lat
+FROM candidate_location cl
+WHERE cl.is_cluster_primary = TRUE
+  AND cl.source_tier = 1
+  AND cl.geom IS NOT NULL
+  AND cl.lon IS NOT NULL
+  AND cl.lat IS NOT NULL
+ORDER BY cl.id
+LIMIT 1500;
+
+SELECT COUNT(*) AS sampled_candidates FROM l1_sample;
+
+-- ── Per-candidate raw sub-signals (one bulk pass, LATERAL per source) ──
+DROP TABLE IF EXISTS l1_metrics;
+CREATE TEMP TABLE l1_metrics AS
+SELECT
+    s.parcel_id,
+    -- OSM trip generators (planet_osm_point ∪ planet_osm_polygon), 3500 m.
+    COALESCE(osm.offices, 0)       AS osm_offices,
+    COALESCE(osm.malls_retail, 0)  AS osm_malls_retail,
+    COALESCE(osm.transit, 0)       AS osm_transit,
+    COALESCE(osm.mosques, 0)       AS osm_mosques,
+    COALESCE(osm.schools, 0)       AS osm_schools,
+    COALESCE(osm.hospitals, 0)     AS osm_hospitals,
+    COALESCE(osm.hotels, 0)        AS osm_hotels,
+    -- Weighted total = exact quantity the OSM sub-score normalizes.
+    ( 2.00 * COALESCE(osm.offices, 0)
+    + 4.00 * COALESCE(osm.malls_retail, 0)
+    + 2.00 * COALESCE(osm.transit, 0)
+    + 1.50 * COALESCE(osm.mosques, 0)
+    + 1.75 * COALESCE(osm.schools, 0)
+    + 2.00 * COALESCE(osm.hospitals, 0)
+    + 2.50 * COALESCE(osm.hotels, 0) )           AS osm_weighted_total,
+    COALESCE(fl.floors_sum, 0)     AS building_floors_sum,
+    COALESCE(fnb.review_weighted, 0) AS fnb_review_weighted,
+    COALESCE(fnb.venue_count, 0)   AS fnb_venue_count,
+    COALESCE(p1000.pop, 0)         AS pop_reach_1000,
+    COALESCE(p1500.pop, 0)         AS pop_reach_1500,
+    COALESCE(p3500.pop, 0)         AS pop_reach_3500
+FROM l1_sample s
+LEFT JOIN LATERAL (
+    SELECT
+        COUNT(*) FILTER (WHERE g.kind = 'offices')      AS offices,
+        COUNT(*) FILTER (WHERE g.kind = 'malls_retail') AS malls_retail,
+        COUNT(*) FILTER (WHERE g.kind = 'transit')      AS transit,
+        COUNT(*) FILTER (WHERE g.kind = 'mosques')      AS mosques,
+        COUNT(*) FILTER (WHERE g.kind = 'schools')      AS schools,
+        COUNT(*) FILTER (WHERE g.kind = 'hospitals')    AS hospitals,
+        COUNT(*) FILTER (WHERE g.kind = 'hotels')       AS hotels
+    FROM (
+        SELECT
+            CASE
+              WHEN (lower(COALESCE(office,'')) <> '' OR lower(COALESCE(building,'')) IN ('office','commercial')) THEN 'offices'
+              WHEN (lower(COALESCE(shop,'')) IN ('mall','supermarket','department_store','wholesale') OR lower(COALESCE(amenity,'')) = 'marketplace') THEN 'malls_retail'
+              WHEN (lower(COALESCE(railway,'')) IN ('station','halt','tram_stop','subway_entrance','stop') OR lower(COALESCE(amenity,'')) IN ('bus_station')) THEN 'transit'
+              WHEN (lower(COALESCE(amenity,'')) IN ('place_of_worship','mosque') OR lower(COALESCE(building,'')) = 'mosque') THEN 'mosques'
+              WHEN (lower(COALESCE(amenity,'')) IN ('school','college','university','kindergarten') OR lower(COALESCE(building,'')) IN ('school','university')) THEN 'schools'
+              WHEN (lower(COALESCE(amenity,'')) IN ('hospital','clinic','doctors')) THEN 'hospitals'
+              WHEN (lower(COALESCE(tourism,'')) IN ('hotel','motel','hostel','guest_house') OR lower(COALESCE(building,'')) = 'hotel') THEN 'hotels'
+              ELSE NULL
+            END AS kind
+        FROM planet_osm_point p
+        WHERE p.way IS NOT NULL
+          AND ST_DWithin(ST_Transform(p.way, 4326)::geography,
+                         ST_SetSRID(ST_MakePoint(s.lon, s.lat), 4326)::geography, 3500)
+        UNION ALL
+        SELECT
+            CASE
+              WHEN (lower(COALESCE(office,'')) <> '' OR lower(COALESCE(building,'')) IN ('office','commercial')) THEN 'offices'
+              WHEN (lower(COALESCE(shop,'')) IN ('mall','supermarket','department_store','wholesale') OR lower(COALESCE(amenity,'')) = 'marketplace') THEN 'malls_retail'
+              WHEN (lower(COALESCE(railway,'')) IN ('station','halt','tram_stop','subway_entrance','stop') OR lower(COALESCE(amenity,'')) IN ('bus_station')) THEN 'transit'
+              WHEN (lower(COALESCE(amenity,'')) IN ('place_of_worship','mosque') OR lower(COALESCE(building,'')) = 'mosque') THEN 'mosques'
+              WHEN (lower(COALESCE(amenity,'')) IN ('school','college','university','kindergarten') OR lower(COALESCE(building,'')) IN ('school','university')) THEN 'schools'
+              WHEN (lower(COALESCE(amenity,'')) IN ('hospital','clinic','doctors')) THEN 'hospitals'
+              WHEN (lower(COALESCE(tourism,'')) IN ('hotel','motel','hostel','guest_house') OR lower(COALESCE(building,'')) = 'hotel') THEN 'hotels'
+              ELSE NULL
+            END AS kind
+        FROM planet_osm_polygon pg
+        WHERE pg.way IS NOT NULL
+          AND ST_DWithin(ST_Transform(pg.way, 4326)::geography,
+                         ST_SetSRID(ST_MakePoint(s.lon, s.lat), 4326)::geography, 3500)
+    ) g
+    WHERE g.kind IS NOT NULL
+) osm ON TRUE
+LEFT JOIN LATERAL (
+    SELECT SUM(
+        CASE
+          WHEN o.num_floors IS NOT NULL AND o.num_floors > 0 THEN LEAST(60, GREATEST(1, round(o.num_floors)::int))
+          WHEN o.height IS NOT NULL AND o.height > 0 THEN LEAST(60, GREATEST(1, round(o.height / 3.2)::int))
+          ELSE 1
+        END
+    ) AS floors_sum
+    FROM overture_buildings o
+    WHERE o.geom IS NOT NULL
+      AND ST_DWithin(ST_Transform(o.geom, 4326)::geography,
+                     ST_SetSRID(ST_MakePoint(s.lon, s.lat), 4326)::geography, 3500)
+) fl ON TRUE
+LEFT JOIN LATERAL (
+    SELECT SUM(COALESCE(rp.review_count, 0)) AS review_weighted,
+           COUNT(*) AS venue_count
+    FROM restaurant_poi rp
+    WHERE rp.geom IS NOT NULL
+      AND rp.business_status IS DISTINCT FROM 'CLOSED_PERMANENTLY'
+      AND lower(rp.category) = ANY(ARRAY['burger','pizza','chicken','fast_food'])
+      AND ST_DWithin(rp.geom::geography,
+                     ST_SetSRID(ST_MakePoint(s.lon, s.lat), 4326)::geography, 3500)
+) fnb ON TRUE
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(pd.population), 0) AS pop
+    FROM population_density pd
+    WHERE pd.geom IS NOT NULL
+      AND ST_DWithin(pd.geom::geography,
+                     ST_SetSRID(ST_MakePoint(s.lon, s.lat), 4326)::geography, 1000)
+) p1000 ON TRUE
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(pd.population), 0) AS pop
+    FROM population_density pd
+    WHERE pd.geom IS NOT NULL
+      AND ST_DWithin(pd.geom::geography,
+                     ST_SetSRID(ST_MakePoint(s.lon, s.lat), 4326)::geography, 1500)
+) p1500 ON TRUE
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(pd.population), 0) AS pop
+    FROM population_density pd
+    WHERE pd.geom IS NOT NULL
+      AND ST_DWithin(pd.geom::geography,
+                     ST_SetSRID(ST_MakePoint(s.lon, s.lat), 4326)::geography, 3500)
+) p3500 ON TRUE;
+
+-- NOTE: the population LATERALs above assume population_density has a `geom`
+-- column. If your deployment stores lat/lon instead, swap the predicate to
+--   pd.lat IS NOT NULL AND pd.lon IS NOT NULL
+--   AND ST_DWithin(ST_SetSRID(ST_MakePoint(pd.lon::double precision, pd.lat::double precision),4326)::geography, ..., radius)
+-- (this mirrors the runtime fallback in _bulk_enrich_population).
+
+-- ── Percentiles per raw sub-signal (the numbers that set the anchors) ──
+SELECT 'fnb_review_weighted' AS signal,
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY fnb_review_weighted)::numeric, 1) AS p5,
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY fnb_review_weighted)::numeric, 1) AS p25,
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY fnb_review_weighted)::numeric, 1) AS p50,
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY fnb_review_weighted)::numeric, 1) AS p75,
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY fnb_review_weighted)::numeric, 1) AS p90,
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY fnb_review_weighted)::numeric, 1) AS p95,
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY fnb_review_weighted)::numeric, 1) AS p99,
+       round(MAX(fnb_review_weighted)::numeric, 1) AS max,
+       COUNT(*) FILTER (WHERE fnb_review_weighted = 0) AS n_zero
+FROM l1_metrics
+UNION ALL
+SELECT 'building_floors_sum',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY building_floors_sum)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY building_floors_sum)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY building_floors_sum)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY building_floors_sum)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY building_floors_sum)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY building_floors_sum)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY building_floors_sum)::numeric, 1),
+       round(MAX(building_floors_sum)::numeric, 1),
+       COUNT(*) FILTER (WHERE building_floors_sum = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'osm_weighted_total',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY osm_weighted_total)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY osm_weighted_total)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY osm_weighted_total)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY osm_weighted_total)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY osm_weighted_total)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY osm_weighted_total)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY osm_weighted_total)::numeric, 1),
+       round(MAX(osm_weighted_total)::numeric, 1),
+       COUNT(*) FILTER (WHERE osm_weighted_total = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'osm_offices',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY osm_offices)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY osm_offices)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY osm_offices)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY osm_offices)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY osm_offices)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY osm_offices)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY osm_offices)::numeric, 1),
+       round(MAX(osm_offices)::numeric, 1),
+       COUNT(*) FILTER (WHERE osm_offices = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'osm_malls_retail',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY osm_malls_retail)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY osm_malls_retail)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY osm_malls_retail)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY osm_malls_retail)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY osm_malls_retail)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY osm_malls_retail)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY osm_malls_retail)::numeric, 1),
+       round(MAX(osm_malls_retail)::numeric, 1),
+       COUNT(*) FILTER (WHERE osm_malls_retail = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'osm_transit',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY osm_transit)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY osm_transit)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY osm_transit)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY osm_transit)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY osm_transit)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY osm_transit)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY osm_transit)::numeric, 1),
+       round(MAX(osm_transit)::numeric, 1),
+       COUNT(*) FILTER (WHERE osm_transit = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'osm_mosques',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY osm_mosques)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY osm_mosques)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY osm_mosques)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY osm_mosques)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY osm_mosques)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY osm_mosques)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY osm_mosques)::numeric, 1),
+       round(MAX(osm_mosques)::numeric, 1),
+       COUNT(*) FILTER (WHERE osm_mosques = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'osm_schools',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY osm_schools)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY osm_schools)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY osm_schools)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY osm_schools)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY osm_schools)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY osm_schools)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY osm_schools)::numeric, 1),
+       round(MAX(osm_schools)::numeric, 1),
+       COUNT(*) FILTER (WHERE osm_schools = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'osm_hospitals',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY osm_hospitals)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY osm_hospitals)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY osm_hospitals)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY osm_hospitals)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY osm_hospitals)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY osm_hospitals)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY osm_hospitals)::numeric, 1),
+       round(MAX(osm_hospitals)::numeric, 1),
+       COUNT(*) FILTER (WHERE osm_hospitals = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'osm_hotels',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY osm_hotels)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY osm_hotels)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY osm_hotels)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY osm_hotels)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY osm_hotels)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY osm_hotels)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY osm_hotels)::numeric, 1),
+       round(MAX(osm_hotels)::numeric, 1),
+       COUNT(*) FILTER (WHERE osm_hotels = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'pop_reach_1000',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY pop_reach_1000)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY pop_reach_1000)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY pop_reach_1000)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY pop_reach_1000)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY pop_reach_1000)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY pop_reach_1000)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY pop_reach_1000)::numeric, 1),
+       round(MAX(pop_reach_1000)::numeric, 1),
+       COUNT(*) FILTER (WHERE pop_reach_1000 = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'pop_reach_1500',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY pop_reach_1500)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY pop_reach_1500)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY pop_reach_1500)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY pop_reach_1500)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY pop_reach_1500)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY pop_reach_1500)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY pop_reach_1500)::numeric, 1),
+       round(MAX(pop_reach_1500)::numeric, 1),
+       COUNT(*) FILTER (WHERE pop_reach_1500 = 0)
+FROM l1_metrics
+UNION ALL
+SELECT 'pop_reach_3500',
+       round(percentile_cont(0.05) WITHIN GROUP (ORDER BY pop_reach_3500)::numeric, 1),
+       round(percentile_cont(0.25) WITHIN GROUP (ORDER BY pop_reach_3500)::numeric, 1),
+       round(percentile_cont(0.50) WITHIN GROUP (ORDER BY pop_reach_3500)::numeric, 1),
+       round(percentile_cont(0.75) WITHIN GROUP (ORDER BY pop_reach_3500)::numeric, 1),
+       round(percentile_cont(0.90) WITHIN GROUP (ORDER BY pop_reach_3500)::numeric, 1),
+       round(percentile_cont(0.95) WITHIN GROUP (ORDER BY pop_reach_3500)::numeric, 1),
+       round(percentile_cont(0.99) WITHIN GROUP (ORDER BY pop_reach_3500)::numeric, 1),
+       round(MAX(pop_reach_3500)::numeric, 1),
+       COUNT(*) FILTER (WHERE pop_reach_3500 = 0)
+FROM l1_metrics;
+
+-- ── Population radius discrimination: spread ratio (p95/p50) by radius ──
+-- A higher ratio ⇒ the radius discriminates more. Expect 3500 m near 1.0
+-- (near-constant) and the tighter radii materially above it.
+SELECT
+    round((percentile_cont(0.95) WITHIN GROUP (ORDER BY pop_reach_1000)
+         / NULLIF(percentile_cont(0.50) WITHIN GROUP (ORDER BY pop_reach_1000), 0))::numeric, 3) AS spread_ratio_1000,
+    round((percentile_cont(0.95) WITHIN GROUP (ORDER BY pop_reach_1500)
+         / NULLIF(percentile_cont(0.50) WITHIN GROUP (ORDER BY pop_reach_1500), 0))::numeric, 3) AS spread_ratio_1500,
+    round((percentile_cont(0.95) WITHIN GROUP (ORDER BY pop_reach_3500)
+         / NULLIF(percentile_cont(0.50) WITHIN GROUP (ORDER BY pop_reach_3500), 0))::numeric, 3) AS spread_ratio_3500,
+    round(STDDEV_POP(pop_reach_1500)::numeric, 1) AS stddev_1500,
+    round(STDDEV_POP(pop_reach_3500)::numeric, 1) AS stddev_3500
+FROM l1_metrics;
+
+DROP TABLE IF EXISTS l1_metrics;
+DROP TABLE IF EXISTS l1_sample;

--- a/tests/test_expansion_advisor_demand_generator.py
+++ b/tests/test_expansion_advisor_demand_generator.py
@@ -37,25 +37,29 @@ def run_expansion_search(*args, **kwargs):
 # Pure-function tests
 # ---------------------------------------------------------------------------
 
+# Realistic dense-Riyadh catchment OSM counts (3.5 km). The PR-1a anchors expect
+# hundreds of offices, so these are scaled to land in the calibrated band.
 _FULL_OSM = {
-    "offices": 12,
-    "malls_retail": 3,
-    "transit": 2,
-    "mosques": 8,
-    "schools": 6,
-    "hospitals": 1,
-    "hotels": 4,
+    "offices": 600,
+    "malls_retail": 40,
+    "transit": 15,
+    "mosques": 80,
+    "schools": 60,
+    "hospitals": 12,
+    "hotels": 30,
 }
 
 
 def _index(**overrides):
     base = dict(
-        population_reach=120000.0,
+        population_reach=250000.0,
+        population_local_reach=45000.0,
         osm_counts=_FULL_OSM,
-        building_floors_proxy_sum=850.0,
-        fnb_review_weighted=4200.0,
+        building_floors_proxy_sum=20000.0,
+        fnb_review_weighted=80000.0,
         fnb_venue_count=70,
         radius_m=3500,
+        pop_radius_m=1500,
     )
     base.update(overrides)
     return _demand_generator_index(**base)
@@ -64,13 +68,15 @@ def _index(**overrides):
 def test_composite_in_range_and_all_subcomponents_present():
     idx = _index()
     assert 0.0 <= idx["composite_0_100"] <= 100.0
-    # raw sub-values retained for PR-2 recalibration
-    assert idx["population_reach"] == 120000
-    assert idx["building_floors_proxy_sum"] == 850.0
-    assert idx["fnb_review_weighted_density"] == 4200.0
+    # raw sub-values retained for the next recalibration (no re-enrich needed)
+    assert idx["population_reach"] == 250000
+    assert idx["population_local_reach"] == 45000
+    assert idx["pop_radius_m"] == 1500
+    assert idx["building_floors_proxy_sum"] == 20000.0
+    assert idx["fnb_review_weighted_density"] == 80000.0
     assert idx["fnb_venue_count"] == 70
     assert idx["radius_m"] == 3500
-    assert idx["weights_version"]  # non-empty
+    assert idx["weights_version"] == "l1_v2_2026-06"
     for k in (
         "offices",
         "malls_retail",
@@ -83,11 +89,15 @@ def test_composite_in_range_and_all_subcomponents_present():
         assert idx["osm_generators"][k] == _FULL_OSM[k]
     for k in ("population", "osm_generators", "building_floors", "fnb_review_weighted"):
         assert 0.0 <= idx["subscores"][k] <= 100.0
+    # PR-1a: dense-but-not-extreme catchment must leave HEADROOM (not peg at 100),
+    # which is exactly the saturation v1 suffered from.
+    assert idx["composite_0_100"] < 95.0
 
 
 def test_composite_varies_with_inputs():
     low = _index(
         population_reach=1000.0,
+        population_local_reach=1000.0,
         osm_counts={},
         building_floors_proxy_sum=0.0,
         fnb_review_weighted=0.0,
@@ -99,9 +109,101 @@ def test_composite_varies_with_inputs():
     assert high["composite_0_100"] > 0.0
 
 
+def test_recalibrated_index_spreads_across_a_fixture():
+    """PR-1a regression guard for the ceiling-pinning bug.
+
+    The v1 index gave low-activity المربع (low everything) the SAME 98.75 as
+    high-activity الورود (near-max everything). With the re-anchored normalization
+    a realistic spread of catchments must produce a wide, well-ordered composite —
+    materially > the v1 stddev of 1.92, many distinct values, and the low-activity
+    candidate clearly below the high-activity one.
+    """
+    fixture = [
+        # (label, population_local, osm_counts, floors, fnb_review_weighted)
+        (
+            "almurabba_low",
+            9000,
+            {"offices": 40, "malls_retail": 2, "schools": 5},
+            3500,
+            13000,
+        ),
+        (
+            "mid_a",
+            25000,
+            {
+                "offices": 200,
+                "malls_retail": 10,
+                "transit": 4,
+                "mosques": 30,
+                "schools": 25,
+            },
+            9000,
+            45000,
+        ),
+        (
+            "mid_b",
+            38000,
+            {
+                "offices": 350,
+                "malls_retail": 18,
+                "transit": 6,
+                "mosques": 45,
+                "schools": 40,
+                "hospitals": 5,
+            },
+            14000,
+            70000,
+        ),
+        (
+            "alward_high",
+            70000,
+            {
+                "offices": 1200,
+                "malls_retail": 60,
+                "transit": 20,
+                "mosques": 90,
+                "schools": 70,
+                "hospitals": 15,
+                "hotels": 45,
+            },
+            30000,
+            150000,
+        ),
+    ]
+    composites = []
+    by_label = {}
+    for label, pop, osm, floors, fnb in fixture:
+        idx = _demand_generator_index(
+            population_reach=250000.0,
+            population_local_reach=float(pop),
+            osm_counts=osm,
+            building_floors_proxy_sum=float(floors),
+            fnb_review_weighted=float(fnb),
+            fnb_venue_count=10,
+            radius_m=3500,
+            pop_radius_m=1500,
+        )
+        composites.append(idx["composite_0_100"])
+        by_label[label] = idx["composite_0_100"]
+
+    # Wide spread: uses much of 0-100 and beats the v1 stddev artifact (1.92).
+    spread = max(composites) - min(composites)
+    assert spread >= 30.0, composites
+    assert len(set(round(c) for c in composites)) == len(composites), composites
+    # Ordering sanity: low-activity must rank clearly below high-activity.
+    assert by_label["almurabba_low"] < by_label["alward_high"] - 20.0
+    assert (
+        by_label["almurabba_low"]
+        < by_label["mid_a"]
+        < by_label["mid_b"]
+        < by_label["alward_high"]
+    )
+
+
 def test_zero_inputs_are_safe():
     idx = _index(
         population_reach=0.0,
+        population_local_reach=0.0,
         osm_counts={},
         building_floors_proxy_sum=0.0,
         fnb_review_weighted=0.0,
@@ -113,11 +215,13 @@ def test_zero_inputs_are_safe():
 
 
 def test_osm_subscore_monotonic_and_bounded():
+    # Counts scaled into the calibrated band (offices in the hundreds).
     s0 = _demand_generator_osm_subscore({})
-    s1 = _demand_generator_osm_subscore({"malls_retail": 1})
-    s2 = _demand_generator_osm_subscore({"malls_retail": 10, "offices": 10})
+    s1 = _demand_generator_osm_subscore({"offices": 100, "malls_retail": 10})
+    s2 = _demand_generator_osm_subscore({"offices": 800, "malls_retail": 50})
     assert 0.0 <= s0 <= s1 <= s2 <= 100.0
     assert s1 > s0
+    assert s2 > s1
 
 
 def test_index_is_numerator_only_more_fnb_raises_score():
@@ -254,4 +358,8 @@ def test_flag_on_emits_index_without_changing_scores(
         }
         assert "fnb_review_weighted_density" in idx
         assert "building_floors_proxy_sum" in idx
-        assert idx["weights_version"]
+        # PR-1a: tighter-radius population sub-term retained raw alongside the
+        # full 3500 m reach.
+        assert "population_local_reach" in idx
+        assert idx["pop_radius_m"] == 1500
+        assert idx["weights_version"] == "l1_v2_2026-06"


### PR DESCRIPTION
The v1 index pinned at the ceiling (composite stddev 1.92, 5 distinct values;
المربع scored the same as الورود) because every normalization reference sat far
below real Riyadh catchment values, saturating all four sub-scores. This is
calibration, not data — fixed without wiring into the score.

- Re-anchor every sub-signal to the real distribution: winsorize at p99, map
  city-wide p5→p95 onto 0-100, log-transform the wide-spread signals. Anchors in
  one versioned block (_DEMAND_GENERATOR_NORM_ANCHORS), provisional until Phase A.
- Re-anchor the OSM sub-score (was a /20 sigmoid that saturated to ~95 for all).
- Population term (option a): compute the sub-score at a tighter radius
  (EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M, default 1500 m) via a new bulk-enrich
  block where population actually varies; retain the full 3500 m reach raw.
- Rebalance composite weights onto the discriminators (osm 0.35, fnb 0.30,
  floors 0.20, population 0.15; sum 1.0).
- Bump weights_version to l1_v2_2026-06; retain every raw sub-value (+ new
  population_local_reach / pop_radius_m) so the next calibration needs no re-enrich.
- New Phase A probe scripts/diagnostics/l1_signal_distributions.sql (psql -f safe).
- Tests: rescaled fixtures + spread/ordering regression guard; still emit-only and
  rankings unchanged when the flag is off.

Still flag-gated (EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED, default OFF). No edits
to component_weights / _demand_blend_weights / sum==100 / gates / final_score. The
competition_whitespace=15.00 constant is a separate pre-existing denominator issue,
flagged for later, not touched here.