### PR TITLE
feat(expansion): engine-aware Demand Strength card inputs (PR-D)

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -9744,6 +9744,23 @@ def run_expansion_search(
             and service_model == "qsr"
         ):
             feature_snapshot_json["demand_score_source"] = _demand_score_source
+            # PR-D rider: persist the demand-blend transparency block alongside
+            # demand_score_source so the frontend Demand Strength card can show
+            # the delivery leg and the weights actually used. Display-only —
+            # never read by scoring. listing_realized_split reads the LIVE
+            # setting (repo default 0.5; production overrides via env), never a
+            # hardcoded constant.
+            _blend_pop_w, _blend_del_w = _demand_blend_weights(service_model)
+            feature_snapshot_json["demand_blend"] = {
+                "pop_or_index_weight": _blend_pop_w,
+                "delivery_weight": _blend_del_w,
+                "delivery_score": round(
+                    _safe_float(prepared_item["delivery_score"]), 2
+                ),
+                "listing_realized_split": float(
+                    settings.EXPANSION_REALIZED_DEMAND_BLEND
+                ),
+            }
         # Compute the two raw ages independently so the pill logic on the
         # frontend and in _top_positives_and_risks can decide "New" vs
         # "Updated" without relying on which timestamp won the GREATEST()

--- a/frontend/src/features/expansion-advisor/DecisionLogicCard.test.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionLogicCard.test.tsx
@@ -7,6 +7,7 @@ import en from "../../i18n/en.json";
 import ar from "../../i18n/ar.json";
 import DecisionLogicCard from "./DecisionLogicCard";
 import type {
+  CandidateFeatureSnapshot,
   CandidateGateReasons,
   CandidateScoreBreakdown,
   RerankReason,
@@ -652,5 +653,172 @@ describe("DecisionLogicCard i18n rendering", () => {
     expect(html).toContain(ar.expansionAdvisor.decisionLogicContributions);
     expect(html).toContain(ar.expansionAdvisor.decisionLogicRanking);
     expect(html).toContain(ar.expansionAdvisor.decisionLogicDeterministicOnly);
+  });
+});
+
+/* ─── 12. PR-D: engine-aware Demand Strength inputs ─────────────────────── */
+
+const LEGACY_DEMAND_INPUT_KEYS = [
+  "population_reach",
+  "realized_demand_30d",
+  "realized_demand_branches",
+  "radiance_growth_pct",
+] as const;
+
+const DG_DEMAND_INPUT_KEYS = [
+  "dg_composite",
+  "fnb_review_weighted_density",
+  "fnb_venue_count",
+  "osm_generators_total",
+  "building_floors_proxy_sum",
+  "population_local_reach",
+  "delivery_score",
+  "blend_weights",
+  "listing_realized_split",
+  "radius_m",
+  "weights_version",
+] as const;
+
+function dgFeatureSnapshot(overrides?: {
+  weights_version?: string;
+  demand_score_source?: string | undefined;
+  omit_fnb_density?: boolean;
+}): Record<string, unknown> {
+  const idx: Record<string, unknown> = {
+    composite_0_100: 61.45,
+    weights_version: overrides?.weights_version ?? "l1_v2_2026-06",
+    radius_m: 3500,
+    pop_radius_m: 1500,
+    population_reach: 180000,
+    population_local_reach: 42000,
+    osm_generators: {
+      offices: 12,
+      malls_retail: 3,
+      transit: 5,
+      mosques: 8,
+      schools: 4,
+      hospitals: 1,
+      hotels: 2,
+    },
+    building_floors_proxy_sum: 18234.5,
+    fnb_review_weighted_density: 98321.25,
+    fnb_venue_count: 57,
+  };
+  if (overrides?.omit_fnb_density) delete idx.fnb_review_weighted_density;
+  const fs: Record<string, unknown> = {
+    context_sources: {},
+    missing_context: [],
+    data_completeness_score: 80,
+    population_reach: 180000,
+    realized_demand_30d: 380,
+    realized_demand_branches: 6,
+    radiance_growth: { value_yoy_pct: 4.2 },
+    demand_generator_index: idx,
+    demand_blend: {
+      pop_or_index_weight: 0.75,
+      delivery_weight: 0.25,
+      delivery_score: 64.2,
+      listing_realized_split: 0.7,
+    },
+  };
+  if (overrides && "demand_score_source" in overrides) {
+    if (overrides.demand_score_source !== undefined) {
+      fs.demand_score_source = overrides.demand_score_source;
+    }
+  } else {
+    fs.demand_score_source = "dg_index";
+  }
+  return fs;
+}
+
+function renderWithSnapshot(fs: Record<string, unknown>): string {
+  return renderToStaticMarkup(
+    <DecisionLogicCard
+      gateReasons={productionGateReasons()}
+      scoreBreakdown={fullBreakdown()}
+      deterministicRank={1}
+      finalRank={1}
+      rerankStatus={"flag_off" as RerankStatus}
+      candidate={{ feature_snapshot_json: fs as CandidateFeatureSnapshot }}
+    />,
+  );
+}
+
+function inputValueFor(html: string, key: string): string | null {
+  const re = new RegExp(
+    `data-input="${key}"[\\s\\S]*?ea-decision-logic__component-input-value">([^<]*)<`,
+  );
+  const m = html.match(re);
+  return m ? m[1] : null;
+}
+
+describe("DecisionLogicCard PR-D — dg_index demand inputs (dine_in)", () => {
+  it("renders the dg input rows and none of the legacy demand rows", () => {
+    const html = renderWithSnapshot(dgFeatureSnapshot());
+    for (const key of DG_DEMAND_INPUT_KEYS) {
+      expect(html).toContain(`data-input="${key}"`);
+    }
+    for (const key of LEGACY_DEMAND_INPUT_KEYS) {
+      expect(html).not.toContain(`data-input="${key}"`);
+    }
+  });
+
+  it("renders the dg definition and resolved values", () => {
+    const html = renderWithSnapshot(dgFeatureSnapshot());
+    expect(html).toContain(
+      en.expansionAdvisor.scoreComponents.demand_potential.inputs.dg_composite.label,
+    );
+    expect(html).toContain("blended with realized delivery demand");
+    expect(html).not.toContain("nighttime-light growth trend");
+    expect(inputValueFor(html, "dg_composite")).toBe("61.45");
+    expect(inputValueFor(html, "osm_generators_total")).toBe("35");
+    expect(inputValueFor(html, "blend_weights")).toBe("0.75 / 0.25");
+    expect(inputValueFor(html, "delivery_score")).toBe("64.20");
+  });
+});
+
+describe("DecisionLogicCard PR-D — dg_index demand inputs (qsr)", () => {
+  it("renders the l1_v3 weights_version", () => {
+    const html = renderWithSnapshot(
+      dgFeatureSnapshot({ weights_version: "l1_v3_qsr_2026-06" }),
+    );
+    expect(inputValueFor(html, "weights_version")).toBe("l1_v3_qsr_2026-06");
+  });
+});
+
+describe("DecisionLogicCard PR-D — pop_score and legacy fallbacks", () => {
+  it("pop_score candidate (cafe) keeps the legacy rows byte-identical", () => {
+    const html = renderWithSnapshot(
+      dgFeatureSnapshot({ demand_score_source: "pop_score" }),
+    );
+    for (const key of LEGACY_DEMAND_INPUT_KEYS) {
+      expect(html).toContain(`data-input="${key}"`);
+    }
+    for (const key of DG_DEMAND_INPUT_KEYS) {
+      expect(html).not.toContain(`data-input="${key}"`);
+    }
+    expect(html).toContain(
+      en.expansionAdvisor.scoreComponents.demand_potential.inputs.population_reach.label,
+    );
+    expect(html).toContain("nighttime-light growth trend");
+    expect(html).not.toContain("blended with realized delivery demand");
+  });
+
+  it("absent demand_score_source (flags off / historical rows) → legacy rows", () => {
+    const html = renderWithSnapshot(
+      dgFeatureSnapshot({ demand_score_source: undefined }),
+    );
+    for (const key of LEGACY_DEMAND_INPUT_KEYS) {
+      expect(html).toContain(`data-input="${key}"`);
+    }
+    for (const key of DG_DEMAND_INPUT_KEYS) {
+      expect(html).not.toContain(`data-input="${key}"`);
+    }
+  });
+
+  it("missing dg sub-field renders an em-dash, not an error", () => {
+    const html = renderWithSnapshot(dgFeatureSnapshot({ omit_fnb_density: true }));
+    expect(inputValueFor(html, "fnb_review_weighted_density")).toBe("—");
+    expect(inputValueFor(html, "dg_composite")).toBe("61.45");
   });
 });

