### PR TITLE
feat(expansion): wire L1 demand-generator index into QSR scoring (l1_v3 re-anchor)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -159,6 +159,25 @@ class Settings:
         os.getenv("EXPANSION_DEMAND_GENERATOR_SCORING_ENABLED", "false").strip().lower()
         in {"1", "true", "yes", "on"}
     )
+    # --- Expansion Advisor L1 demand-generator index SCORING — QSR (l1_v3) ---
+    # Wires the L1 index composite into the QSR demand blend, swapping the
+    # near-constant pop_score numerator for the demand-generator composite
+    # (demand_score = composite·0.60 + delivery_score·0.40). QSR is re-anchored
+    # against the l1_v3 anchor set read at QSR's 1500 m demand radius. Real scoring
+    # change → changes QSR rankings when enabled. SEPARATE from the dine-in flag on
+    # purpose: the dine-in flag is already ON in prod, so reusing it would take QSR
+    # live the instant this deploys with no flag-off→flag-on validation window.
+    # Default OFF: when false QSR final_score and ordering are byte-for-byte
+    # identical to production. Only takes effect when
+    # EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED is ALSO true (the composite must be
+    # computed to be scored); if this is on while the index flag is off, the service
+    # logs once and falls back to pop_score.
+    EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED: bool = (
+        os.getenv("EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED", "false")
+        .strip()
+        .lower()
+        in {"1", "true", "yes", "on"}
+    )
 
     # --- Expansion Advisor structured decision memo (Phase 1) ---
     # Model/token/temperature controls for the new structured memo path in

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -864,6 +864,27 @@ def _population_reference(service_model: str | None) -> float:
     )
 
 
+def _demand_generator_radius_m(service_model: str | None) -> float:
+    """Demand-generator enrich/index radius (metres) for this service model.
+
+    Change-1 (Phase-A discrepancy E.2): the L1 demand-generator index must be
+    computed at the SAME catchment the model is scored at, so read each model's
+    demand radius from ``_CATCHMENT_RADII_M[model]['demand']`` instead of the
+    flat ``EXPANSION_DEMAND_GENERATOR_RADIUS_M``:
+
+        dine_in -> 3500 (UNCHANGED — already equal to the flat default),
+        qsr     -> 1500, cafe -> 1000, delivery_first -> 3000.
+
+    Any model absent from ``_CATCHMENT_RADII_M`` falls back to the flat
+    ``EXPANSION_DEMAND_GENERATOR_RADIUS_M`` (mirrors ``_catchment_radii``'s
+    fallback intent without forcing qsr's 1500 m onto an unknown model).
+    """
+    radii = _CATCHMENT_RADII_M.get((service_model or "").lower())
+    if radii and "demand" in radii:
+        return float(radii["demand"])
+    return float(settings.EXPANSION_DEMAND_GENERATOR_RADIUS_M)
+
+
 def _chunked(seq: list[Any], size: int):
     for i in range(0, len(seq), size):
         yield seq[i : i + size]
@@ -1832,6 +1853,15 @@ def _foot_traffic_score(nearby_amenity_count: int) -> float:
 # new data sources, still emit-only.
 _DEMAND_GENERATOR_WEIGHTS_VERSION = "l1_v2_2026-06"
 
+# l1_v3 (QSR re-anchor): the dine-in l1_v2 anchors above were gathered at the
+# 3500 m demand radius. At QSR's tighter 1500 m demand radius the raw counts are
+# genuinely smaller (QSR fnb p95 ~72k vs dine-in 225k; floors p95 ~6.9k vs 35.6k),
+# so reusing l1_v2 would map nearly every QSR candidate near 0. l1_v3 re-anchors
+# the SAME four sub-signals (and the SAME 0.40/0.35/0.20/0.05 mix) to the QSR
+# 1500 m distribution — a clean re-anchor, NOT a re-mix. QSR-keyed; dine-in keeps
+# l1_v2 untouched.
+_DEMAND_GENERATOR_WEIGHTS_VERSION_QSR = "l1_v3_qsr_2026-06"
+
 # Per-generator-type weights for the OSM sub-score. Seeded from the heatmap
 # path's _ANCHOR_WEIGHTS (restaurant_scoring_factors.py:772-784), regrouped onto
 # the seven generator buckets enriched here; transit/mosque buckets (absent from
@@ -1866,6 +1896,45 @@ _DEMAND_GENERATOR_NORM_ANCHORS: dict[str, tuple[float, float, float, bool]] = {
     "population_local":    (8281.0,   52010.0,  53393.0, False),
 }
 
+# l1_v3 QSR anchors — gathered at QSR's 1500 m demand radius (Phase-A probe, 548
+# city-wide candidates). Same tuple shape (p5, p95, p99, log?) and same transforms
+# as l1_v2; only the anchor values differ, fit to the 1500 m counts.
+#   - fnb_review_weighted: n_zero 26/548 (~5%), healthy spread (keeps 0.35).
+#   - building_floors:     n_zero 0, clean (keeps 0.20).
+#   - osm_weighted_total:  n_zero 45 (~8%), discriminating (keeps 0.40). KNOWN
+#       LIMITATION: p95==p99==951.8 is a winsorization plateau, so the highest-OSM
+#       QSR candidates won't separate from EACH OTHER at the top; the mid band
+#       (p25=15 -> p75=657) still discriminates. Acceptable for v3, revisit later.
+#       osm p5: the probe p5 was 0.0; a log anchor needs a positive floor, so we
+#       use p5=3.4 (matching l1_v2's positive osm floor). _demand_generator_normalize
+#       also clamps a 0 p5 safely (log1p(0)=0, and hi>lo still holds), but 3.4 keeps
+#       the low tail from pegging at exactly 0.
+#   - population_local:    spread ratio ~1.1 at 1000/1200/1500 m (flat everywhere),
+#       so it keeps only the token 0.05 weight; anchors ~= l1_v2 (pop barely differs
+#       at 1500 m vs the l1_v2 pop sub-radius, which is also 1500 m).
+_DEMAND_GENERATOR_NORM_ANCHORS_QSR: dict[str, tuple[float, float, float, bool]] = {
+    #  signal                 p5         p95         p99       log
+    "fnb_review_weighted": (186.5,   72026.0, 94509.0, True),
+    "building_floors":     (1262.9,   6898.0,  9483.7, True),
+    "osm_weighted_total":  (3.4,       951.8,   951.8, True),   # see osm caveat above
+    "population_local":    (7410.4,  51979.7, 53392.6, False),  # ~= l1_v2 at 1500 m
+}
+
+
+def _demand_generator_anchors(
+    service_model: str | None,
+) -> dict[str, tuple[float, float, float, bool]]:
+    """Select the L1 normalization anchor set by service model.
+
+    qsr -> l1_v3 (gathered at QSR's 1500 m demand radius); every other model ->
+    l1_v2 (the dine-in anchors at 3500 m, UNCHANGED). Defaulting non-qsr to l1_v2
+    keeps dine_in / cafe / delivery_first byte-for-byte on the existing anchors.
+    """
+    if (service_model or "").lower() == "qsr":
+        return _DEMAND_GENERATOR_NORM_ANCHORS_QSR
+    return _DEMAND_GENERATOR_NORM_ANCHORS
+
+
 # Top-level composite weights over the four normalized sub-signals (sum 1.0).
 # PR-1a rebalance: the discriminating signals (OSM trip generators + free F&B
 # review density) drive the spread. Phase A showed the 1500 m population radius
