### PR TITLE
fix(expansion): un-floor delivery_first competition_whitespace

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -820,7 +820,13 @@ _CATCHMENT_RADII_M: dict[str, dict[str, float]] = {
     # spans two genuinely different scopes (same-category counts at 3000 m
     # saturated the whitespace curve — p50 ~230 vs a domain ending at 25).
     "dine_in":        {"demand": 3500.0, "competition": 1000.0, "provider": 3500.0},
-    "delivery_first": {"demand": 3000.0, "competition": 2500.0, "provider": 3000.0},
+    # delivery_first competition tightened 2500 -> 1000 m for the same reason
+    # as dine_in: same-category counts at 2500 m are both enormous and nearly
+    # constant (probe p50/p75/p90 all ~145, max 149, 0% within the curve REF),
+    # so the whitespace component floored 100% of the shortlist at 15.0 — dead
+    # signal. The discriminating variation lives at 1000 m (probe p50 ~16, p90
+    # ~29). demand/provider stay at 3000 m (platform delivery radius).
+    "delivery_first": {"demand": 3000.0, "competition": 1000.0, "provider": 3000.0},
     "qsr":            {"demand": 1500.0, "competition": 1200.0, "provider": 1500.0},
     "cafe":           {"demand": 1000.0, "competition":  800.0, "provider": 1000.0},
 }
@@ -2560,9 +2566,19 @@ _WHITESPACE_LOG_REF: dict[str, float] = {
     # 1000 m trade area where in-range counts run p50 ~16 / p75 ~24 / p90 ~32;
     # under the default REF=25 the p50 already sits at the floor, collapsing
     # the whole p50–p75 band to a flat 15. REF=50 keeps that band spread and
-    # floors only the genuinely saturated count ≥ ~40 tail. All other service
-    # models keep the default 25.
+    # floors only the genuinely saturated count ≥ ~40 tail.
+    #
+    # delivery_first has the identical signature once its competition radius is
+    # tightened to 1000 m: probe counts run p50 ~16 / p90 ~29 / max ~32, so the
+    # default REF=25 would re-floor the p50. REF=50 spreads that band (count
+    # 16 → ~28). The 1000 m probe counts are the under-counting approximation
+    # (simplified category match, no alias expansion), so true production counts
+    # run somewhat higher — REF=50 (matching dine_in) deliberately avoids
+    # re-flooring on the alias-expanded counts rather than sizing lower.
+    #
+    # All other service models keep the default 25.
     "dine_in": 50.0,
+    "delivery_first": 50.0,
 }
 _WHITESPACE_LOG_REF_DEFAULT: float = 25.0
 
