### PR TITLE
PR-C (Item 2): re-anchor realized-demand reference per service model; make delivery-leg radius explicit

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -107,13 +107,18 @@ class Settings:
     EXPANSION_REALIZED_DEMAND_BLEND: float = float(
         os.getenv("EXPANSION_REALIZED_DEMAND_BLEND", "0.5")
     )
-    # Reference point for the square-root-scaled realized-demand score in
-    # _delivery_score(): realized_demand == this value maps to a score of 100.
-    # Calibrated 2026-05-15 from the trailing-90d realized_demand_30d
-    # distribution across 3,128 populated candidates (median 133, p75 263,
-    # p90 496, p95 840). Anchor at p75: a candidate at the 75th percentile of
-    # measured demand saturates the demand leg, median candidates score ~71,
-    # only the top quartile maxes out. See
+    # FALLBACK reference point for the square-root-scaled realized-demand
+    # score in _delivery_score(): realized_demand == this value maps to a
+    # score of 100. Since 2026-06-10 the search pipeline uses per-service-
+    # model anchors (_REALIZED_DEMAND_REFERENCE in
+    # app/services/expansion_advisor.py: delivery_first 307 / dine_in 402 /
+    # qsr 327); this env value applies only to models absent from that dict
+    # (e.g. cafe) and to callers that don't pass an explicit reference.
+    # Originally calibrated 2026-05-15 from the trailing-90d
+    # realized_demand_30d distribution across 3,128 populated candidates
+    # (median 133, p75 263, p90 496, p95 840). Anchor at p75: a candidate at
+    # the 75th percentile of measured demand saturates the demand leg, median
+    # candidates score ~71, only the top quartile maxes out. See
     # scripts/diagnostics/realized_demand_calibration.sql.
     EXPANSION_REALIZED_DEMAND_REFERENCE: float = float(
         os.getenv("EXPANSION_REALIZED_DEMAND_REFERENCE", "263.0")

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -2627,6 +2627,7 @@ def _delivery_score(
     *,
     realized_demand: float | None = None,
     blend_weight: float = 0.5,
+    reference: float | None = None,
 ) -> float:
     """Square-root scaled delivery score for wider dynamic range.
 
@@ -2645,6 +2646,13 @@ def _delivery_score(
     When realized demand is available, blend it with the listing-count
     signal: ``score = (1-w) · listing + w · realized``.  Otherwise fall
     back to today's supply-count behavior unchanged.
+
+    ``reference`` is the realized-demand saturation point (realized_demand
+    == reference maps to 100).  Callers in the search pipeline pass the
+    service-model-aware anchor from ``_realized_demand_reference()``; when
+    omitted it falls back to the global
+    ``EXPANSION_REALIZED_DEMAND_REFERENCE`` setting, preserving the legacy
+    behavior for any caller that hasn't been updated.
     """
     listing_score = (
         0.0
@@ -2653,14 +2661,15 @@ def _delivery_score(
     )
     if realized_demand is None or realized_demand <= 0:
         return listing_score
-    # Reference point (EXPANSION_REALIZED_DEMAND_REFERENCE): realized_demand
-    # equal to the reference maps to a score of 100.  Square-root scaling
-    # mirrors the listing-count term so the two blend cleanly.  Calibrate via
+    # Reference point: realized_demand equal to the reference maps to a
+    # score of 100.  Square-root scaling mirrors the listing-count term so
+    # the two blend cleanly.  Calibrate per service model via
+    # scripts/diagnostics/delivery_demand_legs_probe.sql
+    # (_REALIZED_DEMAND_REFERENCE), global fallback via
     # scripts/diagnostics/realized_demand_calibration.sql.
-    realized_score = _clamp(
-        (realized_demand / settings.EXPANSION_REALIZED_DEMAND_REFERENCE) ** 0.5
-        * 100.0
-    )
+    if reference is None:
+        reference = settings.EXPANSION_REALIZED_DEMAND_REFERENCE
+    realized_score = _clamp((realized_demand / reference) ** 0.5 * 100.0)
     bw = max(0.0, min(1.0, blend_weight))
     return _clamp(listing_score * (1.0 - bw) + realized_score * bw)
 
@@ -2715,6 +2724,43 @@ _WHITESPACE_LOG_REF: dict[str, float] = {
     "qsr": 75.0,
 }
 _WHITESPACE_LOG_REF_DEFAULT: float = 25.0
+
+
+_REALIZED_DEMAND_REFERENCE: dict[str, float] = {
+    # Per-service-model saturation reference for the realized-demand leg of
+    # _delivery_score (realized_demand == REF maps to a score of 100 on the
+    # square-root curve). Re-anchored 2026-06-10 from a 1,220-candidate /
+    # trailing-30d probe (scripts/diagnostics/delivery_demand_legs_probe.sql)
+    # using the SAME rule as the original 2026-05-15 calibration of
+    # EXPANSION_REALIZED_DEMAND_REFERENCE: anchor at each model's
+    # realized_demand_30d p75 so the median lands in the ~70s and only the
+    # top quartile saturates. The global p75=263 anchor had drifted low —
+    # 62.5% of qsr candidates sat at/over it, pinning the realized leg at 100
+    # (probe realized_p50 score: qsr 100, dine_in 98.5).
+    #
+    # These anchors are calibrated to counts measured at the 1200 m
+    # EXPANSION_REALIZED_DEMAND_RADIUS_M catchment — re-derive them from the
+    # probe if that radius ever changes.
+    #
+    # cafe is deliberately absent (no cafe rows in the probe window) and any
+    # model not listed here falls back to the
+    # EXPANSION_REALIZED_DEMAND_REFERENCE env default (263.0).
+    "delivery_first": 307.0,
+    "dine_in": 402.0,
+    "qsr": 327.0,
+}
+
+
+def _realized_demand_reference(service_model: str | None) -> float:
+    """Realized-demand saturation reference for this service model.
+
+    Models absent from ``_REALIZED_DEMAND_REFERENCE`` (e.g. ``cafe``) fall
+    back to the ``EXPANSION_REALIZED_DEMAND_REFERENCE`` env default.
+    """
+    return _REALIZED_DEMAND_REFERENCE.get(
+        (service_model or "").lower(),
+        settings.EXPANSION_REALIZED_DEMAND_REFERENCE,
+    )
 
 
 def _competition_whitespace_score(
@@ -7819,6 +7865,16 @@ def run_expansion_search(
                 f"cat_{i}": f"%{term}%"
                 for i, term in enumerate(_cat_terms)
             }
+            # Delivery-market count radius. This bulk enrichment deliberately
+            # overrides the pool SQL's model-aware :demand_radius_m count for
+            # ALL service models: both delivery legs (this listing count and
+            # the realized-demand Δrating_count below) share the single
+            # EXPANSION_REALIZED_DEMAND_RADIUS_M catchment (default 1200 m).
+            # The _REALIZED_DEMAND_REFERENCE anchors are calibrated to counts
+            # at THIS radius — re-anchor them if it ever changes.
+            _del_params["del_radius_m"] = int(
+                settings.EXPANSION_REALIZED_DEMAND_RADIUS_M
+            )
             for _idx, _r in enumerate(rows):
                 _pid = str(_r.get("parcel_id") or "")
                 _lon = _safe_float(_r.get("lon"))
@@ -7849,7 +7905,7 @@ def run_expansion_search(
                              AND ST_DWithin(
                                  d.geom::geography,
                                  ST_SetSRID(ST_MakePoint(c.lon::double precision, c.lat::double precision), 4326)::geography,
-                                 1200
+                                 :del_radius_m
                              )
                             GROUP BY c.parcel_id
                         """),
@@ -8282,6 +8338,7 @@ def run_expansion_search(
             delivery_listing_count,
             realized_demand=_realized_demand_30d,
             blend_weight=settings.EXPANSION_REALIZED_DEMAND_BLEND,
+            reference=_realized_demand_reference(service_model),
         )
         _pop_w, _del_w = _demand_blend_weights(service_model)
         demand_score = _clamp(pop_score * _pop_w + delivery_score * _del_w)
@@ -8402,6 +8459,7 @@ def run_expansion_search(
             delivery_listing_count,
             realized_demand=_realized_demand_30d,
             blend_weight=settings.EXPANSION_REALIZED_DEMAND_BLEND,
+            reference=_realized_demand_reference(service_model),
         )
         demand_score = _clamp(pop_score * _pop_w + delivery_score * _del_w)
 

--- a/docs/investigations/weight_audit_6_findings.md
+++ b/docs/investigations/weight_audit_6_findings.md
@@ -1,0 +1,42 @@
+# Weight audit — findings log
+
+> Note: the original audit write-up (Items 1–6) was produced outside the repo;
+> this file starts the in-repo log with the PR-C entry. Earlier items are
+> referenced by number only.
+
+## Item 2 / PR-C — realized-demand re-anchor: two-step deploy (2026-06-10)
+
+PR-C re-anchors the realized-demand reference per service model
+(`_REALIZED_DEMAND_REFERENCE` in `app/services/expansion_advisor.py`:
+delivery_first 307 / dine_in 402 / qsr 327, p75 anchors from
+`scripts/diagnostics/delivery_demand_legs_probe.sql`; cafe falls back to the
+`EXPANSION_REALIZED_DEMAND_REFERENCE` env default of 263) and makes the bulk
+delivery-leg count radius read `EXPANSION_REALIZED_DEMAND_RADIUS_M`
+explicitly (no value change — still 1200 m).
+
+Deploy in two steps:
+
+1. **Merge + deploy this PR.** The re-anchor takes effect immediately:
+   realized-demand leg scores come off the 100 ceiling (pre-fix probe:
+   realized_p50 score 100 for qsr, 98.5 for dine_in; 62.5% of qsr candidates
+   sat at/over the stale global anchor of 263). Validate with section B of
+   `scripts/diagnostics/delivery_demand_legs_probe.sql` on fresh searches —
+   realized_p50 should land in the ~75–90 band.
+2. **Then** shift the blend toward the demand-native leg (env-only, no code
+   change — `_delivery_score` already reads the setting):
+
+   ```bash
+   kubectl set env deployment/oaktree-estimator -n default \
+     EXPANSION_REALIZED_DEMAND_BLEND=0.7
+   ```
+
+   This moves the listing(supply)/realized blend from 0.5/0.5 to 0.3/0.7.
+   Rationale: the listing leg is competitor supply (its correlation with
+   provider_whitespace runs −0.94…−0.96 across service models), while
+   realized rating-velocity is the demand-native signal. After step 2,
+   re-run the probe and confirm the delivery-leg spread widens and
+   corr(demand_score, competitor_count) does not increase.
+
+Do step 2 only after step 1 is verified — raising the realized weight while
+the realized leg is still saturated at 100 would compress, not widen, the
+delivery-leg spread.

--- a/scripts/diagnostics/delivery_demand_legs_probe.sql
+++ b/scripts/diagnostics/delivery_demand_legs_probe.sql
@@ -1,0 +1,77 @@
+\pset footer off
+--
+-- delivery_demand_legs_probe.sql
+--
+-- Per-service-model distribution of the realized-demand delivery leg, used
+-- to anchor _REALIZED_DEMAND_REFERENCE in app/services/expansion_advisor.py
+-- (delivery_first 307 / dine_in 402 / qsr 327, derived 2026-06-10 from a
+-- 1,220-candidate trailing-30d probe). Run in Codespace against the
+-- production DB.
+--
+-- Anchor rule (same as the original 2026-05-15 global calibration in
+-- scripts/diagnostics/realized_demand_calibration.sql): take each model's
+-- realized_demand_30d p75 from section A as its reference — p75 maps to a
+-- score of 100, the median lands in the ~70s, only the top quartile
+-- saturates. Counts are measured at the 1200 m
+-- EXPANSION_REALIZED_DEMAND_RADIUS_M catchment; re-derive the anchors if
+-- that radius ever changes. cafe is deliberately unanchored (no cafe rows
+-- in the probe window) and falls back to the env default (263).
+--
+-- "Populated" = realized_demand_30d present AND realized_demand_branches
+-- >= 3, the same gate the snapshot writer applies.
+--
+\echo ''
+\echo '=== A. realized_demand_30d percentiles per service model (trailing 30d) ==='
+SELECT
+  s.service_model,
+  COUNT(*)                                                            AS n,
+  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY rd)::numeric, 1) AS median,
+  ROUND(percentile_cont(0.75) WITHIN GROUP (ORDER BY rd)::numeric, 1) AS p75,
+  ROUND(percentile_cont(0.90) WITHIN GROUP (ORDER BY rd)::numeric, 1) AS p90
+FROM (
+  SELECT
+    c.search_id,
+    (c.feature_snapshot_json->>'realized_demand_30d')::numeric AS rd
+  FROM expansion_candidate c
+  WHERE c.feature_snapshot_json ? 'realized_demand_30d'
+    AND (c.feature_snapshot_json->>'realized_demand_30d') IS NOT NULL
+    AND COALESCE((c.feature_snapshot_json->>'realized_demand_branches')::numeric, 0) >= 3
+) populated
+JOIN expansion_search s ON s.id = populated.search_id
+WHERE s.created_at >= now() - interval '30 days'
+GROUP BY s.service_model
+ORDER BY s.service_model;
+
+\echo ''
+\echo '=== B. Realized-leg score under the per-model anchors (post-deploy check) ==='
+-- After deploying the re-anchor, run on fresh searches only (created_at
+-- after the deploy). Healthy shape: realized_p50 in the ~75-90 band and
+-- pct_at_ceiling roughly 25% — not the pre-fix 100/62.5% saturation.
+SELECT
+  s.service_model,
+  COUNT(*) AS n,
+  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY score)::numeric, 1) AS realized_p50,
+  ROUND(percentile_cont(0.75) WITHIN GROUP (ORDER BY score)::numeric, 1) AS realized_p75,
+  ROUND(100.0 * AVG((score >= 100)::int), 1) AS pct_at_ceiling
+FROM (
+  SELECT
+    c.search_id,
+    LEAST(100.0, sqrt(
+      (c.feature_snapshot_json->>'realized_demand_30d')::numeric
+      / CASE s2.service_model
+          WHEN 'delivery_first' THEN 307.0
+          WHEN 'dine_in'        THEN 402.0
+          WHEN 'qsr'            THEN 327.0
+          ELSE 263.0  -- env fallback (cafe / unknown models)
+        END
+    ) * 100.0) AS score
+  FROM expansion_candidate c
+  JOIN expansion_search s2 ON s2.id = c.search_id
+  WHERE c.feature_snapshot_json ? 'realized_demand_30d'
+    AND (c.feature_snapshot_json->>'realized_demand_30d') IS NOT NULL
+    AND COALESCE((c.feature_snapshot_json->>'realized_demand_branches')::numeric, 0) >= 3
+) scored
+JOIN expansion_search s ON s.id = scored.search_id
+WHERE s.created_at >= now() - interval '30 days'  -- post-deploy: tighten to the deploy timestamp
+GROUP BY s.service_model
+ORDER BY s.service_model;

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -2358,6 +2358,77 @@ def test_delivery_score_realized_low_demand_pulls_score_down():
     assert saturated_with_low_demand < saturated_listing_only
 
 
+def test_realized_demand_reference_per_service_model():
+    """Known models read the probe-derived anchors; others fall back to env."""
+    from app.core.config import settings
+    from app.services.expansion_advisor import _realized_demand_reference
+
+    assert _realized_demand_reference("delivery_first") == 307.0
+    assert _realized_demand_reference("dine_in") == 402.0
+    assert _realized_demand_reference("qsr") == 327.0
+    # cafe is deliberately unanchored (no probe rows); unknown / missing
+    # models also fall back to the global env default.
+    fallback = settings.EXPANSION_REALIZED_DEMAND_REFERENCE
+    assert _realized_demand_reference("cafe") == fallback
+    assert _realized_demand_reference(None) == fallback
+    assert _realized_demand_reference("weird") == fallback
+
+
+def test_delivery_score_explicit_reference():
+    """An explicit reference re-anchors the realized leg's 100-point."""
+    from app.services.expansion_advisor import _delivery_score
+
+    # realized_demand == reference saturates the realized leg at 100.
+    assert _delivery_score(
+        10, realized_demand=327.0, blend_weight=1.0, reference=327.0
+    ) == pytest.approx(100.0, abs=0.01)
+    # Exact mid value: rd=216, ref=327 → √(216/327)·100 = 81.274...,
+    # blended at w=0.5 with the listing score for count 10 (exactly 50.0)
+    # → 0.5·50 + 0.5·81.274 = 65.637.
+    assert _delivery_score(
+        10, realized_demand=216.0, blend_weight=1.0, reference=327.0
+    ) == pytest.approx(81.274, abs=0.01)
+    assert _delivery_score(
+        10, realized_demand=216.0, blend_weight=0.5, reference=327.0
+    ) == pytest.approx(65.637, abs=0.01)
+    # Omitting reference preserves the legacy global-setting behavior.
+    from app.core.config import settings
+
+    legacy = _delivery_score(10, realized_demand=216.0, blend_weight=0.5)
+    explicit_global = _delivery_score(
+        10,
+        realized_demand=216.0,
+        blend_weight=0.5,
+        reference=settings.EXPANSION_REALIZED_DEMAND_REFERENCE,
+    )
+    assert legacy == pytest.approx(explicit_global, abs=1e-9)
+
+
+def test_bulk_delivery_radius_reads_settings_not_literal():
+    """The bulk delivery-count SQL must take its radius from settings.
+
+    Guards against the magic-number regression: the listing-count leg and the
+    realized-demand leg share the EXPANSION_REALIZED_DEMAND_RADIUS_M
+    catchment, and the _REALIZED_DEMAND_REFERENCE anchors are calibrated to
+    counts at that radius.
+    """
+    import inspect
+
+    import app.services.expansion_advisor as svc
+
+    source = inspect.getsource(svc.run_expansion_search)
+    start = source.index("Bulk delivery enrichment")
+    end = source.index("Bulk realized-demand enrichment")
+    bulk_block = source[start:end]
+    assert "EXPANSION_REALIZED_DEMAND_RADIUS_M" in bulk_block
+    # The SQL itself (not comments) must bind the radius, not inline it.
+    sql_start = bulk_block.index('text(f"""')
+    sql_end = bulk_block.index('""")', sql_start)
+    bulk_sql = bulk_block[sql_start:sql_end]
+    assert ":del_radius_m" in bulk_sql
+    assert "1200" not in bulk_sql
+
+
 # ---------------------------------------------------------------------------
 # Phase 2 — bounded LLM shortlist reranking integration
 #


### PR DESCRIPTION
## What is wrong now

`EXPANSION_REALIZED_DEMAND_REFERENCE=263` was anchored at the city-wide realized_demand p75 on 2026-05-15. The distribution has shifted up: a 1,220-candidate trailing-30d probe shows p75 at **delivery_first 307 / dine_in 402 / qsr 327**, with 62.5% of qsr candidates at/over the stale anchor. The realized-demand leg of `_delivery_score` saturates (realized_p50 score = 100 for qsr, 98.5 for dine_in), so the leg stops discriminating among the upper half of candidates.

Separately, the bulk delivery-market count radius was a hardcoded `1200` in the bulk-enrich SQL, silently overriding the pool SQL's model-aware `:demand_radius_m`.

## Changes

**1. Per-model realized-demand reference** (`app/services/expansion_advisor.py`)
- `_REALIZED_DEMAND_REFERENCE` dict (delivery_first 307 / dine_in 402 / qsr 327) + `_realized_demand_reference()` helper, mirroring the `_WHITESPACE_LOG_REF` pattern. Same anchor rule as the original calibration: p75 ⇒ score 100, median lands ~70s, only the top quartile saturates. **cafe is deliberately absent** (no cafe rows in the probe window) and falls back to the env default.
- `_delivery_score` gains an optional `reference` parameter (omitted ⇒ falls back to `settings.EXPANSION_REALIZED_DEMAND_REFERENCE` at call time, so existing callers/tests are byte-identical). Both search-pipeline call sites pass `reference=_realized_demand_reference(service_model)`.
- `config.py` comment updated: the env var is now the FALLBACK for unanchored models.

**2. Delivery-leg radius made explicit — zero behavior change**
- The bulk delivery-count SQL now binds `settings.EXPANSION_REALIZED_DEMAND_RADIUS_M` (default 1200, value unchanged) instead of the literal `1200`; both delivery legs (listing count + realized Δrating_count) now explicitly share one catchment. Comment documents that (a) this deliberately overrides the pool-SQL count for ALL service models, and (b) the anchors above are calibrated to counts at THIS radius — re-anchor if it ever changes. Using the settings var (rather than a separate constant) is intentional coupling: changing the env moves both legs together, which is the desired semantics.

**3. Diagnostics + docs**
- `scripts/diagnostics/delivery_demand_legs_probe.sql` — section A reproduces the per-model p75 anchor derivation; section B is the post-deploy realized-leg score distribution check. (The original probe was run ad-hoc and never committed, so this file is new rather than extended.)
- `docs/investigations/weight_audit_6_findings.md` — new file (no prior in-repo audit log existed) recording the two-step deploy below.

## Two-step deploy (Ahmed executes)

1. **Merge + deploy this PR.** Re-anchor takes effect; realized scores drop off saturation. Validate with section B of the legs probe on fresh searches: realized_p50 should land in the ~75–90 band.
2. **Then:** `kubectl set env deployment/oaktree-estimator -n default EXPANSION_REALIZED_DEMAND_BLEND=0.7` — shifts the listing(supply)/realized blend from 0.5/0.5 to 0.3/0.7. Env-only; `_delivery_score` already reads the setting. Rationale: the listing leg is competitor supply (corr with provider_whitespace −0.94…−0.96 across models); realized rating-velocity is the demand-native signal. After step 2, re-run the probe and confirm the delivery-leg spread widens and corr(demand_score, competitor_count) does not increase. Do step 2 only after step 1 is verified.

## Out of scope (deliberately untouched)

Radius values / count semantics; the `delivery_competition_count = delivery_listing_count` double-booking; listing-leg-as-floor redesign; Items 1/3/4/5/6.

## Tests

- 3 new: `test_realized_demand_reference_per_service_model`, `test_delivery_score_explicit_reference` (exact pins: rd=327/ref=327 ⇒ 100; rd=216/ref=327 ⇒ 81.274; blended w=0.5 with listing-score 50 ⇒ 65.637), `test_bulk_delivery_radius_reads_settings_not_literal`.
- 3 existing `_delivery_score` tests pass **unchanged**.
- Full suite: **2306 passed, 24 skipped** (2303 + 3 new). flake8 violation count identical before/after.

⛔ **Do not merge without explicit approval from Ahmed.**

https://claude.ai/code/session_01KBJNxJ349sExz3j6KBcLFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBJNxJ349sExz3j6KBcLFZ)_