--- a/frontend/src/features/expansion-advisor/DecisionLogicCard.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionLogicCard.tsx
@@ -9,8 +9,10 @@ import type {
 } from "../../lib/api/expansionAdvisor";
 import { humanGateLabel } from "./formatHelpers";
 import {
+  DEMAND_DG_INPUTS,
   PER_COMPONENT_INPUTS,
   VIABILITY_LEG_ORDER,
+  isDgIndexDemand,
   type ResolvedInputValue,
   type SourceToken,
 } from "./scoreComponentMeta";
@@ -339,10 +341,23 @@ function ContributionsSection({
     const label = t(`expansionAdvisor.scoreComponents.${c.key}.label`, {
       defaultValue: c.key.replace(/_/g, " "),
     });
-    const definition = t(`expansionAdvisor.scoreComponents.${c.key}.definition`, {
-      defaultValue: "",
-    });
-    const descriptors = PER_COMPONENT_INPUTS[c.key] ?? [];
+    // Demand Strength is engine-aware: candidates whose demand component was
+    // scored off the L1 demand-generator composite (demand_score_source ===
+    // "dg_index") show the dg input set and its definition. A missing field
+    // or "pop_score" selects the legacy rows unchanged (cafe, delivery_first,
+    // flags-off environments, historical rows).
+    const dgDemand =
+      c.key === "demand_potential" &&
+      isDgIndexDemand(featureSnapshot as Record<string, unknown> | undefined);
+    const definition = t(
+      dgDemand
+        ? `expansionAdvisor.scoreComponents.${c.key}.definition_dg_index`
+        : `expansionAdvisor.scoreComponents.${c.key}.definition`,
+      { defaultValue: "" },
+    );
+    const descriptors = dgDemand
+      ? DEMAND_DG_INPUTS
+      : PER_COMPONENT_INPUTS[c.key] ?? [];
     const resolved = descriptors.map((d) => ({
       key: d.key,
       ...d.resolve({

--- a/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
+++ b/frontend/src/features/expansion-advisor/Pr4dI18n.test.tsx
@@ -346,3 +346,69 @@ describe("restartInLocale — persist + reload from the click site", () => {
     }
   });
 });
+
+/* ─── PR-D: dg_index Demand Strength keys — en/ar parity ─────────────── */
+
+describe("PR-D — dg_index demand keys exist in BOTH locales", () => {
+  const NEW_INPUT_KEYS = [
+    "dg_composite",
+    "fnb_review_weighted_density",
+    "fnb_venue_count",
+    "osm_generators_total",
+    "building_floors_proxy_sum",
+    "population_local_reach",
+    "delivery_score",
+    "blend_weights",
+    "listing_realized_split",
+    "radius_m",
+    "weights_version",
+  ] as const;
+
+  const NEW_SOURCE_TOKENS = ["fnb_reviews", "building_density"] as const;
+
+  function demandBlock(locale: typeof en | typeof ar) {
+    return (locale.expansionAdvisor.scoreComponents as Record<string, any>)
+      .demand_potential;
+  }
+
+  it("definition_dg_index is present and non-empty in en and ar", () => {
+    for (const locale of [en, ar]) {
+      const def = demandBlock(locale).definition_dg_index;
+      expect(typeof def).toBe("string");
+      expect(def.length).toBeGreaterThan(0);
+    }
+  });
+
+  for (const key of NEW_INPUT_KEYS) {
+    it(`inputs.${key}.label is present and non-empty in en and ar`, () => {
+      for (const locale of [en, ar]) {
+        const label = demandBlock(locale).inputs?.[key]?.label;
+        expect(typeof label).toBe("string");
+        expect(label.length).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  for (const token of NEW_SOURCE_TOKENS) {
+    it(`scoreSources.${token} is present and non-empty in en and ar`, () => {
+      for (const locale of [en, ar]) {
+        const label = (locale.expansionAdvisor.scoreSources as Record<string, string>)[
+          token
+        ];
+        expect(typeof label).toBe("string");
+        expect(label.length).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  it("ar labels are not byte-identical English leftovers", () => {
+    const arBlock = demandBlock(ar);
+    const enBlock = demandBlock(en);
+    expect(arBlock.definition_dg_index).not.toBe(enBlock.definition_dg_index);
+    for (const key of NEW_INPUT_KEYS) {
+      // weights_version values are version strings, but the LABELS must
+      // still be localized.
+      expect(arBlock.inputs[key].label).not.toBe(enBlock.inputs[key].label);
+    }
+  });
+});

--- a/frontend/src/features/expansion-advisor/scoreComponentMeta.test.ts
+++ b/frontend/src/features/expansion-advisor/scoreComponentMeta.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { PER_COMPONENT_INPUTS } from "./scoreComponentMeta";
+import {
+  DEMAND_DG_INPUTS,
+  PER_COMPONENT_INPUTS,
+  isDgIndexDemand,
+} from "./scoreComponentMeta";
 import type { ResolveCtx } from "./scoreComponentMeta";
 
 function ctx(overrides: Partial<ResolveCtx>): ResolveCtx {
@@ -67,5 +71,120 @@ describe("scoreComponentMeta — listing-derived source attributes to the candid
   it("attributes listing_quality has_image to aqar when platform is missing", () => {
     const out = hasImageInput.resolve(ctx({ candidate: { image_url: "https://example.com/x.jpg" } }));
     expect(out.source).toBe("aqar");
+  });
+});
+
+/* ─── PR-D: dg_index demand inputs ───────────────────────────────────────── */
+
+function dgSnapshot(): Record<string, unknown> {
+  return {
+    demand_score_source: "dg_index",
+    demand_generator_index: {
+      composite_0_100: 61.45,
+      weights_version: "l1_v2_2026-06",
+      radius_m: 3500,
+      population_reach: 180000,
+      pop_radius_m: 1500,
+      population_local_reach: 42000,
+      osm_generators: {
+        offices: 12,
+        malls_retail: 3,
+        transit: 5,
+        mosques: 8,
+        schools: 4,
+        hospitals: 1,
+        hotels: 2,
+      },
+      building_floors_proxy_sum: 18234.5,
+      fnb_review_weighted_density: 98321.25,
+      fnb_venue_count: 57,
+      subscores: {
+        population: 55.1,
+        osm_generators: 62.3,
+        building_floors: 48.7,
+        fnb_review_weighted: 70.2,
+      },
+    },
+    demand_blend: {
+      pop_or_index_weight: 0.75,
+      delivery_weight: 0.25,
+      delivery_score: 64.2,
+      listing_realized_split: 0.7,
+    },
+  };
+}
+
+function dgInput(key: string) {
+  return DEMAND_DG_INPUTS.find((d) => d.key === key)!;
+}
+
+describe("scoreComponentMeta — DEMAND_DG_INPUTS resolvers", () => {
+  it("resolves every descriptor from a full dg snapshot", () => {
+    const c = ctx({ featureSnapshot: dgSnapshot() });
+    expect(dgInput("dg_composite").resolve(c).value).toBe(61.45);
+    expect(dgInput("fnb_review_weighted_density").resolve(c).value).toBe(98321.25);
+    expect(dgInput("fnb_venue_count").resolve(c).value).toBe(57);
+    // osm_generators_total = sum of the seven per-kind counts.
+    expect(dgInput("osm_generators_total").resolve(c).value).toBe(35);
+    expect(dgInput("building_floors_proxy_sum").resolve(c).value).toBe(18234.5);
+    expect(dgInput("population_local_reach").resolve(c).value).toBe(42000);
+    expect(dgInput("delivery_score").resolve(c).value).toBe(64.2);
+    expect(dgInput("blend_weights").resolve(c).value).toBe("0.75 / 0.25");
+    expect(dgInput("listing_realized_split").resolve(c).value).toBe(0.7);
+    expect(dgInput("radius_m").resolve(c).value).toBe(3500);
+    expect(dgInput("weights_version").resolve(c).value).toBe("l1_v2_2026-06");
+  });
+
+  it("attributes sources per descriptor", () => {
+    const c = ctx({ featureSnapshot: dgSnapshot() });
+    expect(dgInput("dg_composite").resolve(c).source).toBe("oaktree_internal");
+    expect(dgInput("fnb_review_weighted_density").resolve(c).source).toBe("fnb_reviews");
+    expect(dgInput("fnb_venue_count").resolve(c).source).toBe("fnb_reviews");
+    expect(dgInput("osm_generators_total").resolve(c).source).toBe("osm");
+    expect(dgInput("building_floors_proxy_sum").resolve(c).source).toBe("building_density");
+    expect(dgInput("population_local_reach").resolve(c).source).toBe("population_grid");
+    expect(dgInput("delivery_score").resolve(c).source).toBe("expansion_delivery_market");
+  });
+
+  it("honors the delivery_source override for the delivery leg", () => {
+    const c = ctx({
+      featureSnapshot: dgSnapshot(),
+      contextSources: { delivery_source: "hungerstation" },
+    });
+    expect(dgInput("delivery_score").resolve(c).source).toBe("hungerstation");
+  });
+
+  it("resolves every descriptor to null when the dg blocks are absent", () => {
+    const c = ctx({ featureSnapshot: { demand_score_source: "dg_index" } });
+    for (const d of DEMAND_DG_INPUTS) {
+      expect(d.resolve(c).value).toBeNull();
+    }
+  });
+
+  it("resolves a partially-missing dg block field-by-field", () => {
+    const c = ctx({
+      featureSnapshot: {
+        demand_score_source: "dg_index",
+        demand_generator_index: { composite_0_100: 40.0 },
+      },
+    });
+    expect(dgInput("dg_composite").resolve(c).value).toBe(40.0);
+    expect(dgInput("fnb_review_weighted_density").resolve(c).value).toBeNull();
+    expect(dgInput("osm_generators_total").resolve(c).value).toBeNull();
+    // demand_blend absent (pre-rider dg_index rows) → delivery rows null.
+    expect(dgInput("delivery_score").resolve(c).value).toBeNull();
+    expect(dgInput("blend_weights").resolve(c).value).toBeNull();
+  });
+});
+
+describe("scoreComponentMeta — isDgIndexDemand engine selector", () => {
+  it("is true only for demand_score_source === 'dg_index'", () => {
+    expect(isDgIndexDemand({ demand_score_source: "dg_index" })).toBe(true);
+    expect(isDgIndexDemand({ demand_score_source: "pop_score" })).toBe(false);
+  });
+
+  it("treats absence as pop_score — never an error", () => {
+    expect(isDgIndexDemand({})).toBe(false);
+    expect(isDgIndexDemand(undefined)).toBe(false);
   });
 });

--- a/frontend/src/features/expansion-advisor/scoreComponentMeta.ts
+++ b/frontend/src/features/expansion-advisor/scoreComponentMeta.ts
@@ -29,7 +29,9 @@ export type SourceToken =
   | "oaktree_internal"
   | "expansion_road_context"
   | "expansion_parking_asset"
-  | "expansion_delivery_market";
+  | "expansion_delivery_market"
+  | "fnb_reviews"
+  | "building_density";
 
 export type ResolvedInputValue = string | number | boolean | null;
 
@@ -487,6 +489,140 @@ export const PER_COMPONENT_INPUTS: Record<string, InputDescriptor[]> = {
     },
   ],
 };
+
+/* ─── Demand Strength — dg_index engine inputs ───────────────────────────── */
+
+// Alternate input set for the demand_potential component, used when the
+// backend scored the demand leg off the L1 demand-generator composite
+// (feature_snapshot_json.demand_score_source === "dg_index"). All paths read
+// the persisted feature_snapshot_json.demand_generator_index block (emitted
+// by app/services/expansion_advisor.py:_demand_generator_index) plus the
+// demand_blend transparency block. Absence of any field resolves to null and
+// renders as an em-dash, matching the legacy rows — dg_index candidates from
+// before the demand_blend rider simply skip those values.
+export const DEMAND_DG_INPUTS: InputDescriptor[] = [
+  {
+    key: "dg_composite",
+    resolve: ({ featureSnapshot }) => ({
+      value: asNumber(
+        readNested(featureSnapshot, "demand_generator_index", "composite_0_100"),
+      ),
+      source: "oaktree_internal",
+    }),
+  },
+  {
+    key: "fnb_review_weighted_density",
+    resolve: ({ featureSnapshot }) => ({
+      value: asNumber(
+        readNested(featureSnapshot, "demand_generator_index", "fnb_review_weighted_density"),
+      ),
+      source: "fnb_reviews",
+    }),
+  },
+  {
+    key: "fnb_venue_count",
+    resolve: ({ featureSnapshot }) => ({
+      value: asNumber(
+        readNested(featureSnapshot, "demand_generator_index", "fnb_venue_count"),
+      ),
+      source: "fnb_reviews",
+    }),
+  },
+  {
+    key: "osm_generators_total",
+    resolve: ({ featureSnapshot }) => {
+      const kinds = readNested(featureSnapshot, "demand_generator_index", "osm_generators");
+      if (!kinds || typeof kinds !== "object" || Array.isArray(kinds)) {
+        return { value: null, source: "osm" };
+      }
+      let total = 0;
+      let seen = false;
+      for (const v of Object.values(kinds as Record<string, unknown>)) {
+        const n = asNumber(v);
+        if (n != null) {
+          total += n;
+          seen = true;
+        }
+      }
+      return { value: seen ? total : null, source: "osm" };
+    },
+  },
+  {
+    key: "building_floors_proxy_sum",
+    resolve: ({ featureSnapshot }) => ({
+      value: asNumber(
+        readNested(featureSnapshot, "demand_generator_index", "building_floors_proxy_sum"),
+      ),
+      source: "building_density",
+    }),
+  },
+  {
+    key: "population_local_reach",
+    resolve: ({ featureSnapshot }) => ({
+      value: asNumber(
+        readNested(featureSnapshot, "demand_generator_index", "population_local_reach"),
+      ),
+      source: "population_grid",
+    }),
+  },
+  {
+    key: "delivery_score",
+    resolve: ({ featureSnapshot, contextSources }) => ({
+      value: asNumber(readNested(featureSnapshot, "demand_blend", "delivery_score")),
+      source: overrideSource(contextSources, "delivery_source", "expansion_delivery_market"),
+    }),
+  },
+  {
+    key: "blend_weights",
+    resolve: ({ featureSnapshot }) => {
+      const popW = asNumber(
+        readNested(featureSnapshot, "demand_blend", "pop_or_index_weight"),
+      );
+      const delW = asNumber(readNested(featureSnapshot, "demand_blend", "delivery_weight"));
+      return {
+        value: popW != null && delW != null ? `${popW} / ${delW}` : null,
+        source: "oaktree_internal",
+      };
+    },
+  },
+  {
+    key: "listing_realized_split",
+    resolve: ({ featureSnapshot }) => ({
+      value: asNumber(
+        readNested(featureSnapshot, "demand_blend", "listing_realized_split"),
+      ),
+      source: "oaktree_internal",
+    }),
+  },
+  {
+    key: "radius_m",
+    resolve: ({ featureSnapshot }) => ({
+      value: asNumber(readNested(featureSnapshot, "demand_generator_index", "radius_m")),
+      source: "oaktree_internal",
+    }),
+  },
+  {
+    key: "weights_version",
+    resolve: ({ featureSnapshot }) => ({
+      value: asString(
+        readNested(featureSnapshot, "demand_generator_index", "weights_version"),
+      ),
+      source: "oaktree_internal",
+    }),
+  },
+];
+
+/**
+ * True when this candidate's demand component was scored off the L1
+ * demand-generator composite. Absence of demand_score_source (flags off,
+ * historical rows) or "pop_score" both select the legacy input rows —
+ * absence is NEVER an error.
+ */
+export function isDgIndexDemand(
+  featureSnapshot: Record<string, unknown> | undefined,
+): boolean {
+  return readNested(featureSnapshot, "demand_score_source") === "dg_index";
+}
 
 /* ─── Canonical viability legs (stable order, matches backend) ───────────── */
 

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -1252,11 +1252,23 @@
       "demand_potential": {
         "label": "قوة الطلب",
         "definition": "أدلة الطلب المركبة: السكان ضمن نطاق المشي/القيادة، الطلب الفعلي للتوصيل خلال 30 يومًا، واتجاه نمو إضاءة الحي ليلًا.",
+        "definition_dg_index": "مؤشر مولدات الطلب: مركب من كتلة تقييمات المطاعم والمقاهي، ومولدات الرحلات، والكثافة العمرانية، والسكان المحليين — يقاس عند نطاق النموذج ويُمزج مع الطلب الفعلي للتوصيل.",
         "inputs": {
           "population_reach": { "label": "نطاق السكان" },
           "realized_demand_30d": { "label": "سرعة تقييمات التوصيل (30 يومًا)" },
           "realized_demand_branches": { "label": "الفروع المساهمة بالتقييمات" },
-          "radiance_growth_pct": { "label": "نمو الإضاءة سنويًا (٪)" }
+          "radiance_growth_pct": { "label": "نمو الإضاءة سنويًا (٪)" },
+          "dg_composite": { "label": "مركب مولدات الطلب (0–100)" },
+          "fnb_review_weighted_density": { "label": "كتلة تقييمات المطاعم والمقاهي (موزونة)" },
+          "fnb_venue_count": { "label": "منشآت المطاعم والمقاهي ضمن النطاق" },
+          "osm_generators_total": { "label": "مولدات الرحلات (عدد OSM)" },
+          "building_floors_proxy_sum": { "label": "الكثافة العمرانية (مؤشر الطوابق)" },
+          "population_local_reach": { "label": "نطاق السكان المحلي" },
+          "delivery_score": { "label": "درجة جزء التوصيل" },
+          "blend_weights": { "label": "أوزان المزج (المؤشر / التوصيل)" },
+          "listing_realized_split": { "label": "حصة الطلب الفعلي في جزء التوصيل" },
+          "radius_m": { "label": "نصف قطر النطاق (م)" },
+          "weights_version": { "label": "إصدار أوزان المؤشر" }
         }
       },
       "access_visibility": {
@@ -1314,7 +1326,9 @@
       "oaktree_internal": "Oaktree الداخلي",
       "expansion_road_context": "سياق الطرق",
       "expansion_parking_asset": "أصول المواقف",
-      "expansion_delivery_market": "سوق التوصيل"
+      "expansion_delivery_market": "سوق التوصيل",
+      "fnb_reviews": "بيانات تقييمات المطاعم والمقاهي",
+      "building_density": "بيانات الكثافة العمرانية"
     },
     "bonuses": {
       "bestValue": "أفضل قيمة",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1272,11 +1272,23 @@
       "demand_potential": {
         "label": "Demand Strength",
         "definition": "Combined demand evidence: population reach within a walking/driving catchment, realized 30-day delivery demand, and the district's nighttime-light growth trend.",
+        "definition_dg_index": "Demand-generator index: a composite of F&B review mass, trip generators, built density, and local population — measured at the model's catchment radius and blended with realized delivery demand.",
         "inputs": {
           "population_reach": { "label": "Population reach" },
           "realized_demand_30d": { "label": "Delivery rating velocity (30d)" },
           "realized_demand_branches": { "label": "Rating-contributing branches" },
-          "radiance_growth_pct": { "label": "Radiance YoY growth (%)" }
+          "radiance_growth_pct": { "label": "Radiance YoY growth (%)" },
+          "dg_composite": { "label": "Demand-generator composite (0–100)" },
+          "fnb_review_weighted_density": { "label": "F&B review mass (weighted)" },
+          "fnb_venue_count": { "label": "F&B venues in catchment" },
+          "osm_generators_total": { "label": "Trip generators (OSM count)" },
+          "building_floors_proxy_sum": { "label": "Built density (floors proxy)" },
+          "population_local_reach": { "label": "Local population reach" },
+          "delivery_score": { "label": "Delivery leg score" },
+          "blend_weights": { "label": "Blend weights (index / delivery)" },
+          "listing_realized_split": { "label": "Delivery leg realized share" },
+          "radius_m": { "label": "Catchment radius (m)" },
+          "weights_version": { "label": "Index weights version" }
         }
       },
       "access_visibility": {
@@ -1334,7 +1346,9 @@
       "oaktree_internal": "Oaktree internal",
       "expansion_road_context": "Expansion road context",
       "expansion_parking_asset": "Expansion parking asset",
-      "expansion_delivery_market": "Expansion delivery market"
+      "expansion_delivery_market": "Expansion delivery market",
+      "fnb_reviews": "F&B review data",
+      "building_density": "Building footprint data"
     },
     "bonuses": {
       "bestValue": "Best Value",

--- a/tests/test_expansion_advisor_demand_generator.py
+++ b/tests/test_expansion_advisor_demand_generator.py
@@ -673,3 +673,95 @@ def test_qsr_flag_does_not_touch_other_models(
         for it in on:
             fs = it.get("feature_snapshot_json") or {}
             assert "demand_score_source" not in fs
+
+
+# ---------------------------------------------------------------------------
+# PR-D rider — demand_blend transparency emit (display-only)
+# ---------------------------------------------------------------------------
+
+
+def test_demand_blend_emitted_alongside_demand_score_source(
+    disable_market_viability_floors, monkeypatch
+):
+    """When the dine-in scoring flag is on, every candidate that gets
+    demand_score_source also gets the demand_blend transparency block with the
+    service model's blend weights, the pass-1 delivery leg score, and the
+    LIVE listing/realized split setting."""
+    monkeypatch.setattr(
+        expansion_service.settings,
+        "EXPANSION_REALIZED_DEMAND_BLEND",
+        0.7,
+        raising=False,
+    )
+    items = _run_flags(monkeypatch, index=True, scoring=True)
+    assert items
+    for it in items:
+        fs = it.get("feature_snapshot_json") or {}
+        assert fs.get("demand_score_source") == "dg_index"
+        blend = fs.get("demand_blend")
+        assert blend is not None
+        assert set(blend) == {
+            "pop_or_index_weight",
+            "delivery_weight",
+            "delivery_score",
+            "listing_realized_split",
+        }
+        # dine_in blend weights from _demand_blend_weights.
+        assert blend["pop_or_index_weight"] == 0.75
+        assert blend["delivery_weight"] == 0.25
+        assert 0.0 <= blend["delivery_score"] <= 100.0
+        # Reads the LIVE setting (monkeypatched here), never a hardcoded value.
+        assert blend["listing_realized_split"] == 0.7
+
+
+def test_demand_blend_follows_live_split_setting(
+    disable_market_viability_floors, monkeypatch
+):
+    """The emitted listing_realized_split tracks the live
+    EXPANSION_REALIZED_DEMAND_BLEND — change the setting, the snapshot
+    follows."""
+    monkeypatch.setattr(
+        expansion_service.settings,
+        "EXPANSION_REALIZED_DEMAND_BLEND",
+        0.3,
+        raising=False,
+    )
+    items = _run_flags(monkeypatch, index=True, scoring=True)
+    assert items
+    for it in items:
+        fs = it.get("feature_snapshot_json") or {}
+        assert fs["demand_blend"]["listing_realized_split"] == 0.3
+
+
+def test_demand_blend_qsr_weights(
+    disable_market_viability_floors, monkeypatch
+):
+    """QSR path emits the qsr blend weights (0.60 / 0.40)."""
+    items = _run_flags(
+        monkeypatch,
+        index=True,
+        scoring=False,
+        scoring_qsr=True,
+        service_model="qsr",
+    )
+    assert items
+    for it in items:
+        fs = it.get("feature_snapshot_json") or {}
+        assert fs.get("demand_score_source") == "dg_index"
+        blend = fs.get("demand_blend")
+        assert blend is not None
+        assert blend["pop_or_index_weight"] == 0.60
+        assert blend["delivery_weight"] == 0.40
+
+
+def test_demand_blend_absent_when_scoring_flags_off(
+    disable_market_viability_floors, monkeypatch
+):
+    """Scoring flags off → no demand_blend key (snapshot byte-for-byte
+    unchanged, matching the demand_score_source contract)."""
+    items = _run_flags(monkeypatch, index=True, scoring=False)
+    assert items
+    for it in items:
+        fs = it.get("feature_snapshot_json") or {}
+        assert "demand_blend" not in fs
+        assert "demand_score_source" not in fs


### PR DESCRIPTION
Frontend: when feature_snapshot_json.demand_score_source == "dg_index",
the Demand Strength breakdown shows the L1 demand-generator inputs
(composite, F&B review mass, trip generators, built density, local
population, delivery leg + blend weights, radius, weights version) and an
engine-specific definition; absence of the field or "pop_score" keeps the
legacy rows byte-identical. New labels ship in both locales, with two new
source tokens (fnb_reviews, building_density).

Backend rider: persist feature_snapshot_json.demand_blend (blend weights,
pass-1 delivery_score, live EXPANSION_REALIZED_DEMAND_BLEND) next to the
demand_score_source emit. Display-only; never read by scoring.

Per docs/investigations/demand_ui_memo_investigation.md §D PR-D.

https://claude.ai/code/session_01EFDdCpwdAtiswTSrvhzQ98