### PR TITLE
fix(expansion): un-floor qsr competition_whitespace (radius 1200->1000 m, REF 25->75)

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -827,7 +827,13 @@ _CATCHMENT_RADII_M: dict[str, dict[str, float]] = {
     # signal. The discriminating variation lives at 1000 m (probe p50 ~16, p90
     # ~29). demand/provider stay at 3000 m (platform delivery radius).
     "delivery_first": {"demand": 3000.0, "competition": 1000.0, "provider": 3000.0},
-    "qsr":            {"demand": 1500.0, "competition": 1200.0, "provider": 1500.0},
+    # qsr competition tightened 1200 -> 1000 m for the same reason as dine_in
+    # and delivery_first: same-category counts at 1200 m run p50 35 / p75 62
+    # on broad scopes — too large for the log-decay domain, flooring 67-82%
+    # of a city-wide probe at 15.0. The discriminating variation lives at
+    # 1000 m (burger-scope probe p25 4 / p50 16 / p75 24 / p90 34).
+    # demand/provider stay at 1500 m (convenience walk/drive-thru catchment).
+    "qsr":            {"demand": 1500.0, "competition": 1000.0, "provider": 1500.0},
     "cafe":           {"demand": 1000.0, "competition":  800.0, "provider": 1000.0},
 }
 
@@ -2694,9 +2700,19 @@ _WHITESPACE_LOG_REF: dict[str, float] = {
     # run somewhat higher — REF=50 (matching dine_in) deliberately avoids
     # re-flooring on the alias-expanded counts rather than sizing lower.
     #
+    # qsr has the same settlement shape as dine_in and delivery_first once its
+    # competition radius is tightened to 1000 m, but its counts run higher, so
+    # it takes REF=75 instead of 50: floors only count >= 39 (c* exact 38.69);
+    # at the 1000 m counts this spreads the p25–p75 band to ~26–63 (burger
+    # scope) and floors 4.9%. KNOWN LIMITATION: broad `fast_food`-scope briefs
+    # still floor ~32% at this setting (probe record 15); acceptable because
+    # production briefs are narrow-scope; the structural fix would be
+    # scope-aware REF — future work, not this PR.
+    #
     # All other service models keep the default 25.
     "dine_in": 50.0,
     "delivery_first": 50.0,
+    "qsr": 75.0,
 }
 _WHITESPACE_LOG_REF_DEFAULT: float = 25.0
 