@@ -1879,16 +1948,20 @@ _DEMAND_GENERATOR_COMPOSITE_WEIGHTS: dict[str, float] = {
 }
 
 
-def _demand_generator_normalize(signal: str, value: float) -> float:
+def _demand_generator_normalize(
+    signal: str, value: float, *, service_model: str | None = None
+) -> float:
     """Winsorize at p99 then map the p5→p95 anchor band onto 0-100.
 
     Robust 0-100 normalization shared by every L1 sub-signal: a single busy
     outlier cannot dominate (winsorized at p99) and the dense end keeps headroom
     (top anchor is p95, not the max). Wide-spread signals are log-transformed so
     the bulk of the distribution spreads instead of bunching near zero. Anchors
-    live in _DEMAND_GENERATOR_NORM_ANCHORS (PR-1a, set from the Phase A probe).
+    are selected per service model (qsr -> l1_v3 at 1500 m, else l1_v2 at 3500 m);
+    ``service_model=None`` keeps the l1_v2 default so existing callers are
+    unchanged.
     """
-    p5, p95, p99, use_log = _DEMAND_GENERATOR_NORM_ANCHORS[signal]
+    p5, p95, p99, use_log = _demand_generator_anchors(service_model)[signal]
     v = min(max(0.0, _safe_float(value)), p99)  # winsorize the top tail at p99
     if use_log:
         v = math.log1p(v)
@@ -1901,17 +1974,22 @@ def _demand_generator_normalize(signal: str, value: float) -> float:
     return _clamp((v - lo) / (hi - lo) * 100.0)
 
 
-def _demand_generator_osm_subscore(osm_counts: dict[str, int]) -> float:
+def _demand_generator_osm_subscore(
+    osm_counts: dict[str, int], *, service_model: str | None = None
+) -> float:
     """Σ(count·weight) over generator buckets → 0-100 against the city-wide anchor.
 
     PR-1a: the v1 sigmoid (ref /20) saturated to ~95 for every candidate because
     real Riyadh catchments hold hundreds of offices. The weighted total is now
     log-normalized against the empirical p5→p95 band so offices/retail — the
-    strongest raw discriminators — actually drive spread."""
+    strongest raw discriminators — actually drive spread. The OSM bucket weights
+    are unchanged; only the normalization anchor band is service-model-aware."""
     weighted_total = 0.0
     for _kind, _w in _DEMAND_GENERATOR_OSM_WEIGHTS.items():
         weighted_total += _w * float(osm_counts.get(_kind, 0) or 0)
-    return _demand_generator_normalize("osm_weighted_total", weighted_total)
+    return _demand_generator_normalize(
+        "osm_weighted_total", weighted_total, service_model=service_model
+    )
 
 
 # PR-2: one-time warning guard for the "scoring flag on, index flag off"
@@ -1933,6 +2011,25 @@ def _warn_dg_scoring_without_index() -> None:
         )
 
 
+# QSR analogue of the guard above: the QSR scoring flag is separate from the
+# dine-in one, so it gets its own one-time warning when it is on without the
+# index flag (mirrors the dine-in misconfiguration path; QSR falls back to
+# pop_score).
+_DG_SCORING_QSR_WITHOUT_INDEX_WARNED = False
+
+
+def _warn_dg_scoring_qsr_without_index() -> None:
+    global _DG_SCORING_QSR_WITHOUT_INDEX_WARNED
+    if not _DG_SCORING_QSR_WITHOUT_INDEX_WARNED:
+        _DG_SCORING_QSR_WITHOUT_INDEX_WARNED = True
+        logger.warning(
+            "EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED is true but "
+            "EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED is false; the demand-"
+            "generator composite is not computed, so QSR demand scoring falls "
+            "back to pop_score. Enable the index flag to activate QSR scoring."
+        )
+
+
 def _demand_generator_index(
     *,
     population_reach: float,
@@ -1943,6 +2040,7 @@ def _demand_generator_index(
     radius_m: int,
     population_local_reach: float | None = None,
     pop_radius_m: int | None = None,
+    service_model: str | None = None,
 ) -> dict[str, Any]:
     """Compose the emit-only L1 demand-generator index for one candidate.
 
@@ -1970,15 +2068,21 @@ def _demand_generator_index(
         if population_local_reach is not None
         else _safe_float(population_reach)
     )
-    pop_sub = _demand_generator_normalize("population_local", _pop_local)
+    pop_sub = _demand_generator_normalize(
+        "population_local", _pop_local, service_model=service_model
+    )
     # OSM generators: log-normalized weighted count.
-    osm_sub = _demand_generator_osm_subscore(osm_counts)
+    osm_sub = _demand_generator_osm_subscore(osm_counts, service_model=service_model)
     # Building floor-density daytime proxy (log-normalized).
     _floors = max(0.0, _safe_float(building_floors_proxy_sum))
-    floors_sub = _demand_generator_normalize("building_floors", _floors)
+    floors_sub = _demand_generator_normalize(
+        "building_floors", _floors, service_model=service_model
+    )
     # Free F&B review-weighted density (log-normalized).
     _rw = max(0.0, _safe_float(fnb_review_weighted))
