### PR TITLE
fix(expansion): drop access_visibility score-domain sensitivity multiplier; fix cafe blend docstring

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -2222,12 +2222,21 @@ def _parking_evidence_band_for_listing(
 
 
 def _access_visibility_score(*, frontage_score: float, access_score: float, brand_profile: dict[str, Any]) -> float:
-    visibility_weight = _sensitivity_weight(brand_profile.get("visibility_sensitivity"))
+    """Blend frontage and access into a pure site measurement on 0-100.
+
+    Brand sensitivity preference is expressed in the WEIGHT domain only
+    (``_brand_weight_multipliers`` lifts/trims the access_visibility
+    top-level weight from the site-sensitivity knobs). The raw score here
+    is deliberately NOT scaled by visibility_sensitivity — a previous
+    ``· (0.75 + visibility_weight·0.25)`` multiplier capped medium-
+    sensitivity brands at 90 and all-low brands at 82.5, compressing the
+    component's spread and skewing cross-brand comparability (weight-audit
+    Item 4b). frontage_sensitivity still steers the frontage/access blend.
+    """
     frontage_weight = _sensitivity_weight(brand_profile.get("frontage_sensitivity"))
     blend = 0.5 + frontage_weight * 0.2
     access_blend = 1.0 - blend
-    weighted = frontage_score * blend + access_score * access_blend
-    return _clamp(weighted * (0.75 + visibility_weight * 0.25))
+    return _clamp(frontage_score * blend + access_score * access_blend)
 
 
 def _ea_table_has_rows(db: Session, table_name: str) -> bool:
@@ -2655,7 +2664,8 @@ def _demand_blend_weights(service_model: str) -> tuple[float, float]:
 
     - delivery_first: delivery density is the primary demand signal (0.40 / 0.60)
     - dine_in: population/foot-traffic dominates (0.75 / 0.25)
-    - cafe: moderate population bias (0.70 / 0.30)
+    - cafe: moderate population bias (0.55 / 0.45 — shifted from 0.70/0.30 to
+      reduce score compression from uniform population signals)
     - qsr (default): balanced with slight population lean (0.60 / 0.40)
     """
     _BLENDS: dict[str, tuple[float, float]] = {

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -833,6 +833,41 @@ def test_brand_weight_reweight_delivery_channel_lifts_delivery_demand(monkeypatc
     assert abs(sum(weights.values()) - 100) < 1e-3
 
 
+def test_access_visibility_score_is_pure_site_measurement():
+    """Weight-audit Item 4b: the score-domain visibility multiplier is removed.
+
+    Sensitivity preference is expressed in the weight domain only
+    (_brand_weight_multipliers); the raw score is a pure site measurement:
+    - a medium-sensitivity profile with perfect inputs reaches 100.0 (the old
+      `· (0.75 + vw·0.25)` multiplier capped it at 90.0);
+    - the score is invariant to visibility_sensitivity;
+    - frontage_sensitivity still steers the frontage/access blend.
+    """
+    assert expansion_service._access_visibility_score(
+        frontage_score=100.0,
+        access_score=100.0,
+        brand_profile={"visibility_sensitivity": "medium"},
+    ) == 100.0
+
+    scores = {
+        level: expansion_service._access_visibility_score(
+            frontage_score=80.0,
+            access_score=40.0,
+            brand_profile={"visibility_sensitivity": level},
+        )
+        for level in ("low", "medium", "high")
+    }
+    assert scores["low"] == scores["medium"] == scores["high"] == 64.8
+
+    # High frontage sensitivity: blend = 0.5 + 1.0*0.2 = 0.7
+    # -> 80*0.7 + 40*0.3 = 68.0 (vs 64.8 at the medium-blend 0.62).
+    assert expansion_service._access_visibility_score(
+        frontage_score=80.0,
+        access_score=40.0,
+        brand_profile={"frontage_sensitivity": "high"},
+    ) == 68.0
+
+
 def test_compare_includes_v61_fields():
     db = FakeDB(
         compare_rows=[


### PR DESCRIPTION
Weight-audit PR-A (Items 4b + 5):

- _access_visibility_score no longer scales by (0.75 + visibility_weight*0.25).
  Brand sensitivity preference is expressed in the weight domain only
  (_brand_weight_multipliers); the raw score is now a pure site measurement on
  the full 0-100 scale (a medium-sensitivity brand previously capped at 90 raw,
  an all-low brand at 82.5). The frontage-sensitivity blend is unchanged.
- _demand_blend_weights docstring: cafe line corrected from (0.70 / 0.30) to
  the live dict value (0.55 / 0.45), deliberately set in 92268f741c to reduce
  score compression from uniform population signals. Comment-only.

New test pins the pure-measurement behavior (medium profile reaches 100.0,
invariance to visibility_sensitivity, frontage blend still active). Existing
weight-domain reweight tests untouched. Full suite: 2302 passed, 24 skipped.

https://claude.ai/code/session_01DrYmKWUJ65wpCBjpDcDXwD