@@ -2713,15 +2729,18 @@ def _competition_whitespace_score(
     15.0 floor, so it decays steeply at low counts and gently at high ones,
     reaching the floor structurally at ``count = REF``. ``REF`` is
     service-model-aware via ``_WHITESPACE_LOG_REF`` (``dine_in`` and
-    ``delivery_first`` → 50, all other models → 25 default), because both
-    score their competitors over a tighter 1000 m trade area whose in-range
-    counts are large enough that the default REF=25 would floor the p50.
+    ``delivery_first`` → 50, ``qsr`` → 75, all other models → 25 default),
+    because those three score their competitors over a tighter 1000 m trade
+    area whose in-range counts are large enough that the default REF=25
+    would floor the p50 (qsr's counts run higher still, hence 75).
 
     Representative outputs (count → score):
       REF=25 (default):  0→100*, 1→79, 3→57, 6→40, 16→15 (floored at ≤16),
                          25→15 (floor).
       REF=50 (dine_in):  0→100*, 1→82, 6→50, 16→28, 24→18, 32→15, 40→15,
                          50→15 (floor).
+      REF=75 (qsr):      0→100*, 4→63, 16→35, 24→26, 32→19, 39→15 (floor
+                         onset), 75→15 (floor).
     (*count 0 only when ``confident``; see F4 below.)
 
     F4 (defensive): ``count=0`` only earns the wide-open 100 when
@@ -6914,7 +6933,13 @@ def _bulk_enrich_competitors(
                             -- thin-evidence radii flow to Python None and
                             -- _chain_strength_score keeps its neutral 50.0 (no
                             -- COALESCE). MAX is retained above purely for the
-                            -- chain_strength_max JSON diagnostic.
+                            -- chain_strength_max JSON diagnostic. The
+                            -- competition radius also bounds these share
+                            -- counts: tightening it (qsr 1200 -> 1000 m, like
+                            -- delivery_first before it) shrinks matched counts
+                            -- and pushes a few more candidates under
+                            -- :chain_min_matched into the neutral 50 —
+                            -- expected and accepted.
                             CASE
                               WHEN COUNT(*) FILTER (WHERE in_category AND chain_strength IS NOT NULL)
                                    >= :chain_min_matched

--- a/docs/fix-qsr-competition-whitespace-report.md
+++ b/docs/fix-qsr-competition-whitespace-report.md
@@ -1,0 +1,214 @@
+# PATCH PR-B — qsr competition radius + whitespace curve recalibration (Item 1)
+
+**Branch:** `claude/weight-audit-pr-b-1yvztx` (commit `2cca3509a`)
+**Status:** Pushed — no PR opened, no merge, no dispatch. **Ahmed reviews the diff (especially the
+REF=75 constant and the 1000 m radius) and gives explicit merge approval.**
+**Type:** Real scoring change (not emit-only, not flag-gated). **Changes qsr rankings on deploy** —
+same class as the merged dine_in (#1288) and delivery_first (#1291) whitespace fixes; this PR follows
+that bug-fix precedent exactly. Single-purpose: ONLY the two constants + tests + comments. Out of
+scope (deliberately): scope-aware REF, cafe values, Items 2–6 of the weight audit.
+
+---
+
+## 1. What is wrong now
+
+Production scores qsr same-category competitors over a **1200 m** competition radius and lets qsr
+fall through to the **default curve REF=25**. A city-wide probe (548 QSR candidates, exact production
+count predicate) showed this floors:
+
+- **67.2%** of burger-scope candidates at 15.00, and
+- **81.6%** of fast_food-scope candidates at 15.00,
+
+confirmed live by search `d4ca314b` — **10 of 15** shortlist candidates flat at 15.00. A
+near-constant component output means `competition_whitespace` carries close to **zero discriminating
+signal** for qsr, exactly the signature already fixed for dine_in and delivery_first.
+
+## 2. Why it happens — both levers are required
+
+The radius and the curve reference were never co-calibrated for qsr:
+
+- **Why not REF-only.** At 1200 m the counts run **p50 35 / p75 62** on broad scopes — they overflow
+  the log-decay domain. Raising REF alone would un-floor some of the band but leaves the curve
+  discriminating over a count range where the distribution is fat and compressed.
+- **Why not radius-only.** The discriminating variation lives at **1000 m** (burger-scope probe
+  **p25 4 / p50 16 / p75 24 / p90 34**), but under REF=25 the p50 (count 16) still floors
+  (16 → raw 13.0 → floored 15.0). Tightening the radius is necessary but not sufficient.
+
+Same settlement shape as dine_in and delivery_first (both 1000 m). Their counts settled lower, so
+they took REF=50; **qsr counts run higher → REF=75**.
+
+## 3. The fix (two coupled constants + tests + comments — qsr blast radius only)
+
+### Change 1 — qsr competition radius 1200 → 1000 m
+
+`app/services/expansion_advisor.py:836` — `_CATCHMENT_RADII_M['qsr']['competition']`:
+`1200.0 → 1000.0`. The model's **`demand` (1500) and `provider` (1500) radii are unchanged**
+(convenience walk/drive-thru catchment). dine_in / delivery_first / cafe rows untouched. Block
+comment extended in the same style as the dine_in/delivery_first entries
+(`expansion_advisor.py:830-835`).
+
+### Change 2 — add a qsr curve reference
+
+`app/services/expansion_advisor.py:2715` — `_WHITESPACE_LOG_REF`: add `"qsr": 75.0`.
+`dine_in: 50.0`, `delivery_first: 50.0`, and `_WHITESPACE_LOG_REF_DEFAULT = 25.0` are unchanged;
+cafe and unknown models still resolve to the 25 default. No call-site change needed — the scorer is
+already called with `service_model=service_model` (`expansion_advisor.py:8270`), and both
+`_bulk_enrich_competitors` call sites (`:7637`, `:7682`) already pass `service_model`, so the radius
+flows through `_catchment_radii(service_model)["competition"]` (`:6857`).
+
+Comment at the dict entry (`expansion_advisor.py:2704-2711`) records: floors only count ≥ 39
+(c\* exact 38.69); at the 1000 m counts this spreads the p25–p75 band to ~26–63 (burger scope) and
+floors 4.9%.
+
+> **KNOWN LIMITATION (recorded verbatim in the code comment):** broad `fast_food`-scope briefs still
+> floor ~32% at this setting (probe record 15); acceptable because production briefs are
+> narrow-scope; the structural fix would be scope-aware REF — future work, not this PR.
+
+### Change 3 — update the blast-radius guard tests
+
+The delivery_first fix had pinned **qsr** bit-for-bit to the legacy REF=25 curve
+(`test_competition_whitespace_cafe_qsr_reference_unchanged`). That guard now encoded the bug. Updated
+to:
+
+- **drop qsr** from the legacy REF=25 loop (now guards cafe / `None` only), same representative
+  counts `1/3/6/8/12/16/24/25/40/50/145` (`tests/test_expansion_advisor_service.py:547-575`);
+- new `test_competition_whitespace_qsr_reference_varies_off_floor` pins qsr **bit-for-bit to the
+  REF=75 curve** (via a `_ref75` helper) across counts `1/3/4/6/16/24/32/38/39/50/75/145`, plus exact
+  curve pins — see §4 (`tests/test_expansion_advisor_service.py:622-680`);
+- `test_competition_whitespace_f4_path_unchanged_per_model` already covered qsr — unchanged;
+- the dine_in and delivery_first dedicated tests are **byte-identical** (verified: no diff hunk
+  touches either function body).
+
+The guard's point is unchanged — pin per-model whitespace behaviour — it now encodes the fixed qsr
+curve instead of the buggy one. It is **not** weakened to a no-op.
+
+### Change 4 — chain-share side-effect comment (comment-only)
+
+`app/services/expansion_advisor.py:6935-6941` — appended to the **existing** chain-share comment
+anchor inside `_bulk_enrich_competitors`'s SQL (no code restructure): the competition radius also
+bounds the chain_strength share counts; at 1000 m matched counts shrink and a few more candidates
+fall under `EXPANSION_CHAIN_MIN_MATCHED=3` into the neutral 50 — expected and accepted, mirroring
+the delivery_first precedent.
+
+### Change 5 — docstring + diagnostics
+
+- `_competition_whitespace_score` docstring updated (`expansion_advisor.py:2730-2744`): it previously
+  asserted qsr uses the 25 default, which would have been stale; a REF=75 representative-output row
+  was added.
+- New `scripts/diagnostics/qsr_whitespace_probe.sql`: ~10-line search-scoped post-rollout validation
+  query (auto-scopes to the latest qsr `expansion_search`; psql `-f` safe, no `\set`). The original
+  city-wide probe was never committed to the repo, so there was nothing in-repo to extend — this
+  file is the in-repo home for the search-scoped section.
+
+---
+
+## 4. REF = 75 rationale (verified in code, exact formula)
+
+`score(c) = clamp(max(15, 100·(1 − log1p(c)/log1p(75))))`. Floor onset: c\* = 38.69 → first integer
+count that floors is **39**.
+
+| count        | REF=25 (default / cafe) | REF=75 (qsr)        |
+|--------------|--------------------------|---------------------|
+| 0 (confident)| 100                      | 100                 |
+| 1            | 78.7                     | 83.99               |
+| 4 (p25)      | 50.0                     | **62.84**           |
+| 16 (p50)     | **15.0 (floored)**       | **34.58**           |
+| 24 (p75)     | 15.0                     | **25.67**           |
+| 32           | 15.0                     | 19.26               |
+| 38           | 15.0                     | 15.41 (last off-floor) |
+| 39           | 15.0                     | **15.0 (floor onset)** |
+| 75           | 15.0                     | 15.0 (structural floor) |
+| 145          | 15.0                     | 15.0                |
+
+### ⚠️ Arithmetic mismatches vs the brief (> 0.05 — flagged per instruction)
+
+The brief's test-pin arithmetic was chat-side; tests use the exact recomputed values:
+
+| count | brief said | exact value | delta  |
+|-------|-----------|-------------|--------|
+| 4     | 62.77     | **62.84**   | 0.07 ⚠️ |
+| 16    | 34.39     | **34.58**   | 0.19 ⚠️ |
+| 24    | 25.45     | **25.67**   | 0.22 ⚠️ |
+| 39    | 15.0      | 15.0 (raw 14.82) | ✓ |
+| c\*   | 38.70     | 38.69       | ✓      |
+
+Note the brief's *evidence* section (p25/p50/p75 scores 62.8 / 34.6 / 25.7) matches the exact values
+— only the test-pin section drifted.
+
+---
+
+## 5. Validation
+
+### Already run (this patch)
+
+```bash
+python -m pytest tests/test_expansion_advisor_service.py -k whitespace -q   # 6 passed
+python -m pytest -q                                       # 2303 passed, 24 skipped
+```
+
+(HEAD baseline was 2302 passed; the +1 is the new qsr guard test.) flake8 issue count on the two
+touched files is identical to HEAD (1433, all pre-existing); black was already failing on both files
+at HEAD (pre-existing repo-wide drift) — not introduced or worsened here.
+
+### Post-merge + deploy (Ahmed — this DOES change qsr rankings)
+
+1. Merge → deploy → fresh **city-wide QSR** search (old searches won't backfill).
+2. `psql "$DATABASE_URL" -f scripts/diagnostics/qsr_whitespace_probe.sql` (auto-scopes to the latest
+   qsr search). Success criteria:
+   - `pct_floored` drops from ~67% toward **~5%** (narrow scope);
+   - `distinct_whitespace_values` ≥ **6** in a 15-candidate shortlist;
+   - `competitor_count_p50` reflects the **1000 m** radius (shortlist p50 roughly **0.6–0.7×** the
+     1200 m counts);
+   - `count_score_corr` ≤ 0 — monotonic score-vs-count.
+3. Spot-check chain_strength inputs on the same search for the expected **mild rise in neutral-50s**
+   (radius side effect, see §6).
+
+---
+
+## 6. Risk / tradeoff — blast radius
+
+- **Intended ranking shift, qsr only.** Sites that previously all read 15.0 now spread across the
+  p25–p75 band (~26–63 burger scope); the genuinely saturated ≥ 39 tail still floors. Corrected
+  behaviour, not a regression.
+- **Side effect (expected and accepted):** the competition radius also bounds the chain_strength
+  share counts. At 1000 m matched counts shrink and a few more candidates fall under
+  `EXPANSION_CHAIN_MIN_MATCHED=3` into the neutral 50 — mirrors the delivery_first precedent, noted
+  in-code at the chain-share aggregation.
+- **Known limitation:** broad `fast_food`-scope briefs still floor ~32% at REF=75. Acceptable —
+  production briefs are narrow-scope; the structural fix is scope-aware REF (future work, explicitly
+  out of this PR's scope).
+- **Contained.** dine_in (REF 50), delivery_first (REF 50), cafe (REF 25) keep their radii and REFs,
+  pinned bit-for-bit by guard tests (their dedicated tests are byte-identical). No change to the
+  curve formula, the 15.00 floor, the F4 `count<=0` branches (50/100), `component_weights`, the
+  `sum == 100` invariant, gates, or any other model's radii.
+- **Curve constant is the review point.** REF=75 lives in the named `_WHITESPACE_LOG_REF` dict so
+  Ahmed can tune the knee without touching the formula.
+
+---
+
+## 7. Change inventory (exact anchors)
+
+| Change | Location |
+|--------|----------|
+| `_CATCHMENT_RADII_M["qsr"]["competition"]` 1200 → 1000 + block comment | `app/services/expansion_advisor.py:830-836` |
+| `_WHITESPACE_LOG_REF["qsr"] = 75.0` + comment incl. KNOWN LIMITATION | `app/services/expansion_advisor.py:2704-2715` |
+| `_competition_whitespace_score` docstring (REF=75 row; qsr no longer "default") | `app/services/expansion_advisor.py:2730-2744` |
+| Chain-share side-effect comment (existing anchor, comment-only) | `app/services/expansion_advisor.py:6935-6941` |
+| Guard test: qsr dropped from legacy REF=25 loop | `tests/test_expansion_advisor_service.py:547-575` |
+| New `test_competition_whitespace_qsr_reference_varies_off_floor` | `tests/test_expansion_advisor_service.py:622-680` |
+| New search-scoped post-rollout probe | `scripts/diagnostics/qsr_whitespace_probe.sql` |
+
+Diff stat: `3 files changed, 128 insertions(+), 11 deletions(-)`.
+
+There was **no pre-existing test pinning the qsr competition radius at 1200** — the only radius pin
+(`tests/test_expansion_advisor_demand_generator.py:518`) reads the *demand* radius through the dict
+and is unaffected. The REF pin was the qsr entry in the legacy REF=25 guard loop, handled in §3.
+
+---
+
+## 8. Merge recommendation
+
+**Low risk, high signal.** Targeted, well-tested, follows the merged dine_in/delivery_first
+precedent exactly; the behaviour-corrupting input is fixed at the source and the only judgement
+call — the REF=75 constant — is surfaced in a named dict for review. Recommend merge after Ahmed
+signs off on the constant and the 1000 m radius, then run the post-deploy validation in §5.

--- a/scripts/diagnostics/qsr_whitespace_probe.sql
+++ b/scripts/diagnostics/qsr_whitespace_probe.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- qsr_whitespace_probe.sql — search-scoped post-rollout check (PR-B, Item 1)
+-- ----------------------------------------------------------------------------
+-- Validates the qsr competition_whitespace recalibration (competition radius
+-- 1200 -> 1000 m, REF 25 -> 75) on the LATEST qsr search. Run AFTER deploy and
+-- a fresh city-wide qsr search (old searches won't backfill). Expected vs the
+-- pre-fix probe: pct_floored drops from ~67% (burger scope) toward ~5%,
+-- distinct_whitespace_values >= 6 in a 15-candidate shortlist, and
+-- competitor_count_p50 reflects 1000 m (~0.6–0.7x the 1200 m counts).
+--
+-- HOW TO RUN (psql -f safe, no \set):
+--   psql "$DATABASE_URL" -f scripts/diagnostics/qsr_whitespace_probe.sql
+-- ============================================================================
+WITH s AS (
+    SELECT id FROM expansion_search
+    WHERE service_model = 'qsr'
+    ORDER BY created_at DESC LIMIT 1
+)
+SELECT
+    ec.search_id,
+    COUNT(*)                                              AS candidates,
+    COUNT(*) FILTER (WHERE ec.whitespace_score <= 15.0)   AS floored,
+    ROUND(100.0 * COUNT(*) FILTER (WHERE ec.whitespace_score <= 15.0)
+          / COUNT(*), 1)                                  AS pct_floored,
+    COUNT(DISTINCT ec.whitespace_score)                   AS distinct_whitespace_values,
+    percentile_cont(0.5) WITHIN GROUP (ORDER BY ec.competitor_count)  AS competitor_count_p50,
+    percentile_cont(0.5) WITHIN GROUP (ORDER BY ec.whitespace_score)  AS whitespace_p50,
+    -- Monotonic score-vs-count sanity: must be <= 0 (more competitors,
+    -- lower whitespace) for every confident candidate.
+    corr(ec.competitor_count::float, ec.whitespace_score::float)      AS count_score_corr
+FROM expansion_candidate ec
+JOIN s ON ec.search_id = s.id
+GROUP BY ec.search_id;

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -545,12 +545,13 @@ def test_competition_whitespace_dine_in_reference_varies_off_floor():
 
 
 def test_competition_whitespace_cafe_qsr_reference_unchanged():
-    """Blast-radius guard: qsr / cafe (REF=25 default) are unchanged.
+    """Blast-radius guard: cafe / unknown models (REF=25 default) unchanged.
 
-    These must match the pre-change behaviour bit-for-bit so neither the
-    dine_in nor the delivery_first recalibration can leak into cafe / qsr
-    rankings. delivery_first is deliberately NOT in this loop any more — it
-    now uses REF=50 (see the dedicated test below).
+    These must match the pre-change behaviour bit-for-bit so none of the
+    dine_in / delivery_first / qsr recalibrations can leak into cafe (or an
+    unknown service model's) rankings. delivery_first and qsr are
+    deliberately NOT in this loop any more — they now use REF=50 and REF=75
+    respectively (see the dedicated tests below).
     """
     import math
 
@@ -565,7 +566,7 @@ def test_competition_whitespace_cafe_qsr_reference_unchanged():
     # Representative competitor counts spanning empty -> saturated, including
     # the probe percentiles called out in the fix report.
     for count in (1, 3, 6, 8, 12, 16, 24, 25, 40, 50, 145):
-        for model in ("cafe", "qsr", None):
+        for model in ("cafe", None):
             assert _competition_whitespace_score(
                 count, confident=True, service_model=model
             ) == pytest.approx(_legacy_ref25(count))
@@ -616,6 +617,64 @@ def test_competition_whitespace_delivery_first_reference_varies_off_floor():
     assert _competition_whitespace_score(
         145, confident=True, service_model="delivery_first"
     ) == 15.0
+
+
+def test_competition_whitespace_qsr_reference_varies_off_floor():
+    """qsr uses REF=75 so its tightened 1000 m count band spreads.
+
+    Before the fix qsr scored same-category competitors over a 1200 m radius
+    whose counts overflowed the default REF=25 curve (city-wide probe: 67.2%
+    of burger-scope / 81.6% of fast_food-scope candidates floored at 15.0 —
+    confirmed live by a 10/15-flat search). The discriminating variation
+    lives at 1000 m (burger-scope p25 4 / p50 16 / p75 24), but qsr counts
+    run higher than dine_in's / delivery_first's, so REF=75 (not 50) keeps
+    the p25–p75 band spread to ~26–63 and floors only count >= 39
+    (c* exact 38.69; burger-scope floored share ~4.9%).
+    """
+    import math
+
+    import pytest
+
+    from app.services.expansion_advisor import _competition_whitespace_score
+
+    def _ref75(count: int) -> float:
+        raw = 100.0 * (1.0 - (math.log1p(count) / math.log1p(75)))
+        return max(15.0, raw)
+
+    # qsr follows the REF=75 curve exactly (NOT the legacy REF=25).
+    for count in (1, 3, 4, 6, 16, 24, 32, 38, 39, 50, 75, 145):
+        assert _competition_whitespace_score(
+            count, confident=True, service_model="qsr"
+        ) == pytest.approx(_ref75(count))
+
+    # Exact curve pins at the probe percentiles (burger scope p25/p50/p75).
+    assert _competition_whitespace_score(
+        4, confident=True, service_model="qsr"
+    ) == pytest.approx(62.84, abs=0.01)
+    assert _competition_whitespace_score(
+        16, confident=True, service_model="qsr"
+    ) == pytest.approx(34.58, abs=0.01)
+    assert _competition_whitespace_score(
+        24, confident=True, service_model="qsr"
+    ) == pytest.approx(25.67, abs=0.01)
+    # Floor onset: count 38 is still (barely) off the floor, 39 floors.
+    assert _competition_whitespace_score(
+        38, confident=True, service_model="qsr"
+    ) == pytest.approx(15.41, abs=0.01)
+    assert _competition_whitespace_score(
+        39, confident=True, service_model="qsr"
+    ) == 15.0
+    # Confirmed greenfield is still wide open.
+    assert _competition_whitespace_score(
+        0, confident=True, service_model="qsr"
+    ) == 100.0
+
+    scores = [
+        _competition_whitespace_score(c, confident=True, service_model="qsr")
+        for c in (0, 4, 16, 24, 39)
+    ]
+    # Component carries signal — not a constant floor.
+    assert len(set(scores)) > 1
 
 
 def test_competition_whitespace_f4_path_unchanged_per_model():


### PR DESCRIPTION
A city-wide probe (548 QSR candidates, exact production count predicate)
showed the default (1200 m, REF=25) floors 67.2% (burger scope) / 81.6%
(fast_food scope) of candidates at 15.00 — confirmed live by a search
scoring 10/15 flat. Same two-part signature already fixed for dine_in
and delivery_first: counts at 1200 m run p50 35 / p75 62 on broad
scopes — too large for the log-decay domain — while the discriminating
variation lives at 1000 m (burger p25 4 / p50 16 / p75 24 / p90 34).

Changes (qsr only; not flag-gated, like the dine_in/delivery_first fixes):
- _CATCHMENT_RADII_M['qsr']['competition']: 1200 -> 1000 m
  (demand/provider stay at 1500 m).
- _WHITESPACE_LOG_REF: add 'qsr': 75.0 (qsr counts run higher than
  dine_in/delivery_first's, so 75 not 50). Floors only count >= 39
  (c* exact 38.69); spreads the burger-scope p25-p75 band to ~26-63 and
  floors 4.9%. KNOWN LIMITATION: broad fast_food-scope briefs still
  floor ~32% at this setting; acceptable because production briefs are
  narrow-scope; the structural fix would be scope-aware REF — future
  work, not this PR.
- Update the blast-radius guard test: drop qsr from the legacy REF=25
  loop, add a dedicated REF=75 guard with exact curve pins
  (4 -> 62.84, 16 -> 34.58, 24 -> 25.67, 39 -> 15.0 floor onset,
  0 confident -> 100).
- Add scripts/diagnostics/qsr_whitespace_probe.sql: search-scoped
  post-rollout validation query.

Side effect (expected and accepted, mirroring the delivery_first
precedent): the competition radius also bounds the chain_strength share
counts; at 1000 m matched counts shrink and a few more candidates fall
under EXPANSION_CHAIN_MIN_MATCHED=3 into neutral 50.

No change to the curve formula, the 15.00 floor, F4 count<=0 branches,
component weights, gates, or any other model's radii/REF. dine_in
(REF 50), delivery_first (REF 50), cafe (REF 25) pinned bit-for-bit by
guards; their tests are byte-identical.

Tests: tests/test_expansion_advisor_service.py -k whitespace (6 passed);
full suite 2303 passed, 24 skipped.

https://claude.ai/code/session_01939R4btC6RbfZjjr8eRkHc