@@ -2578,10 +2594,10 @@ def _competition_whitespace_score(
     The curve is ``raw = 100·(1 − log1p(count)/log1p(REF))`` clamped to a
     15.0 floor, so it decays steeply at low counts and gently at high ones,
     reaching the floor structurally at ``count = REF``. ``REF`` is
-    service-model-aware via ``_WHITESPACE_LOG_REF`` (``dine_in`` → 50, all
-    other models → 25 default), because dine_in scores its competitors over
-    a tighter 1000 m trade area whose in-range counts are large enough that
-    the default REF=25 would floor the p50.
+    service-model-aware via ``_WHITESPACE_LOG_REF`` (``dine_in`` and
+    ``delivery_first`` → 50, all other models → 25 default), because both
+    score their competitors over a tighter 1000 m trade area whose in-range
+    counts are large enough that the default REF=25 would floor the p50.
 
     Representative outputs (count → score):
       REF=25 (default):  0→100*, 1→79, 3→57, 6→40, 16→15 (floored at ≤16),

--- a/docs/fix-delivery-first-competition-whitespace-report.md
+++ b/docs/fix-delivery-first-competition-whitespace-report.md
@@ -1,0 +1,166 @@
+# FIX: delivery_first competition radius + whitespace curve recalibration
+
+**Branch:** `claude/delivery-first-whitespace-fix-ax3ezq`
+**Status:** On branch — no PR opened, no push/merge/dispatch. Ahmed reviews the diff (especially the
+REF=50 constant and the 1000 m radius) before merge, and validates on a fresh delivery_first search.
+**Type:** Real scoring change (not emit-only, not flag-gated). **Changes delivery_first rankings on
+deploy** — same class as the dine_in whitespace fix (`docs/fix-dinein-competition-whitespace-report.md`).
+This is the follow-up that report's §7 explicitly flagged.
+
+---
+
+## 1. What is wrong now
+
+A live delivery_first burger search (15 candidates) probed **100% floored**:
+`competition_whitespace = 15.00` for all 15 — **one distinct value**, every site pinned at/above
+the default curve REF=25. The component is **dead signal** for delivery_first, exactly as it was for
+dine_in before its fix.
+
+Root cause is the same two-part issue:
+
+- `_competition_whitespace_score` is fed **same-category competitor counts over the delivery_first
+  `"competition"` radius of 2500 m**. At 2500 m those counts are both **huge and nearly constant**:
+  probe p50/p75/p90 all ≈ **145**, max **149**, **0% within REF**.
+- The log-decay curve `raw = 100·(1 − log1p(count)/log1p(REF))` floors structurally at `count = REF`,
+  and delivery_first fell through to `REF = 25` (the shared default). Any count ≥ 25 floors — with
+  p50 ≈ 145, every candidate floors.
+
+A constant component output means `competition_whitespace` carries **zero discriminating signal** for
+delivery_first.
+
+## 2. Why it happens — both levers are required
+
+The radius and the curve reference were never co-calibrated for delivery_first:
+
+- **Why not REF-only.** At 2500 m the counts don't merely overflow the curve, they **barely vary**
+  (p50/p75/p90 all 145). Raising REF would un-floor them but could not *spread* a flat distribution —
+  the discriminating variation simply isn't present at 2500 m.
+- **Why not radius-only.** The discriminating signal lives at **1000 m** (probe recompute: p50 **16**,
+  p90 **29**, max **32**, with real per-candidate variation). But even at 1000 m the p50 (count 16)
+  **still floors under REF=25** (16 → raw 13.0 → floored 15.0). Tightening the radius is necessary but
+  not sufficient.
+
+dine_in needed **both** radius→1000 and REF→50 for this exact signature; delivery_first shows the same
+signature, so it takes the same two coupled levers.
+
+## 3. The fix (two coupled changes + a test update — delivery_first blast radius only)
+
+### Change 1 — delivery_first competition radius 2500 → 1000 m
+
+`app/services/expansion_advisor.py:829` — `_CATCHMENT_RADII_M['delivery_first']['competition']`:
+`2500.0 → 1000.0`. The model's **`demand` (3000) and `provider` (3000) radii are unchanged** (platform
+delivery radius). dine_in / qsr / cafe rows untouched.
+
+### Change 2 — add a delivery_first curve reference
+
+`app/services/expansion_advisor.py:2581` — `_WHITESPACE_LOG_REF`: add `"delivery_first": 50.0`.
+`dine_in: 50.0` and `_WHITESPACE_LOG_REF_DEFAULT = 25.0` are unchanged; qsr / cafe still resolve to the
+25 default. No call-site change needed — the scorer is already called with `service_model=service_model`
+(`expansion_advisor.py:8146`).
+
+### Change 3 — update the blast-radius guard test
+
+The dine_in fix had pinned **delivery_first** bit-for-bit to the legacy REF=25 curve
+(`test_competition_whitespace_cafe_qsr_reference_unchanged`). That guard now encoded the bug. It is
+updated to:
+
+- **drop delivery_first** from the legacy REF=25 loop (now guards qsr / cafe / `None` only), broadened
+  to representative counts `1/3/6/8/12/16/24/25/40/50/145`;
+- a new `test_competition_whitespace_delivery_first_reference_varies_off_floor` pins delivery_first
+  **bit-for-bit to the REF=50 curve** (via a `_ref50` helper), asserts the p50 (count 16) is off the
+  floor (~27.9) and that genuine saturation (50, 145) still floors at 15.0;
+- `test_competition_whitespace_dine_in_reference_varies_off_floor` is strengthened with an explicit
+  REF=50 representative-count guard (6/16/25/50/145) so the delivery_first change cannot perturb
+  dine_in;
+- `test_competition_whitespace_f4_path_unchanged_per_model` now includes delivery_first.
+
+The point of the guard is unchanged — pin per-model whitespace behaviour — it just now encodes the
+fixed delivery_first curve instead of the buggy one. It is **not** weakened to a no-op.
+
+---
+
+## REF = 50 rationale (verified in code, exact formula)
+
+At 1000 m the probe shows **p50 16 / p90 29 / max 32**. REF=50 spreads that band off the floor:
+
+| count    | REF=25 (default / qsr・cafe) | REF=50 (dine_in + delivery_first) |
+|----------|------------------------------|-----------------------------------|
+| 1        | 78.7                         | 82.4                              |
+| 6        | 40.3                         | 50.5                              |
+| 16 (p50) | **15.0 (floored)**           | **27.9**                          |
+| 24       | 15.0                         | 18.1                              |
+| 29 (p90) | 15.0                         | 15.0\*                            |
+| 32 (max) | 15.0                         | 15.0                              |
+| 50       | 15.0                         | 15.0 (floor)                      |
+| 145      | 15.0                         | 15.0                              |
+
+\* The 1000 m probe counts are the **under-counting approximation** (simplified category match, no
+alias expansion), so true production counts at 1000 m run somewhat higher. REF=50 (matching dine_in) is
+chosen deliberately **not lower**, to avoid re-flooring on the genuine alias-expanded counts. If
+post-deploy validation shows genuinely-competitive sites still bunched low, REF can be nudged up — do
+not pre-optimize.
+
+> Note: the brief's loose parentheticals (e.g. "29 → ~17") were estimates; the tests assert the actual
+> computed REF=50 curve (29 → 15.0 under the exact formula), so they encode true behaviour rather than
+> the approximation.
+
+---
+
+## 4. Validation
+
+### Already run (this patch)
+
+```bash
+python -m pytest tests/test_expansion_advisor_service.py -k whitespace -q   # 5 passed
+python -m pytest tests/test_expansion_advisor_service.py \
+                tests/test_expansion_advisor.py \
+                tests/test_expansion_advisor_demand_generator.py -q          # 280 passed
+python -m pytest tests/ -k "golden or memo" -q                              # 128 passed, 6 skipped
+```
+
+### Post-deploy (Ahmed — this DOES change delivery_first rankings)
+
+1. Merge → deploy → `kubectl rollout status deployment/oaktree-estimator -n default`.
+2. Fresh city-wide **delivery_first** search (old searches won't backfill).
+3. Re-run `scripts/diagnostics/delivery_first_whitespace_probe.sql`
+   (`psql -f … > /tmp/df_val2.txt`). Success criteria:
+   - `pct_whitespace_at_floor` drops from **100%** to only the genuinely saturated few;
+   - `distinct_whitespace_values` rises from 1 to many (signal restored);
+   - `competition_whitespace` spreads roughly **15–82** across the shortlist;
+   - `competitor_count` now reflects the **1000 m** radius (p50 ~16, not ~145);
+   - the shortlist reorders sensibly (low-local-competition sites rise).
+
+---
+
+## 5. Risk / tradeoff — blast radius
+
+- **Intended ranking shift, delivery_first only.** Saturated delivery_first sites that previously all
+  read 15.0 now spread across the p50–p75 band; the genuinely saturated ≥ ~40 tail still floors. This
+  is the corrected behaviour, not a regression.
+- **Blast radius** is the whitespace component's weight (**~5.764%**), larger in effect under a
+  delivery-led brief where delivery weighting dominates the demand blend.
+- **Contained.** dine_in (REF 50), qsr (REF 25), cafe (REF 25) keep their existing radii and REFs,
+  pinned bit-for-bit by guard tests. No change to `_competition_whitespace_score`'s formula, the 15.00
+  floor, the F4 `count<=0` branches (50/100), `component_weights`, `_demand_blend_weights`, the
+  `sum == 100` invariant, gates, or any other model's radii.
+- **Curve constant is the review point.** REF=50 lives in the named `_WHITESPACE_LOG_REF` dict so Ahmed
+  can tune the knee without touching the formula.
+
+---
+
+## 6. Verified anchors (live tree vs brief)
+
+| Symbol | Live `path:line` | Brief anchor | Drift |
+|--------|------------------|--------------|-------|
+| `_CATCHMENT_RADII_M['delivery_first']` | `expansion_advisor.py:829` | :823 | +6 |
+| `_WHITESPACE_LOG_REF['delivery_first']` | `expansion_advisor.py:2581` | :2556 | +25 |
+| call site (already passes `service_model`) | `expansion_advisor.py:8146` | — | — |
+
+---
+
+## 7. Merge recommendation
+
+**Low risk, high signal.** Targeted, well-tested; the behaviour-corrupting input is fixed at the
+source and the only judgement call — the REF=50 constant — is surfaced in a named dict for review.
+Recommend merge after Ahmed signs off on the constant and the 1000 m radius, then run the post-deploy
+validation above.

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -511,9 +511,15 @@ def test_competition_whitespace_dine_in_reference_varies_off_floor():
     floor, collapsing the p50–p75 band to a constant. REF=50 keeps that band
     off the floor and floors only the genuinely saturated count ≥ ~40 tail.
     """
+    import math
+
     import pytest
 
     from app.services.expansion_advisor import _competition_whitespace_score
+
+    def _ref50(count: int) -> float:
+        raw = 100.0 * (1.0 - (math.log1p(count) / math.log1p(50)))
+        return max(15.0, raw)
 
     counts = [0, 6, 16, 24, 40]
     scores = [
@@ -522,6 +528,12 @@ def test_competition_whitespace_dine_in_reference_varies_off_floor():
     ]
     # Whitespace varies across the band — not a constant 15.
     assert len(set(scores)) > 1
+    # Blast-radius guard: dine_in stays bit-for-bit on the REF=50 curve at the
+    # representative counts (the delivery_first fix must not perturb it).
+    for count in (6, 16, 25, 50, 145):
+        assert _competition_whitespace_score(
+            count, confident=True, service_model="dine_in"
+        ) == pytest.approx(_ref50(count))
     # p50 count (16) is off the floor under REF=50.
     assert _competition_whitespace_score(
         16, confident=True, service_model="dine_in"
@@ -533,10 +545,12 @@ def test_competition_whitespace_dine_in_reference_varies_off_floor():
 
 
 def test_competition_whitespace_cafe_qsr_reference_unchanged():
-    """Blast-radius guard: non-dine_in models keep REF=25 exactly.
+    """Blast-radius guard: qsr / cafe (REF=25 default) are unchanged.
 
-    These must match the pre-change behaviour bit-for-bit so the dine_in
-    recalibration cannot leak into cafe / qsr / delivery_first rankings.
+    These must match the pre-change behaviour bit-for-bit so neither the
+    dine_in nor the delivery_first recalibration can leak into cafe / qsr
+    rankings. delivery_first is deliberately NOT in this loop any more — it
+    now uses REF=50 (see the dedicated test below).
     """
     import math
 
@@ -548,18 +562,67 @@ def test_competition_whitespace_cafe_qsr_reference_unchanged():
         raw = 100.0 * (1.0 - (math.log1p(count) / math.log1p(25)))
         return max(15.0, raw)
 
-    for count in (1, 3, 6, 8, 12, 16, 25, 40):
-        for model in ("cafe", "qsr", "delivery_first", None):
+    # Representative competitor counts spanning empty -> saturated, including
+    # the probe percentiles called out in the fix report.
+    for count in (1, 3, 6, 8, 12, 16, 24, 25, 40, 50, 145):
+        for model in ("cafe", "qsr", None):
             assert _competition_whitespace_score(
                 count, confident=True, service_model=model
             ) == pytest.approx(_legacy_ref25(count))
+
+
+def test_competition_whitespace_delivery_first_reference_varies_off_floor():
+    """delivery_first uses REF=50 so its tightened 1000 m count band spreads.
+
+    Before the fix delivery_first scored same-category competitors over a
+    2500 m radius whose counts were both huge and nearly constant (probe
+    p50/p75/p90 all ~145), so the whitespace component floored 100% of the
+    shortlist at 15.0. Tightening the competition radius to 1000 m surfaces
+    real variation (probe p50 ~16 / p90 ~29), but under the default REF=25
+    the p50 (~16) would still floor — so delivery_first now matches dine_in's
+    REF=50, which keeps that band off the floor.
+    """
+    import math
+
+    import pytest
+
+    from app.services.expansion_advisor import _competition_whitespace_score
+
+    def _ref50(count: int) -> float:
+        raw = 100.0 * (1.0 - (math.log1p(count) / math.log1p(50)))
+        return max(15.0, raw)
+
+    # delivery_first follows the REF=50 curve exactly (NOT the legacy REF=25).
+    for count in (1, 3, 6, 16, 24, 32, 40, 50, 145):
+        assert _competition_whitespace_score(
+            count, confident=True, service_model="delivery_first"
+        ) == pytest.approx(_ref50(count))
+
+    scores = [
+        _competition_whitespace_score(c, confident=True, service_model="delivery_first")
+        for c in (0, 6, 16, 24, 40)
+    ]
+    # Component carries signal again — not a constant floor.
+    assert len(set(scores)) > 1
+    # p50 count (16) sits well off the floor under REF=50 (~28) where REF=25
+    # would have floored it at 15.
+    assert _competition_whitespace_score(
+        16, confident=True, service_model="delivery_first"
+    ) == pytest.approx(27.9, abs=0.5)
+    # Genuine saturation still floors at 15.
+    assert _competition_whitespace_score(
+        50, confident=True, service_model="delivery_first"
+    ) == 15.0
+    assert _competition_whitespace_score(
+        145, confident=True, service_model="delivery_first"
+    ) == 15.0
 
 
 def test_competition_whitespace_f4_path_unchanged_per_model():
     """F4 zero-count logic is independent of the service-model reference."""
     from app.services.expansion_advisor import _competition_whitespace_score
 
-    for model in ("dine_in", "cafe", "qsr", None):
+    for model in ("dine_in", "delivery_first", "cafe", "qsr", None):
         assert _competition_whitespace_score(
             0, confident=True, service_model=model
         ) == 100.0


### PR DESCRIPTION
A live delivery_first search probed 100% floored: competition_whitespace
= 15.00 for all 15 candidates (one distinct value). The component carried
zero discriminating signal — the same two-part bug fixed for dine_in.

Root cause: same-category competitor counts are scored over a 2500 m
competition radius where the distribution is both huge and nearly
constant (probe p50/p75/p90 all ~145, 0% within the curve REF), while
the log-decay curve floors structurally at count = REF and delivery_first
fell through to the default REF=25. The discriminating variation lives at
1000 m (probe p50 ~16, p90 ~29), but even there the p50 floors under
REF=25 — so both levers are required.

Changes (delivery_first only; not flag-gated, like the dine_in fix):
- _CATCHMENT_RADII_M['delivery_first']['competition']: 2500 -> 1000 m
  (demand/provider stay at 3000 m).
- _WHITESPACE_LOG_REF: add 'delivery_first': 50.0 (matches dine_in; sized
  to avoid re-flooring on true alias-expanded counts, which run higher
  than the under-counting probe).
- Update the blast-radius guard test: drop delivery_first from the legacy
  REF=25 loop, add a dedicated REF=50 guard, strengthen the dine_in guard,
  and add delivery_first to the F4 path test.

No change to the curve formula, the 15.00 floor, F4 count<=0 branches,
component weights, gates, or any other model's radii/REF. dine_in (REF 50),
qsr (REF 25), cafe (REF 25) pinned bit-for-bit by guards.

Tests: tests/test_expansion_advisor_service.py -k whitespace (5 passed);
full suite 2294 passed, 24 skipped.

https://claude.ai/code/session_01YQwafjBj3SsAPk44gxALbH