-    fnb_sub = _demand_generator_normalize("fnb_review_weighted", _rw)
+    fnb_sub = _demand_generator_normalize(
+        "fnb_review_weighted", _rw, service_model=service_model
+    )
 
     w = _DEMAND_GENERATOR_COMPOSITE_WEIGHTS
     composite = _clamp(
@@ -1989,7 +2093,11 @@ def _demand_generator_index(
     )
     return {
         "composite_0_100": round(composite, 2),
-        "weights_version": _DEMAND_GENERATOR_WEIGHTS_VERSION,
+        "weights_version": (
+            _DEMAND_GENERATOR_WEIGHTS_VERSION_QSR
+            if (service_model or "").lower() == "qsr"
+            else _DEMAND_GENERATOR_WEIGHTS_VERSION
+        ),
         "radius_m": int(radius_m),
         "population_reach": int(round(_safe_float(population_reach))),
         "pop_radius_m": int(pop_radius_m) if pop_radius_m is not None else int(radius_m),
@@ -8775,7 +8883,11 @@ def run_expansion_search(
     # NOTHING here feeds scoring (PR-2 wires it in).
     if settings.EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED and _shortlist_coords:
         t_dg_start = time.monotonic()
-        _dg_radius = float(settings.EXPANSION_DEMAND_GENERATOR_RADIUS_M)
+        # Change-1 (E.2): enrich at THIS service model's demand catchment, not the
+        # flat EXPANSION_DEMAND_GENERATOR_RADIUS_M. dine_in stays 3500 (identical),
+        # qsr -> 1500, cafe -> 1000, delivery_first -> 3000. Required so QSR's l1_v3
+        # 1500 m anchors are applied to 1500 m counts (not 3500 m counts).
+        _dg_radius = _demand_generator_radius_m(service_model)
         # Shared VALUES list of (parcel_id, lon, lat) for the whole shortlist.
         _dg_value_parts: list[str] = []
         _dg_coord_params: dict[str, Any] = {}
@@ -9359,8 +9471,12 @@ def run_expansion_search(
                 building_floors_proxy_sum=_bulk_building_floors.get(_pid_str, 0.0),
                 fnb_review_weighted=_dg_fnb.get("review_weighted", 0.0),
                 fnb_venue_count=_dg_fnb.get("venue_count", 0),
-                radius_m=settings.EXPANSION_DEMAND_GENERATOR_RADIUS_M,
+                # Change-1: emit the model's true enrich radius (dine_in 3500 —
+                # unchanged) so the snapshot radius_m matches the counts above.
+                radius_m=int(_demand_generator_radius_m(service_model)),
                 pop_radius_m=settings.EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M,
+                # Change-2: select l1_v3 anchors for qsr, l1_v2 for everything else.
+                service_model=service_model,
             )
 
         # ── PR-2: gated swap of pop_score → dg_composite in the DINE-IN demand
@@ -9377,6 +9493,34 @@ def run_expansion_search(
         ):
             if not settings.EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED:
                 _warn_dg_scoring_without_index()
+            else:
+                _dg_composite = (
+                    _dg_index_result.get("composite_0_100")
+                    if _dg_index_result
+                    else None
+                )
+                if _dg_composite is not None:
+                    _pop_w, _del_w = _demand_blend_weights(service_model)
+                    demand_score = _clamp(
+                        float(_dg_composite) * _pop_w
+                        + prepared_item["delivery_score"] * _del_w
+                    )
+                    _demand_score_source = "dg_index"
+        # ── Change-3: gated swap of pop_score → dg_composite in the QSR demand
+        # blend, mirroring the dine-in swap above but behind a SEPARATE flag
+        # (EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED) so QSR deploys inert and
+        # is flipped to validate independently of the already-live dine-in flag.
+        # QSR uses l1_v3 anchors (selected in the composite above) and the same
+        # blend shape: demand_score = _clamp(dg_composite·_pop_w +
+        # delivery_score·_del_w), (_pop_w,_del_w)=_demand_blend_weights("qsr")=0.60/0.40.
+        # Reuses the in-memory composite; falls back SILENTLY to pop_score when the
+        # composite is missing or the index flag is off (logged once).
+        elif (
+            settings.EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED
+            and service_model == "qsr"
+        ):
+            if not settings.EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED:
+                _warn_dg_scoring_qsr_without_index()
             else:
                 _dg_composite = (
                     _dg_index_result.get("composite_0_100")
@@ -9498,7 +9642,14 @@ def run_expansion_search(
         # (off → snapshot unchanged) and is never read by scoring.
         if _dg_index_result is not None:
             feature_snapshot_json["demand_generator_index"] = _dg_index_result
-        if settings.EXPANSION_DEMAND_GENERATOR_SCORING_ENABLED:
+        # Emit the transparency field when the flag governing THIS candidate's
+        # service model is on: the dine-in flag (existing behaviour for all models)
+        # or the QSR flag for qsr searches. Both-flags-off → no key (snapshot
+        # unchanged); QSR flag off → no qsr key from the QSR path.
+        if settings.EXPANSION_DEMAND_GENERATOR_SCORING_ENABLED or (
+            settings.EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED
+            and service_model == "qsr"
+        ):
             feature_snapshot_json["demand_score_source"] = _demand_score_source
         # Compute the two raw ages independently so the pill logic on the
         # frontend and in _top_positives_and_risks can decide "New" vs

--- a/scripts/diagnostics/PR_qsr_demand_index_scoring.md
+++ b/scripts/diagnostics/PR_qsr_demand_index_scoring.md
@@ -1,0 +1,205 @@
+# PR — Wire L1 demand-generator index into QSR scoring (`l1_v3` re-anchor)
+
+**Branch:** `claude/qsr-demand-index-scoring-gmyp8q`
+**Scope:** Real scoring change, **flag-gated, default OFF, separate flag from dine-in, QSR only.**
+`dine_in` / `cafe` / `delivery_first` scored output is unchanged.
+
+---
+
+## 1. What is wrong now
+
+QSR's demand leg rides `pop_score`, which **saturates** (~76–82 for nearly all candidates) — the
+same dead signal that was removed from dine-in. There is no usable cross-candidate spread in the QSR
+demand numerator today.
+
+A second, blocking defect sits underneath it (**Phase-A discrepancy E.2**): the live
+demand-generator enrich runs at the *flat* `EXPANSION_DEMAND_GENERATOR_RADIUS_M` (3500 m) for **all**
+service models, decoupled from `_CATCHMENT_RADII_M[model]['demand']`. So QSR's index is computed at
+3500 m even though QSR's catchment is 1500 m.
+
+## 2. Why it happens
+
+- **Demand leg:** the demand blend uses `pop_score` as the population numerator. In dense Riyadh the
+  population reach is ~constant across candidates, so the term saturates and carries almost no
+  ranking information.
+- **Enrich radius:** the enrich reads `settings.EXPANSION_DEMAND_GENERATOR_RADIUS_M` unconditionally
+  (one constant for every model) instead of the per-model demand radius.
+
+The Phase-A probe (548 city-wide candidates, signals gathered at QSR's 1500 m radius) established that
+the demand-generator index **discriminates well for QSR** and that this is a **clean re-anchor, NOT a
+re-mix**:
+
+| sub-signal             | n_zero        | finding                                          | weight |
+|------------------------|---------------|--------------------------------------------------|--------|
+| `fnb_review_weighted`  | 26/548 (~5%)  | healthy spread                                   | 0.35   |
+| `building_floors`      | 0             | clean                                            | 0.20   |
+| `osm_weighted_total`   | 45 (~8%)      | discriminating                                   | 0.40   |
+| `population_local`     | —             | spread ratio ~1.1 at 1000/1200/1500 m (flat)     | 0.05   |
+
+So the **sub-signal mix (0.40 / 0.35 / 0.20 / 0.05) is unchanged** and the **pop radius stays 1500 m**
+— both confirmed by the data, neither touched.
+
+**Why `l1_v2` can't be reused on QSR:** at 1500 m the counts are genuinely smaller (QSR `fnb` p95 ≈ 72k
+vs dine-in 225k; `floors` p95 ≈ 6.9k vs 35.6k), so `l1_v2`'s 3500 m anchors would map almost every QSR
+candidate near 0. Hence a QSR-keyed `l1_v3` anchor set, read at 1500 m. **If we add `l1_v3` (1500 m)
+anchors but leave the enrich at 3500 m, we apply 1500 m anchors to 3500 m counts — worse than doing
+nothing.** That is why the enrich-radius fix (Change 1) **must ship in the same PR.**
+
+## 3. The fix (smallest safe change)
+
+Three changes, all in `app/services/expansion_advisor.py` + one flag in `app/core/config.py`.
+
+### Change 1 — service-model-aware enrich radius (the E.2 prerequisite)
+
+New helper `_demand_generator_radius_m(service_model)` reads the model's demand catchment from
+`_CATCHMENT_RADII_M[model]['demand']` instead of the flat constant:
+
+| model            | enrich radius | vs. before |
+|------------------|---------------|------------|
+| `dine_in`        | 3500 m        | **identical** (3500 was already the flat default) |
+| `qsr`            | 1500 m        | changed (now correct) |
+| `cafe`           | 1000 m        | changed (emit-only) |
+| `delivery_first` | 3000 m        | changed (emit-only) |
+| unknown          | flat fallback | falls back to `EXPANSION_DEMAND_GENERATOR_RADIUS_M`, **not** qsr's 1500 m |
+
+Applied at the enrich site (`_dg_radius`) and at the emitted `radius_m` so the snapshot's `radius_m`
+matches the counts it was computed from. The pop sub-term radius
+(`EXPANSION_DEMAND_GENERATOR_POP_RADIUS_M`, 1500 m) is left as-is — the probe confirmed 1500 m for QSR.
+
+- **`dine_in`'s scored output does not change** — its demand radius is already 3500, so reading it from
+  `_CATCHMENT_RADII_M['dine_in']['demand']` is identical. Pinned by a test.
+- **`cafe` / `delivery_first`:** their emitted `demand_generator_index` composite **will change** (now
+  computed at their own demand radius) but it is **emit-only / not scored** for them, so no scored
+  output moves. This also correctly fixes the decoupling bug generally, not just for QSR.
+
+### Change 2 — `l1_v3` QSR anchor block + service-model-aware anchor selection
+
+New `_DEMAND_GENERATOR_NORM_ANCHORS_QSR` alongside the existing dine-in `l1_v2`, same tuple shape
+`(p5, p95, p99, log?)` and same transforms:
+
+```python
+_DEMAND_GENERATOR_NORM_ANCHORS_QSR: dict[str, tuple[float, float, float, bool]] = {
+    #  signal                 p5         p95         p99       log
+    "fnb_review_weighted": (186.5,   72026.0, 94509.0, True),
+    "building_floors":     (1262.9,   6898.0,  9483.7, True),
+    "osm_weighted_total":  (3.4,       951.8,   951.8, True),   # see osm caveat
+    "population_local":    (7410.4,  51979.7, 53392.6, False),  # ~= l1_v2 at 1500 m
+}
+```
+
+`_demand_generator_anchors(service_model)` selects **`qsr` → `l1_v3`, everything else → `l1_v2`**.
+`service_model` is threaded through `_demand_generator_normalize` / `_demand_generator_osm_subscore` /
+`_demand_generator_index` with a **default of `None` → `l1_v2`**, so every existing caller is
+byte-identical. The weights-version tag is bumped to **`l1_v3_qsr_2026-06` for QSR only**; the dine-in
+`l1_v2_2026-06` tag is untouched.
+
+**osm caveat:** QSR `osm` p95 == p99 == 951.8 — the top is a winsorization plateau, so the highest-OSM
+QSR candidates won't separate from each other; the mid-range (p25 = 15 → p75 = 657) still discriminates.
+Acceptable for v3; a known limitation to revisit, not a blocker.
+
+**osm p5:** the probe p5 was 0.0. A log anchor needs a positive floor, and `_demand_generator_normalize`
+already clamps a 0 p5 safely (`log1p(0)=0`, and `hi > lo` still holds), but we use **p5 = 3.4** (matching
+`l1_v2`'s positive osm floor) so the low tail doesn't peg at exactly 0.
+
+### Change 3 — gated QSR blend swap (the actual scoring wire)
+
+New flag **`EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED: bool = False`** (default OFF), effective
+only when `EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED` is also true (else it logs once and falls back to
+`pop_score`).
+
+At the demand-blend swap site, a QSR branch mirrors PR-2's dine-in swap: when the QSR flag is on,
+`service_model == "qsr"`, and the composite is present, the blend uses `dg_composite` in place of
+`pop_score`:
+
+```
+demand_score = _clamp(dg_composite · _pop_w + delivery_score · _del_w)
+(_pop_w, _del_w) = _demand_blend_weights("qsr")  # = 0.60 / 0.40
+```
+
+It reuses the in-memory composite (no snapshot re-read) and emits
+`demand_score_source = "dg_index" | "pop_score"` for QSR (only when the QSR flag is on).
+
+**Why a separate flag, not the existing dine-in flag:** the dine-in flag is already **ON in prod**, so
+reusing it would take QSR live the instant this deploys with no flag-off → flag-on validation window.
+A separate flag means QSR deploys **inert** and is flipped to validate independently.
+
+## 4. Hard constraints honored
+
+- `dine_in` / `cafe` / `delivery_first` scored output identical to pre-PR. `dine_in` stays on `l1_v2` at
+  3500 m with its own flag; `cafe` / `delivery_first` stay on `pop_score` (only their emit-only composite
+  changes via Change 1). All three pinned by tests.
+- Sub-signal mix (0.40 / 0.35 / 0.20 / 0.05), OSM bucket weights, pop radius (1500), the 15.00
+  whitespace floor, `component_weights`, `sum == 100`, gates — all unchanged.
+- Flag-gated, default OFF, separate flag. Deploys inert.
+- No merge / push to other branches / dispatch.
+
+**Emit-only blast-radius note:** with the index flag on, QSR's *emitted* composite changes (now `l1_v3`
+@ 1500 m) even with the QSR scoring flag off — but that is emit-only; QSR's **scored** output stays on
+`pop_score` until the new flag is flipped. `cafe` / `delivery_first` emitted composites likewise change
+(their own demand radius), not scored.
+
+## 5. Files changed
+
+| file | change |
+|------|--------|
+| `app/core/config.py` | new `EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED` flag (default OFF) |
+| `app/services/expansion_advisor.py` | `_demand_generator_radius_m()` helper; `l1_v3` anchors + `_demand_generator_anchors()`; `service_model` threaded through normalize/osm-subscore/index; QSR version tag; QSR blend swap + one-time warning; emit guard |
+| `tests/test_expansion_advisor_demand_generator.py` | QSR + radius + anchor-selection tests |
+| `scripts/diagnostics/qsr_index_validation.sql` | QSR analogue of `l1_index_validation.sql` |
+
+## 6. Validation steps
+
+### Tests added / run
+
+- **Flag off (QSR):** QSR `final_score` + ordering identical to a both-flags-off baseline; no
+  `demand_score_source` key.
+- **Flag on + qsr + composite present:** blend uses `dg_composite` at 0.60 / 0.40,
+  `demand_score_source == "dg_index"`, emitted index carries the `l1_v3_qsr_2026-06` tag, score moves.
+- **Flag on + composite missing:** falls back to `pop_score`, no exception.
+- **Anchor selection:** `qsr` normalizes against `l1_v3`, `dine_in` against `l1_v2`; a representative
+  input maps differently (l1_v3's tighter anchors normalize the same count higher).
+- **Enrich radius:** `dine_in` still 3500 (unchanged), `qsr` now 1500, asserted from
+  `_CATCHMENT_RADII_M`; unknown → flat fallback.
+- **`dine_in` scored signal bit-identical:** the index-radius refactor does not perturb dine-in.
+- **Blast guard:** flipping the QSR flag leaves `dine_in` / `cafe` / `delivery_first` untouched.
+
+Commands:
+
+```bash
+python -m pytest tests/test_expansion_advisor_demand_generator.py -q   # 21 passed
+python -m pytest -q                                                    # 2301 passed, 24 skipped
+```
+
+> CI gate is `pytest -q` (`.github/workflows/ci.yml`); no flake8/black gate. New code matches the
+> existing hand-formatted style of the surrounding flags and the existing `l1_v2` anchor block.
+
+### Live validation (Ahmed, Codespace — after diff review; changes QSR rankings when enabled)
+
+1. Merge → deploy → rollout status.
+2. `kubectl set env deployment/oaktree-estimator -n default
+   EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED=true`; wait for rollout;
+   `printenv | grep QSR` to confirm (and `INDEX_ENABLED` still true).
+3. Fresh city-wide **QSR** search.
+4. Run `scripts/diagnostics/qsr_index_validation.sql`. Success criteria:
+   - `demand_score_source = "dg_index"` for QSR candidates with a composite (`n_dg_index` ≈ all).
+   - `corr(composite, final_score)` jumps materially from its flag-off baseline (the proof QSR now
+     scores off the index) — analogous to dine-in's 0.06 → 0.51.
+   - QSR composites spread sensibly at 1500 m (NOT bunched near 0 — confirms `l1_v3` anchors fit the
+     1500 m counts; the whole point vs reusing `l1_v2`). Check `radius_m = 1500` and
+     `weights_version = l1_v3_qsr_2026-06` in the snapshot.
+   - QSR shortlist reorders sensibly; top-10 flag-off vs flag-on diff.
+
+## 7. Risk / tradeoff
+
+- **Risk: low while the flag is OFF** — deploys inert; QSR scored output identical to prod.
+- **When flipped ON:** QSR rankings move by design. The osm plateau (p95 == p99) is a known limitation
+  that compresses the highest-OSM QSR candidates at the top; the mid band still discriminates.
+- **Emit-only drift:** `cafe` / `delivery_first` / (index-on) QSR emitted composites change. Not scored;
+  surfaced here so the snapshot change is expected, not a surprise.
+
+## 8. Merge recommendation
+
+**Merge with low risk.** The change is additive, flag-gated, default OFF on a separate flag, and ships
+the E.2 enrich-radius prerequisite alongside the anchors so 1500 m anchors are applied to 1500 m counts.
+Validate live by flipping `EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED=true` and running
+`qsr_index_validation.sql`.

--- a/scripts/diagnostics/qsr_index_validation.sql
+++ b/scripts/diagnostics/qsr_index_validation.sql
@@ -1,0 +1,179 @@
+-- ============================================================================
+-- qsr_index_validation.sql
+-- ----------------------------------------------------------------------------
+-- QSR analogue of l1_index_validation.sql. Validate the l1_v3 QSR demand-
+-- generator re-anchor AFTER a fresh QSR search was run with BOTH
+--   EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED=true   (index computed) and
+--   EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED=true (index scored).
+--
+-- It reads expansion_candidate.feature_snapshot_json->'demand_generator_index'
+-- for the MOST RECENT qsr search and surfaces the composite + every
+-- sub-component alongside each candidate's district, competitor_count, and
+-- whitespace_score, so we can confirm:
+--
+--   1. the index + all sub-components are populated for QSR candidates, the
+--      weights_version is 'l1_v3_qsr_2026-06', and the radius_m is 1500 (QSR's
+--      demand catchment — the whole point of Change-1; NOT 3500),
+--   2. demand_score_source = 'dg_index' for QSR candidates with a composite
+--      (n_dg_index ≈ all) — the proof QSR now scores off the index,
+--   3. the composite SPREADS sensibly at 1500 m (NOT bunched near 0 — confirms
+--      the l1_v3 anchors fit the 1500 m counts, vs reusing l1_v2 at 3500 m), and
+--   4. corr(composite, final_score) jumps materially from its flag-off baseline
+--      (analogous to dine-in's 0.06 → 0.51).
+--
+-- IMPORTANT: validation requires a FRESH qsr search after deploy with the flags
+-- ON. Old searches won't backfill the snapshot, so their candidates have a NULL
+-- demand_generator_index and are filtered out below.
+--
+-- HOW TO RUN (iPad/Safari friendly — psql -f safe, no \set, no heredocs):
+--   psql "$DATABASE_URL" -f scripts/diagnostics/qsr_index_validation.sql
+-- ============================================================================
+
+\timing on
+
+-- Stage the most-recent qsr search's candidates with the index flattened.
+DROP TABLE IF EXISTS qsr_val;
+CREATE TEMP TABLE qsr_val AS
+WITH latest AS (
+    SELECT id, created_at
+    FROM expansion_search
+    WHERE service_model = 'qsr'
+    ORDER BY created_at DESC
+    LIMIT 1
+)
+SELECT
+    ec.parcel_id,
+    ec.district,
+    ec.final_score,
+    ec.competitor_count,
+    ec.whitespace_score                                                   AS competition_whitespace,
+    (ec.feature_snapshot_json ->> 'demand_score_source')                  AS demand_score_source,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'composite_0_100')::numeric AS dg_composite,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'population_reach')::numeric AS pop_reach,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'population_local_reach')::numeric AS pop_local_reach,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'fnb_review_weighted_density')::numeric AS fnb_review_weighted,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'fnb_venue_count')::int      AS fnb_venue_count,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'building_floors_proxy_sum')::numeric AS building_floors_sum,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'offices')::int      AS osm_offices,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'malls_retail')::int AS osm_malls_retail,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'transit')::int      AS osm_transit,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'mosques')::int      AS osm_mosques,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'schools')::int      AS osm_schools,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'hospitals')::int    AS osm_hospitals,
+    (ec.feature_snapshot_json -> 'demand_generator_index' -> 'osm_generators' ->> 'hotels')::int       AS osm_hotels,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'weights_version') AS weights_version,
+    (ec.feature_snapshot_json -> 'demand_generator_index' ->> 'radius_m')::int   AS radius_m
+FROM expansion_candidate ec
+JOIN latest l ON ec.search_id = l.id
+WHERE ec.feature_snapshot_json -> 'demand_generator_index' IS NOT NULL;
+
+-- Which search are we validating, and how many candidates carry the index?
+SELECT
+    (SELECT id FROM expansion_search WHERE service_model = 'qsr'
+      ORDER BY created_at DESC LIMIT 1)                       AS latest_qsr_search_id,
+    (SELECT created_at FROM expansion_search WHERE service_model = 'qsr'
+      ORDER BY created_at DESC LIMIT 1)                       AS created_at,
+    COUNT(*)                                                  AS candidates_with_index,
+    COUNT(DISTINCT district)                                  AS distinct_districts
+FROM qsr_val;
+
+-- ── Criterion 1: index populated, l1_v3 tag, and radius_m = 1500 (Change-1) ──
+-- weights_version must be 'l1_v3_qsr_2026-06' and radius_m must be 1500 (QSR's
+-- demand catchment). A radius_m of 3500 here means the enrich-radius fix (E.2)
+-- did NOT land and the 1500 m anchors are being applied to 3500 m counts.
+SELECT
+    COUNT(*)                                              AS n,
+    COUNT(*) FILTER (WHERE dg_composite        IS NOT NULL) AS have_composite,
+    COUNT(*) FILTER (WHERE pop_reach           IS NOT NULL) AS have_population,
+    COUNT(*) FILTER (WHERE fnb_review_weighted IS NOT NULL) AS have_fnb,
+    COUNT(*) FILTER (WHERE building_floors_sum IS NOT NULL) AS have_building_floors,
+    COUNT(*) FILTER (WHERE osm_offices         IS NOT NULL) AS have_osm,
+    MIN(weights_version)                                  AS weights_version,
+    MIN(radius_m)                                         AS radius_m,
+    MAX(radius_m)                                         AS radius_m_max
+FROM qsr_val;
+
+-- ── Criterion 2: which numerator fed the QSR demand blend? ──
+-- With the QSR scoring flag ON and a composite present, every QSR candidate
+-- should score off 'dg_index'.
+--   n_dg_index    -> scored off the demand-generator composite (expected: all)
+--   n_pop_score   -> fell back to pop_score (flag off on serving pod, or no composite)
+--   n_source_null -> emit not landing in the read snapshot (real wiring bug)
+SELECT
+    count(*) FILTER (WHERE demand_score_source = 'dg_index')   AS n_dg_index,
+    count(*) FILTER (WHERE demand_score_source = 'pop_score')  AS n_pop_score,
+    count(*) FILTER (WHERE demand_score_source IS NULL)        AS n_source_null
+FROM qsr_val;
+
+-- ── Criterion 3: the composite SPREADS at 1500 m (NOT bunched near 0) ──
+-- The whole point of l1_v3 vs reusing l1_v2: at 1500 m the counts are smaller,
+-- so l1_v2's 3500 m anchors would peg nearly every QSR candidate near 0. A
+-- healthy spread here (wide min→max, many distinct values, p50 well above 0)
+-- confirms the l1_v3 anchors fit the 1500 m distribution.
+SELECT
+    COUNT(*)                                         AS n,
+    round(MIN(dg_composite), 2)                      AS min_composite,
+    round(AVG(dg_composite), 2)                      AS avg_composite,
+    round((percentile_cont(0.25) WITHIN GROUP (ORDER BY dg_composite))::numeric, 2) AS p25,
+    round((percentile_cont(0.5)  WITHIN GROUP (ORDER BY dg_composite))::numeric, 2) AS p50,
+    round((percentile_cont(0.75) WITHIN GROUP (ORDER BY dg_composite))::numeric, 2) AS p75,
+    round(MAX(dg_composite), 2)                      AS max_composite,
+    round(STDDEV_POP(dg_composite), 2)               AS stddev,
+    COUNT(*) FILTER (WHERE dg_composite > 0)          AS n_nonzero,
+    COUNT(*) FILTER (WHERE dg_composite < 1.0)        AS n_near_zero,
+    COUNT(DISTINCT round(dg_composite, 1))            AS distinct_rounded_values
+FROM qsr_val;
+
+-- ── Criterion 4: corr(composite, final_score) (jumps from flag-off baseline) ──
+-- Run this script ONCE with the QSR scoring flag OFF (baseline) and again with
+-- it ON; corr_composite_vs_final_score should jump materially (analogous to
+-- dine-in's 0.06 → 0.51) — the proof QSR now scores off the index. The
+-- vs-competitor / vs-whitespace corrs show the index is not just a competitor
+-- proxy (|corr| well below 1).
+SELECT
+    round(corr(dg_composite, competitor_count::double precision)::numeric, 3)        AS corr_composite_vs_competitor_count,
+    round(corr(dg_composite, competition_whitespace::double precision)::numeric, 3)  AS corr_composite_vs_whitespace,
+    round(corr(dg_composite, final_score::double precision)::numeric, 3)             AS corr_composite_vs_final_score
+FROM qsr_val
+WHERE dg_composite IS NOT NULL;
+
+-- ── Eyeball: top candidate per district (geographic spread, 3+ districts) ──
+SELECT DISTINCT ON (district)
+    district,
+    parcel_id,
+    demand_score_source,
+    final_score,
+    dg_composite,
+    competitor_count,
+    competition_whitespace,
+    pop_reach,
+    pop_local_reach,
+    fnb_review_weighted,
+    fnb_venue_count,
+    building_floors_sum,
+    osm_offices, osm_malls_retail, osm_transit, osm_mosques,
+    osm_schools, osm_hospitals, osm_hotels
+FROM qsr_val
+ORDER BY district, dg_composite DESC NULLS LAST;
+
+-- ── Eyeball: overall top 25 by composite (full sub-component breakdown) ──
+SELECT
+    parcel_id,
+    district,
+    demand_score_source,
+    final_score,
+    dg_composite,
+    competitor_count,
+    competition_whitespace,
+    pop_reach,
+    pop_local_reach,
+    fnb_review_weighted,
+    fnb_venue_count,
+    building_floors_sum,
+    osm_offices, osm_malls_retail, osm_transit, osm_mosques,
+    osm_schools, osm_hospitals, osm_hotels
+FROM qsr_val
+ORDER BY dg_composite DESC NULLS LAST
+LIMIT 25;
+
+DROP TABLE IF EXISTS qsr_val;

--- a/tests/test_expansion_advisor_demand_generator.py
+++ b/tests/test_expansion_advisor_demand_generator.py
@@ -16,11 +16,17 @@ from __future__ import annotations
 
 from app.services import expansion_advisor as expansion_service
 from app.services.expansion_advisor import (
+    _CATCHMENT_RADII_M,
     _DEMAND_GENERATOR_COMPOSITE_WEIGHTS,
+    _DEMAND_GENERATOR_NORM_ANCHORS,
+    _DEMAND_GENERATOR_NORM_ANCHORS_QSR,
     _DEMAND_GENERATOR_OSM_WEIGHTS,
     _demand_blend_weights,
+    _demand_generator_anchors,
     _demand_generator_index,
+    _demand_generator_normalize,
     _demand_generator_osm_subscore,
+    _demand_generator_radius_m,
     clear_expansion_caches,
     run_expansion_search as _run_expansion_search_raw,
 )
@@ -370,8 +376,12 @@ def test_flag_on_emits_index_without_changing_scores(
 # ---------------------------------------------------------------------------
 
 
-def _run_flags(monkeypatch, *, index, scoring, service_model="dine_in"):
-    """Run the FakeDB search with the two demand-generator flags set."""
+def _run_flags(monkeypatch, *, index, scoring, service_model="dine_in", scoring_qsr=False):
+    """Run the FakeDB search with the demand-generator flags set.
+
+    ``scoring`` drives the dine-in scoring flag; ``scoring_qsr`` drives the
+    SEPARATE QSR scoring flag. Both default to the production-safe OFF state.
+    """
     monkeypatch.setattr(
         expansion_service.settings, "EXPANSION_DEMAND_GENERATOR_INDEX_ENABLED", index
     )
@@ -379,6 +389,12 @@ def _run_flags(monkeypatch, *, index, scoring, service_model="dine_in"):
         expansion_service.settings,
         "EXPANSION_DEMAND_GENERATOR_SCORING_ENABLED",
         scoring,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        expansion_service.settings,
+        "EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED",
+        scoring_qsr,
         raising=False,
     )
     clear_expansion_caches()
@@ -484,3 +500,176 @@ def test_pr2_non_dine_in_unchanged_with_flag_on(
         for it in on:
             fs = it.get("feature_snapshot_json") or {}
             assert fs.get("demand_score_source") == "pop_score"
+
+
+# ---------------------------------------------------------------------------
+# QSR l1_v3 re-anchor — Change 1 (service-model-aware enrich radius),
+# Change 2 (l1_v3 anchor selection), Change 3 (gated QSR blend swap)
+# ---------------------------------------------------------------------------
+
+
+def test_demand_generator_radius_is_service_model_aware():
+    """Change-1: enrich radius reads each model's demand catchment. dine_in is
+    UNCHANGED at 3500; qsr is now 1500; unknown models fall back to the flat
+    setting (NOT qsr's 1500)."""
+    assert _demand_generator_radius_m("dine_in") == 3500.0
+    assert _demand_generator_radius_m("dine_in") == _CATCHMENT_RADII_M["dine_in"]["demand"]
+    assert _demand_generator_radius_m("qsr") == 1500.0
+    assert _demand_generator_radius_m("qsr") == _CATCHMENT_RADII_M["qsr"]["demand"]
+    assert _demand_generator_radius_m("cafe") == 1000.0
+    assert _demand_generator_radius_m("delivery_first") == 3000.0
+    # Unknown model → flat fallback, never qsr's 1500.
+    assert _demand_generator_radius_m("space_station") == float(
+        expansion_service.settings.EXPANSION_DEMAND_GENERATOR_RADIUS_M
+    )
+
+
+def test_anchor_selection_qsr_vs_dine_in():
+    """Change-2: qsr selects the l1_v3 anchor set, every other model l1_v2; a
+    representative input maps DIFFERENTLY under the two sets (l1_v3's tighter
+    1500 m anchors normalize the same count higher)."""
+    assert _demand_generator_anchors("qsr") is _DEMAND_GENERATOR_NORM_ANCHORS_QSR
+    assert _demand_generator_anchors("dine_in") is _DEMAND_GENERATOR_NORM_ANCHORS
+    assert _demand_generator_anchors("cafe") is _DEMAND_GENERATOR_NORM_ANCHORS
+    assert _demand_generator_anchors(None) is _DEMAND_GENERATOR_NORM_ANCHORS
+
+    val = 50000.0
+    qsr_norm = _demand_generator_normalize(
+        "fnb_review_weighted", val, service_model="qsr"
+    )
+    dine_norm = _demand_generator_normalize(
+        "fnb_review_weighted", val, service_model="dine_in"
+    )
+    default_norm = _demand_generator_normalize("fnb_review_weighted", val)
+    # Default (no service_model) stays on l1_v2 → identical to dine_in.
+    assert default_norm == dine_norm
+    # Same raw count, different normalization; l1_v3's smaller anchors map higher.
+    assert qsr_norm != dine_norm
+    assert qsr_norm > dine_norm
+
+
+def test_dine_in_index_unchanged_by_qsr_refactor():
+    """dine_in scored signal must be bit-identical: threading service_model must
+    not perturb the dine-in composite, and the version tag stays l1_v2. The qsr
+    path threads l1_v3 and a different version tag."""
+    common = dict(
+        population_reach=250000.0,
+        population_local_reach=45000.0,
+        osm_counts=_FULL_OSM,
+        building_floors_proxy_sum=20000.0,
+        fnb_review_weighted=80000.0,
+        fnb_venue_count=70,
+        pop_radius_m=1500,
+    )
+    idx_default = _demand_generator_index(radius_m=3500, **common)
+    idx_dine = _demand_generator_index(radius_m=3500, service_model="dine_in", **common)
+    assert idx_dine["composite_0_100"] == idx_default["composite_0_100"]
+    assert idx_dine["weights_version"] == "l1_v2_2026-06"
+    assert idx_dine["radius_m"] == 3500
+
+    idx_qsr = _demand_generator_index(radius_m=1500, service_model="qsr", **common)
+    assert idx_qsr["weights_version"] == "l1_v3_qsr_2026-06"
+    assert idx_qsr["radius_m"] == 1500
+    # l1_v3 re-anchors the SAME inputs to the 1500 m distribution → composite moves.
+    assert idx_qsr["composite_0_100"] != idx_dine["composite_0_100"]
+
+
+def test_qsr_scoring_flag_off_is_inert(disable_market_viability_floors, monkeypatch):
+    """Change-3: with the QSR scoring flag OFF, a QSR search's final_score +
+    ordering is byte-for-byte identical to the both-flags-off baseline and emits
+    no demand_score_source key."""
+    off = _run_flags(
+        monkeypatch, index=False, scoring=False, scoring_qsr=False, service_model="qsr"
+    )
+    off_scores = [(it["parcel_id"], it["final_score"]) for it in off]
+
+    inert = _run_flags(
+        monkeypatch, index=True, scoring=False, scoring_qsr=False, service_model="qsr"
+    )
+    inert_scores = [(it["parcel_id"], it["final_score"]) for it in inert]
+    assert inert_scores == off_scores
+    for it in inert:
+        fs = it.get("feature_snapshot_json") or {}
+        assert "demand_score_source" not in fs
+
+
+def test_qsr_scoring_on_uses_dg_index(disable_market_viability_floors, monkeypatch):
+    """QSR scoring flag ON + composite present → blend swaps pop_score for the
+    l1_v3 composite at 0.60/0.40, demand_score_source == 'dg_index', the emitted
+    index carries the l1_v3 tag, and the final score actually moves."""
+    baseline = _run_flags(
+        monkeypatch, index=True, scoring=False, scoring_qsr=False, service_model="qsr"
+    )
+    base_scores = {it["parcel_id"]: it["final_score"] for it in baseline}
+
+    on = _run_flags(
+        monkeypatch, index=True, scoring=False, scoring_qsr=True, service_model="qsr"
+    )
+    on_by_pid = {it["parcel_id"]: it for it in on}
+
+    for it in on:
+        fs = it.get("feature_snapshot_json") or {}
+        assert fs.get("demand_score_source") == "dg_index"
+        idx = fs.get("demand_generator_index")
+        assert idx is not None
+        assert idx["weights_version"] == "l1_v3_qsr_2026-06"
+
+    moved = any(
+        abs(on_by_pid[pid]["final_score"] - base_scores[pid]) > 1e-9
+        for pid in base_scores
+        if pid in on_by_pid
+    )
+    assert moved
+
+
+def test_qsr_scoring_on_index_off_falls_back_to_pop_score(
+    disable_market_viability_floors, monkeypatch
+):
+    """QSR scoring flag ON but index flag OFF → composite absent → silent
+    fallback to pop_score (no exception), source 'pop_score', scores identical to
+    the feature-absent baseline."""
+    off = _run_flags(
+        monkeypatch, index=False, scoring=False, scoring_qsr=False, service_model="qsr"
+    )
+    off_scores = [(it["parcel_id"], it["final_score"]) for it in off]
+
+    fallback = _run_flags(
+        monkeypatch, index=False, scoring=False, scoring_qsr=True, service_model="qsr"
+    )
+    fb_scores = [(it["parcel_id"], it["final_score"]) for it in fallback]
+    assert fb_scores == off_scores
+    for it in fallback:
+        fs = it.get("feature_snapshot_json") or {}
+        assert fs.get("demand_score_source") == "pop_score"
+        assert "demand_generator_index" not in fs
+
+
+def test_qsr_flag_does_not_touch_other_models(
+    disable_market_viability_floors, monkeypatch
+):
+    """Hard constraint: flipping the QSR flag ON must leave dine_in / cafe /
+    delivery_first scored output identical and emit no source key for them (the
+    QSR flag governs only qsr candidates)."""
+    for service_model in ("dine_in", "cafe", "delivery_first"):
+        base = _run_flags(
+            monkeypatch,
+            index=True,
+            scoring=False,
+            scoring_qsr=False,
+            service_model=service_model,
+        )
+        base_scores = [(it["parcel_id"], it["final_score"]) for it in base]
+
+        on = _run_flags(
+            monkeypatch,
+            index=True,
+            scoring=False,
+            scoring_qsr=True,
+            service_model=service_model,
+        )
+        on_scores = [(it["parcel_id"], it["final_score"]) for it in on]
+
+        assert on_scores == base_scores, f"{service_model} must ignore the QSR flag"
+        for it in on:
+            fs = it.get("feature_snapshot_json") or {}
+            assert "demand_score_source" not in fs


### PR DESCRIPTION
QSR's demand leg currently rides pop_score, which saturates (~76-82 for
nearly all candidates) — the same dead signal removed from dine-in. The
Phase-A probe (548 city-wide candidates at QSR's 1500m radius) showed the
demand-generator index discriminates well for QSR, but l1_v2's 3500m
anchors map almost every QSR candidate near 0 at 1500m. This re-anchors
QSR onto an l1_v3 anchor set read at 1500m. Flag-gated, default OFF, on a
SEPARATE flag from dine-in. dine_in/cafe/delivery_first scored output is
unchanged.

Change 1 — service-model-aware enrich radius (E.2 prerequisite):
the demand-generator enrich now reads each model's demand catchment from
_CATCHMENT_RADII_M[model]['demand'] instead of the flat
EXPANSION_DEMAND_GENERATOR_RADIUS_M. dine_in stays 3500 (identical); qsr
1500, cafe 1000, delivery_first 3000. Unknown models fall back to the flat
setting. Required so QSR's 1500m anchors apply to 1500m counts. cafe/
delivery_first emitted composite changes (emit-only, not scored).

Change 2 — l1_v3 QSR anchor block + service-model-aware anchor selection:
_DEMAND_GENERATOR_NORM_ANCHORS_QSR added alongside l1_v2; normalize selects
qsr -> l1_v3, else l1_v2 (default unchanged). Sub-signal mix
(0.40/0.35/0.20/0.05), OSM bucket weights, pop radius (1500) all unchanged.
weights_version bumped to l1_v3_qsr_2026-06 for QSR only.

Change 3 — gated QSR blend swap: new flag
EXPANSION_DEMAND_GENERATOR_SCORING_QSR_ENABLED (default OFF). When on (and
the index flag is on) QSR's demand blend uses dg_composite in place of
pop_score at 0.60/0.40, emitting demand_score_source. Falls back silently
to pop_score when the composite is missing.

Adds scripts/diagnostics/qsr_index_validation.sql and QSR tests.

https://claude.ai/code/session_01QmbjhodPHZyqh21Yb8Luzj