### PR TITLE
feat(memo): v12.1 enforce dg-index composite evidence row (PR-E2)

### DIFF
--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -50,7 +50,7 @@ TEMPERATURE = 0.3
 # Bumped whenever STRUCTURED_MEMO_SYSTEM_PROMPT changes meaningfully.
 # Cached memos with a different version are treated as cache-miss and
 # regenerated lazily on next view.
-MEMO_PROMPT_VERSION = "v12-demand-engine-evidence-2026-06"
+MEMO_PROMPT_VERSION = "v12.1-demand-evidence-enforced-2026-06"
 
 # Soft daily ceiling in USD.  Raises RuntimeError before calling OpenAI
 # if the running total for today exceeds this value.
@@ -2658,6 +2658,201 @@ def _corrective_retry_preamble(locale: str, reason: str) -> str:
     return template.format(reason=reason)
 
 
+# ── v12.1 (PR-E2) — dg-index composite evidence enforcement ─────────
+#
+# Two production v12 regenerations on confirmed dg_index candidates produced
+# key_evidence with no demand-generator composite row despite the prompt
+# mandate (Market-context block + the Example C inline note). v12.1 makes
+# the mandate bind with two layers riding the existing machinery:
+#   1. a soft validity check feeding the one-retry corrective loop;
+#   2. a deterministic server-side injection when the retry still lacks the
+#      row, so the composite always reaches persistence for dg_index
+#      candidates.
+
+# Rule-7 signal terms, reused verbatim from the v12 prompt vocabulary.
+_DG_COMPOSITE_SIGNAL_EN = "demand-generator composite"
+_DG_COMPOSITE_SIGNAL_AR = "مركب مولدات الطلب"
+
+# Injected-row implication templates. One template per locale, phrased as
+# engine attribution so it stays truthful at any composite value (the
+# value field carries the magnitude); polarity is banded below so the
+# polarity-discipline rule holds without LLM involvement. Latin digits
+# only (Rule 8 — the value string is "<N>/100" in both locales).
+_DG_INJECTED_IMPLICATION_EN = (
+    "venue activity and trip generators are the measured demand evidence "
+    "for this catchment; population reach is supporting context only"
+)
+# AR gloss: same sentence — "venue activity and trip generators are the
+# measured demand evidence for this catchment; population reach is
+# supporting context only". Reuses the Rule-7 terms مولدات الرحلات and
+# عدد السكان القابلين للوصول verbatim.
+_DG_INJECTED_IMPLICATION_AR = (
+    "نشاط المرافق ومولدات الرحلات هما دليل الطلب المقاس لهذا النطاق؛ "
+    "عدد السكان القابلين للوصول سياق داعم فقط"
+)
+
+
+def _dg_required_composite(feature_snapshot: Any) -> int | None:
+    """Return the rounded demand-generator composite when the v12.1
+    dg-evidence mandate applies to this candidate, else None.
+
+    The mandate applies only when the snapshot says Demand Strength was
+    scored by the dg_index engine AND demand_generator_index carries a
+    numeric composite_0_100. Absent or malformed blocks return None
+    (defensive: both enforcement layers are skipped)."""
+    if not isinstance(feature_snapshot, dict):
+        return None
+    if feature_snapshot.get("demand_score_source") != "dg_index":
+        return None
+    block = feature_snapshot.get("demand_generator_index")
+    if not isinstance(block, dict):
+        return None
+    composite = block.get("composite_0_100")
+    if isinstance(composite, bool) or not isinstance(composite, (int, float)):
+        return None
+    return int(round(composite))
+
+
+def _dg_evidence_invalid_reason(
+    parsed: dict[str, Any], composite_rounded: int
+) -> str | None:
+    """Return a short reason string when no key_evidence row in ``parsed``
+    references the demand-generator composite; None when compliant.
+
+    A row matches when its signal or value mentions the EN signal phrase,
+    the AR Rule-7 term, or a "/100" value equal to the rounded composite."""
+    needles = (
+        _DG_COMPOSITE_SIGNAL_EN,
+        _DG_COMPOSITE_SIGNAL_AR,
+        f"{composite_rounded}/100",
+    )
+    rows = parsed.get("key_evidence")
+    if isinstance(rows, list):
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            haystack = (
+                f"{row.get('signal') or ''} {row.get('value') or ''}".lower()
+            )
+            if any(n.lower() in haystack for n in needles):
+                return None
+    return (
+        "demand_score_source is dg_index but key_evidence has no "
+        "demand-generator composite row"
+    )
+
+
+def _dg_required_evidence_row(
+    composite_rounded: int, locale: str
+) -> dict[str, Any]:
+    """Build the locale-correct composite evidence row.
+
+    Used verbatim in the corrective preamble (so the LLM sees the exact
+    required shape with this candidate's value filled in) and as the base
+    of the deterministic injection. Polarity is banded on the composite so
+    implication and polarity never contradict the rendered value."""
+    if composite_rounded >= 60:
+        polarity = "positive"
+    elif composite_rounded >= 40:
+        polarity = "neutral"
+    else:
+        polarity = "negative"
+    is_ar = locale == "ar"
+    return {
+        "signal": (
+            _DG_COMPOSITE_SIGNAL_AR if is_ar else _DG_COMPOSITE_SIGNAL_EN
+        ),
+        "value": f"{composite_rounded}/100",
+        "implication": (
+            _DG_INJECTED_IMPLICATION_AR if is_ar
+            else _DG_INJECTED_IMPLICATION_EN
+        ),
+        "polarity": polarity,
+    }
+
+
+def _inject_dg_evidence_row(
+    parsed: dict[str, Any], *, composite_rounded: int, locale: str
+) -> bool:
+    """Deterministically insert the composite row into ``parsed`` when it
+    is still missing after the corrective retry. Returns True when a row
+    was injected.
+
+    Position 2 (index 1, after the rent anchor): the frontend narrative
+    renders only the top 4 key_evidence rows (DecisionMemoNarrative.tsx
+    slices to 4), so the row must sit inside that window. Idempotent — a
+    memo that already matches the detector is left untouched. An empty
+    key_evidence list only occurs on the headline local-rewrite null-out
+    path, where the body is intentionally cleared; injecting a lone row
+    there would undo the null-out invariant, so it is skipped."""
+    rows = parsed.get("key_evidence")
+    if not isinstance(rows, list) or not rows:
+        return False
+    if _dg_evidence_invalid_reason(parsed, composite_rounded) is None:
+        return False
+    row = _dg_required_evidence_row(composite_rounded, locale)
+    # Internal marker — harmless to consumers: the frontend reads only
+    # signal/value/implication/polarity and the text renderer reads
+    # signal/value/implication.
+    row["source"] = "deterministic_injection"
+    rows.insert(1, row)
+    return True
+
+
+# dg-evidence corrective preamble. Same loop semantics as the headline
+# preamble: ``{reason}`` and ``{row_json}`` are substituted via .format()
+# on the template only, so braces inside the JSON row are inserted
+# verbatim without being parsed.
+_DG_CORRECTIVE_RETRY_PREAMBLE_EN = (
+    "PREVIOUS RESPONSE WAS REJECTED. Reason: {reason}.\n\n"
+    "feature_snapshot.demand_score_source == \"dg_index\" for this "
+    "candidate, so the demand evidence MUST cite the demand-generator "
+    "composite. key_evidence MUST include this row (copy signal and value "
+    "exactly; you may sharpen the implication):\n"
+    "{row_json}\n\n"
+    "Population reach is supporting context only — it MUST NOT be "
+    "presented as the demand anchor in key_evidence or in body prose. "
+    "Re-emit the full structured memo."
+)
+
+# Arabic dg-evidence corrective preamble. Inline ``#`` glosses give the
+# English meaning of each line for review.
+_DG_CORRECTIVE_RETRY_PREAMBLE_AR = (
+    # "PREVIOUS RESPONSE WAS REJECTED. Reason: {reason}."
+    "تم رفض الاستجابة السابقة. السبب: {reason}.\n\n"
+    # "demand_score_source == "dg_index" for this candidate, so the demand
+    #  evidence MUST cite the demand-generator composite."
+    "feature_snapshot.demand_score_source == \"dg_index\" لهذا المرشح، "
+    "لذا يجب أن تستشهد أدلة الطلب بمركب مولدات الطلب. "
+    # "key_evidence MUST include this row (copy signal and value exactly;
+    #  you may sharpen the implication):"
+    "يجب أن يتضمن key_evidence هذا الصف (انسخ signal و value كما هما؛ "
+    "يمكنك تحسين صياغة implication):\n"
+    "{row_json}\n\n"
+    # "Population reach is supporting context only — it MUST NOT be the
+    #  demand anchor in key_evidence or in body prose. Re-emit the full
+    #  structured memo."
+    "عدد السكان القابلين للوصول سياق داعم فقط — يجب ألا يُقدَّم كمرتكز "
+    "الطلب في key_evidence ولا في نص المذكرة. أعد إصدار المذكرة المنظمة "
+    "كاملة."
+)
+
+
+def _dg_corrective_retry_preamble(
+    locale: str, reason: str, required_row: dict[str, Any]
+) -> str:
+    """Build the dg-evidence retry preamble for ``locale``, embedding the
+    exact required row (with this candidate's composite value) as JSON."""
+    template = (
+        _DG_CORRECTIVE_RETRY_PREAMBLE_AR if locale == "ar"
+        else _DG_CORRECTIVE_RETRY_PREAMBLE_EN
+    )
+    return template.format(
+        reason=reason,
+        row_json=json.dumps(required_row, ensure_ascii=False),
+    )
+
+
 def generate_structured_memo(ctx: MemoContext) -> dict | None:
     """Call the LLM for a structured memo, or return None on any failure.
 
@@ -2733,24 +2928,51 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
         locale=ctx.locale,
     )
 
+    # v12.1 dg-evidence mandate — applies only when the snapshot says the
+    # dg_index engine scored Demand Strength AND the composite is present.
+    dg_composite = _dg_required_composite(ctx.feature_snapshot)
+    dg_reason = (
+        _dg_evidence_invalid_reason(parsed, dg_composite)
+        if dg_composite is not None
+        else None
+    )
+
     usage = getattr(response, "usage", None)
     input_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
     output_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
 
-    if headline_reason is not None:
-        logger.warning(
-            "Structured memo headline rejected for %s: %s | headline=%r",
-            ctx.candidate_id,
-            headline_reason,
-            parsed.get("headline_recommendation"),
-        )
+    if headline_reason is not None or dg_reason is not None:
+        if headline_reason is not None:
+            logger.warning(
+                "Structured memo headline rejected for %s: %s | headline=%r",
+                ctx.candidate_id,
+                headline_reason,
+                parsed.get("headline_recommendation"),
+            )
+        if dg_reason is not None:
+            logger.warning(
+                "Structured memo dg-evidence rejected for %s: %s",
+                ctx.candidate_id,
+                dg_reason,
+            )
+        preamble_parts: list[str] = []
+        if headline_reason is not None:
+            preamble_parts.append(
+                _corrective_retry_preamble(ctx.locale, headline_reason)
+            )
+        if dg_reason is not None:
+            preamble_parts.append(
+                _dg_corrective_retry_preamble(
+                    ctx.locale,
+                    dg_reason,
+                    _dg_required_evidence_row(dg_composite, ctx.locale),
+                )
+            )
         retry_messages = [
             messages[0],
             {
                 "role": "user",
-                "content": _corrective_retry_preamble(
-                    ctx.locale, headline_reason
-                ),
+                "content": "\n\n".join(preamble_parts),
             },
             messages[1],
         ]
@@ -2784,6 +3006,11 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
                     deterministic_verdict=ctx.deterministic_verdict,
                     locale=ctx.locale,
                 )
+                retry_dg_reason = (
+                    _dg_evidence_invalid_reason(retry_parsed, dg_composite)
+                    if dg_composite is not None
+                    else None
+                )
                 retry_usage = getattr(retry_response, "usage", None)
                 input_tokens += int(
                     getattr(retry_usage, "prompt_tokens", 0) or 0
@@ -2791,9 +3018,20 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
                 output_tokens += int(
                     getattr(retry_usage, "completion_tokens", 0) or 0
                 )
-                if retry_reason is None:
+                if headline_reason is None and retry_reason is not None:
+                    # dg-only retry whose headline regressed: keep the
+                    # first response (its headline already passed) and
+                    # fall through to the deterministic injection below.
+                    logger.warning(
+                        "Structured memo dg retry produced an invalid "
+                        "headline for %s: %s — keeping first response",
+                        ctx.candidate_id,
+                        retry_reason,
+                    )
+                elif retry_reason is None:
                     parsed = retry_parsed
                     headline_reason = None
+                    dg_reason = retry_dg_reason
                 else:
                     logger.error(
                         "Structured memo retry headline still invalid for "
@@ -2804,6 +3042,7 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
                     )
                     # Use the retry's body but rewrite the headline locally.
                     parsed = retry_parsed
+                    dg_reason = retry_dg_reason
 
         if headline_reason is not None:
             rewritten = _rewrite_headline_locally(
@@ -2833,6 +3072,21 @@ def generate_structured_memo(ctx: MemoContext) -> dict | None:
             parsed["risks"] = []
             parsed["comparison"] = ""
             parsed["bottom_line"] = ""
+
+    # v12.1 layer 2 — deterministic fallback. If the corrective retry still
+    # lacks the composite row, inject it server-side before the caller
+    # persists the memo (no-op when the headline null-out emptied the body).
+    if dg_reason is not None and dg_composite is not None:
+        if _inject_dg_evidence_row(
+            parsed, composite_rounded=dg_composite, locale=ctx.locale
+        ):
+            logger.warning(
+                "Structured memo dg composite row deterministically "
+                "injected for %s (composite=%d/100, locale=%s)",
+                ctx.candidate_id,
+                dg_composite,
+                ctx.locale,
+            )
 
     cost = _record_cost(input_tokens, output_tokens)
 

--- a/docs/pr-e2-memo-v12-1-dg-evidence-enforcement-report.md
+++ b/docs/pr-e2-memo-v12-1-dg-evidence-enforcement-report.md
@@ -1,0 +1,184 @@
+# PATCH PR-E2 — Memo v12.1: dg-index composite evidence enforcement
+
+**Branch:** `claude/memo-v12-1-dg-index-composite-mq0suo` · **Commit:** `55dda77c0` · **Status:** pushed, no PR, no merge — awaiting Ahmed's review.
+
+## 1. What was wrong
+
+Two production v12 regenerations on confirmed `dg_index` candidates produced
+`key_evidence` with **no demand-generator composite row** (rows were rent /
+rent percentile / access / realized demand; body prose still used population
+reach as demand support). The v12 prompt mandate (Market-context block + the
+Example C inline caveat) is insufficient on its own. The PR-E observation
+held: the deterministic pre-rendered rent phrase (copy-verbatim) complied on
+both samples — **deterministic beats mandate**.
+
+## 2. The fix — two layers, both on existing machinery
+
+Both layers ride the existing one-retry corrective loop in
+`generate_structured_memo`. No validator shape-keys, rent logic, or
+whitelist entries were touched; all Rule 7/8 vocabulary is reused verbatim.
+
+### Layer 1 — soft validation + one corrective retry
+
+Applies only when `feature_snapshot.demand_score_source == "dg_index"` AND
+`demand_generator_index.composite_0_100` is numeric (absent/malformed block
+→ both layers skip, defensively).
+
+A memo is **compliant** when any `key_evidence` row's signal or value
+mentions:
+
+- the EN signal phrase `demand-generator composite`, or
+- the AR Rule-7 term `مركب مولدات الطلب`, or
+- a `/100` value equal to the rounded composite (e.g. `74/100`).
+
+A miss triggers the existing single retry. The new corrective preamble
+(EN + AR variants, same `.format()` semantics as the headline preamble):
+
+1. restates the dg_index mandate,
+2. embeds the **exact required row as JSON with this candidate's composite
+   value filled in** ("copy signal and value exactly; you may sharpen the
+   implication"),
+3. instructs that population reach is supporting context only and MUST NOT
+   be presented as the demand anchor in `key_evidence` or body prose.
+
+If the headline check failed on the same response, both corrective
+preambles are concatenated into the one retry turn (existing one-retry
+semantics preserved).
+
+### Layer 2 — deterministic injection fallback
+
+If the retry still lacks the row, it is injected server-side into the memo
+JSON before persistence:
+
+- **Position 2 (index 1), after the rent anchor.** Verified
+  `DecisionMemoNarrative.tsx` renders `key_evidence.slice(0, 4)` — position
+  2 sits inside the top-4 render window.
+- **Marker field** `"source": "deterministic_injection"` — confirmed
+  harmless: the frontend reads only signal/value/implication/polarity,
+  `isValidStructuredMemo` tolerates extra keys, persistence is raw JSONB,
+  and the legacy text renderer reads signal/value/implication only.
+- **Idempotent** — re-running the detector before insert means it never
+  double-injects.
+- **Skips** when the dg block is absent, and skips the headline
+  local-rewrite null-out path (empty `key_evidence` only occurs there;
+  injecting a lone row would undo the null-out invariant).
+- **Polarity is banded** on the composite so implication and polarity never
+  contradict the rendered value: ≥ 60 → `positive`, 40–59 → `neutral`,
+  < 40 → `negative`.
+
+**Edge case handled:** a dg-only retry whose headline *regresses* (first
+response had a valid headline, retry doesn't) keeps the first response and
+falls through to deterministic injection — the retry can never make the
+memo worse.
+
+## 3. Exact injected row text (composite 74 example)
+
+**EN:**
+
+```json
+{"signal": "demand-generator composite", "value": "74/100", "implication": "venue activity and trip generators are the measured demand evidence for this catchment; population reach is supporting context only", "polarity": "positive", "source": "deterministic_injection"}
+```
+
+**AR** (Latin digits per Rule 8; implication reuses the Rule-7 terms
+مولدات الرحلات and عدد السكان القابلين للوصول):
+
+```json
+{"signal": "مركب مولدات الطلب", "value": "74/100", "implication": "نشاط المرافق ومولدات الرحلات هما دليل الطلب المقاس لهذا النطاق؛ عدد السكان القابلين للوصول سياق داعم فقط", "polarity": "positive", "source": "deterministic_injection"}
+```
+
+The implication template is identical across polarity bands (engine
+attribution, truthful at any value — the `value` field carries the
+magnitude); only the `polarity` field varies.
+
+## 4. Version
+
+`MEMO_PROMPT_VERSION` bumped `v12-demand-engine-evidence-2026-06` →
+`v12.1-demand-evidence-enforced-2026-06` (`llm_decision_memo.py:53`). The
+two non-compliant memos are cached at v12; the mismatch regenerates them on
+next view. **System prompt text is unchanged**, so the pinned prompt-head
+fixture `tests/data/pr4a_structured_memo_system_prompt_en_head.txt` needed
+no regeneration — the byte-identity test still passes.
+
+## 5. Diff stat
+
+```
+app/services/llm_decision_memo.py | 276 ++++++++++++++++++++++++++--
+tests/test_llm_decision_memo.py   | 378 ++++++++++++++++++++++++++++++++++++++
+2 files changed, 644 insertions(+), 12 deletions(-)
+```
+
+## 6. path:line inventory (`app/services/llm_decision_memo.py`)
+
+| Location | Change |
+|---|---|
+| `:53` | `MEMO_PROMPT_VERSION = "v12.1-demand-evidence-enforced-2026-06"` |
+| `:2661–2671` | v12.1 section header comment (evidence + design) |
+| `:2673–2674` | `_DG_COMPOSITE_SIGNAL_EN` / `_DG_COMPOSITE_SIGNAL_AR` (Rule-7 terms, verbatim) |
+| `:2681–2692` | `_DG_INJECTED_IMPLICATION_EN` / `_AR` templates |
+| `:2695` | `_dg_required_composite` — mandate gating + rounded composite |
+| `:2716` | `_dg_evidence_invalid_reason` — the detector |
+| `:2745` | `_dg_required_evidence_row` — locale-correct row builder, banded polarity |
+| `:2774` | `_inject_dg_evidence_row` — position-2 insert, idempotence, null-out guard |
+| `:2806–2838` | `_DG_CORRECTIVE_RETRY_PREAMBLE_EN` / `_AR` |
+| `:2841–2852` | `_dg_corrective_retry_preamble` |
+| `:2933–2940` | first-pass dg detection in `generate_structured_memo` |
+| `:2942–2977` | combined retry trigger + preamble composition |
+| `:3009–3045` | retry re-verification (incl. regressed-headline edge) |
+| `:3077–3090` | layer-2 deterministic injection before return/persistence |
+
+Tests: `tests/test_llm_decision_memo.py:2305–2682` (new v12.1 section).
+
+## 7. Tests
+
+New (23 tests):
+
+- **Gating** (`TestDgRequiredComposite`, 5): dg_index+block → 74; pop_score
+  → None; absent source → None; dg_index without block → None; non-numeric
+  composite → None.
+- **Detector** (`TestDgEvidenceDetector`, 5): compliant by EN phrase, by AR
+  term, by value-match alone → no reason; non-compliant → reason; another
+  row's `80/100` score does not satisfy a composite of 74.
+- **Retry** (`TestDgEvidenceRetry`, 5): missing row → retry fires and the
+  LLM-authored row is kept (no marker); string-pin on the retry preamble
+  (mandate, `"dg_index"`, exact row JSON with `74/100`, population-reach
+  non-anchor line); pop_score never triggers; dg_index-without-block skips
+  both layers; compliant first response → single call.
+- **Injection fallback** (`TestDgEvidenceInjectionFallback`, 3): retry
+  still missing → EN row injected at index 1 with marker, exactly once;
+  AR injection uses the Rule-7 term with Latin-digit `/100`; regressed-
+  headline edge keeps first response and injects.
+- **Injection primitive** (`TestDgInjectionHelper`, 4): index-1 position,
+  idempotence, empty-list (null-out) guard, polarity bands.
+- **Version pin** (`TestMemoPromptVersionBumpedForV121`, 1).
+
+Existing retry-loop tests: **unchanged** (the new reason is additive; all
+pre-existing headline-retry tests pass untouched).
+
+Results:
+
+- memo suites (`test_llm_decision_memo`, `test_pr4a_arabic_structured_memo`,
+  `test_pr4c_arabic_key_evidence`, `test_sample_regression_memos`):
+  **152 passed**
+- full backend suite: **2346 passed, 24 skipped**
+
+Lint note: one 80-char line introduced by the patch was fixed; both touched
+files were already non-black/flake8-compliant at HEAD and CI runs neither,
+so surrounding style was matched rather than reformatting.
+
+## 8. Validation for Ahmed
+
+1. Re-open the **same two dg_index candidates**: the v12 → v12.1 prompt-
+   version mismatch regenerates on view. Both must now show the composite
+   row in KEY EVIDENCE — LLM-authored after one retry, or deterministic at
+   position 2 (an injected row carries `"source": "deterministic_injection"`
+   in `decision_memo_json`, visible via DB/telemetry, invisible in UI).
+2. **Cafe memo re-check:** unchanged — pop_score candidates never trigger
+   either layer (single LLM call, no injection).
+3. **Arabic dg_index memo:** shows مركب مولدات الطلب with a Latin-digit
+   `/100` value.
+
+**Risk:** low. Both layers are no-ops for every non-dg_index candidate; the
+worst-case added cost is one extra LLM call for non-compliant dg_index
+generations (bounded by existing one-retry semantics and the daily cost
+ceiling); the version bump's only cost is one-time regeneration of cached
+v12 memos on next view.

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -2302,6 +2302,384 @@ class TestHeadlineNoRetryWhenAllGatesPassRecommend:
         assert client.chat.completions.create.call_count == 1
 
 
+# ---------------------------------------------------------------------------
+# v12.1 (PR-E2) — dg-index composite evidence enforcement: detector,
+# corrective retry, and deterministic injection fallback.
+# ---------------------------------------------------------------------------
+
+_DG_SIGNAL_EN = "demand-generator composite"
+_DG_SIGNAL_AR = "مركب مولدات الطلب"
+
+# _DG_INDEX_SNAPSHOT_FIELDS (above) carries composite_0_100 = 74.2 → 74.
+_DG_RANK1_CANDIDATE = {
+    **_RANK1_ALL_PASS_CANDIDATE,
+    "id": "dg-rank1",
+    "parcel_id": "dg-rank1",
+    "feature_snapshot_json": {
+        **_RANK1_ALL_PASS_CANDIDATE["feature_snapshot_json"],
+        **_DG_INDEX_SNAPSHOT_FIELDS,
+    },
+}
+
+_POP_SCORE_RANK1_CANDIDATE = {
+    **_RANK1_ALL_PASS_CANDIDATE,
+    "id": "pop-rank1",
+    "parcel_id": "pop-rank1",
+    "feature_snapshot_json": {
+        **_RANK1_ALL_PASS_CANDIDATE["feature_snapshot_json"],
+        "demand_score_source": "pop_score",
+    },
+}
+
+# dg_index source but no demand_generator_index block (defensive case —
+# both enforcement layers must skip).
+_DG_SOURCE_NO_BLOCK_CANDIDATE = {
+    **_RANK1_ALL_PASS_CANDIDATE,
+    "id": "dg-no-block",
+    "parcel_id": "dg-no-block",
+    "feature_snapshot_json": {
+        **_RANK1_ALL_PASS_CANDIDATE["feature_snapshot_json"],
+        "demand_score_source": "dg_index",
+    },
+}
+
+
+def _memo_with_dg_row(headline: str, *, signal: str = _DG_SIGNAL_EN,
+                      value: str = "74/100") -> dict:
+    """A headline-valid memo whose key_evidence includes a composite row."""
+    memo = _memo_with_headline(headline)
+    memo["key_evidence"] = list(memo["key_evidence"]) + [
+        {"signal": signal, "value": value,
+         "implication": "venue activity and trip generators carry the catchment",
+         "polarity": "positive"},
+    ]
+    return memo
+
+
+class TestDgRequiredComposite:
+    """Layer gating — the mandate applies only to dg_index candidates
+    carrying a numeric composite."""
+
+    def test_dg_index_with_block_returns_rounded_composite(self):
+        from app.services.llm_decision_memo import _dg_required_composite
+
+        assert _dg_required_composite(dict(_DG_INDEX_SNAPSHOT_FIELDS)) == 74
+
+    def test_pop_score_returns_none(self):
+        from app.services.llm_decision_memo import _dg_required_composite
+
+        snap = {**_DG_INDEX_SNAPSHOT_FIELDS, "demand_score_source": "pop_score"}
+        assert _dg_required_composite(snap) is None
+
+    def test_absent_source_returns_none(self):
+        from app.services.llm_decision_memo import _dg_required_composite
+
+        snap = {"demand_generator_index": {"composite_0_100": 74.2}}
+        assert _dg_required_composite(snap) is None
+
+    def test_dg_index_without_block_returns_none(self):
+        from app.services.llm_decision_memo import _dg_required_composite
+
+        assert _dg_required_composite({"demand_score_source": "dg_index"}) is None
+
+    def test_non_numeric_composite_returns_none(self):
+        from app.services.llm_decision_memo import _dg_required_composite
+
+        snap = {
+            "demand_score_source": "dg_index",
+            "demand_generator_index": {"composite_0_100": "74"},
+        }
+        assert _dg_required_composite(snap) is None
+
+
+class TestDgEvidenceDetector:
+    """Detector — a memo is compliant when any key_evidence row's
+    signal/value mentions the EN phrase, the AR Rule-7 term, or a /100
+    value equal to the rounded composite."""
+
+    def test_compliant_by_en_signal_phrase(self):
+        from app.services.llm_decision_memo import _dg_evidence_invalid_reason
+
+        memo = _memo_with_dg_row("Recommend — x", value="74.2/100")
+        assert _dg_evidence_invalid_reason(memo, 74) is None
+
+    def test_compliant_by_ar_signal_term(self):
+        from app.services.llm_decision_memo import _dg_evidence_invalid_reason
+
+        memo = _memo_with_dg_row("نوصي — x", signal=_DG_SIGNAL_AR, value="74/100")
+        assert _dg_evidence_invalid_reason(memo, 74) is None
+
+    def test_compliant_by_value_match_alone(self):
+        from app.services.llm_decision_memo import _dg_evidence_invalid_reason
+
+        memo = _memo_with_dg_row("Recommend — x", signal="demand composite",
+                                 value="74/100")
+        assert _dg_evidence_invalid_reason(memo, 74) is None
+
+    def test_non_compliant_returns_reason(self):
+        from app.services.llm_decision_memo import _dg_evidence_invalid_reason
+
+        memo = _memo_with_headline("Recommend — x")
+        reason = _dg_evidence_invalid_reason(memo, 74)
+        assert reason is not None
+        assert "demand-generator composite" in reason
+
+    def test_other_score_value_does_not_match(self):
+        from app.services.llm_decision_memo import _dg_evidence_invalid_reason
+
+        # The base body carries a "80/100" final_score row — must not
+        # satisfy a composite of 74.
+        memo = _memo_with_headline("Recommend — x")
+        assert _dg_evidence_invalid_reason(memo, 74) is not None
+        assert _dg_evidence_invalid_reason(memo, 80) is None
+
+
+class TestDgEvidenceRetry:
+    """Layer 1 — missing composite row triggers the existing one-retry
+    corrective loop with the dg preamble."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_missing_row_triggers_retry_and_keeps_llm_row(
+        self, mock_get_client, monkeypatch
+    ):
+        _enable_structured_memo(monkeypatch)
+        first = _memo_with_headline("Recommend — strong site, demand from reach")
+        second = _memo_with_dg_row("Recommend — strong site, evidenced demand")
+        client = _two_response_client(first, second)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_DG_RANK1_CANDIDATE, brief=BASE_STRUCTURED_BRIEF, lang="en"
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert client.chat.completions.create.call_count == 2
+        rows = memo["key_evidence"]
+        assert any(_DG_SIGNAL_EN in str(r.get("signal", "")) for r in rows)
+        # LLM-authored row, not the deterministic injection.
+        assert all(r.get("source") != "deterministic_injection" for r in rows)
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_retry_preamble_carries_mandate_and_exact_row(
+        self, mock_get_client, monkeypatch
+    ):
+        _enable_structured_memo(monkeypatch)
+        first = _memo_with_headline("Recommend — strong site")
+        second = _memo_with_dg_row("Recommend — strong site")
+        client = _two_response_client(first, second)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_DG_RANK1_CANDIDATE, brief=BASE_STRUCTURED_BRIEF, lang="en"
+        )
+        generate_structured_memo(ctx)
+
+        retry_call = client.chat.completions.create.call_args_list[1]
+        retry_messages = retry_call.kwargs.get("messages") or retry_call[1]["messages"]
+        preamble = retry_messages[1]["content"]
+        assert retry_messages[1]["role"] == "user"
+        assert "PREVIOUS RESPONSE WAS REJECTED" in preamble
+        assert '"dg_index"' in preamble
+        # The exact required row with THIS candidate's composite filled in.
+        assert f'"signal": "{_DG_SIGNAL_EN}"' in preamble
+        assert '"value": "74/100"' in preamble
+        # Body prose must not anchor demand on population reach.
+        assert "MUST NOT be presented as the demand anchor" in preamble
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_pop_score_candidate_never_triggers(self, mock_get_client, monkeypatch):
+        _enable_structured_memo(monkeypatch)
+        good = _memo_with_headline("Recommend — strong economics, no dg row")
+        client = _mock_client_returning(good)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_POP_SCORE_RANK1_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert client.chat.completions.create.call_count == 1
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_dg_source_without_block_skips_both_layers(
+        self, mock_get_client, monkeypatch
+    ):
+        _enable_structured_memo(monkeypatch)
+        good = _memo_with_headline("Recommend — strong economics, no dg row")
+        client = _mock_client_returning(good)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_DG_SOURCE_NO_BLOCK_CANDIDATE,
+            brief=BASE_STRUCTURED_BRIEF,
+            lang="en",
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert client.chat.completions.create.call_count == 1
+        assert all(
+            r.get("source") != "deterministic_injection"
+            for r in memo["key_evidence"]
+        )
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_compliant_first_response_no_retry(self, mock_get_client, monkeypatch):
+        _enable_structured_memo(monkeypatch)
+        good = _memo_with_dg_row("Recommend — evidenced demand")
+        client = _mock_client_returning(good)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_DG_RANK1_CANDIDATE, brief=BASE_STRUCTURED_BRIEF, lang="en"
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert client.chat.completions.create.call_count == 1
+
+
+class TestDgEvidenceInjectionFallback:
+    """Layer 2 — when the retry still lacks the row, the deterministic
+    row is injected at position 2 (index 1) before persistence."""
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_retry_still_missing_injects_en_row_at_position_2(
+        self, mock_get_client, monkeypatch
+    ):
+        _enable_structured_memo(monkeypatch)
+        first = _memo_with_headline("Recommend — strong site")
+        second = _memo_with_headline("Recommend — strong site again")
+        client = _two_response_client(first, second)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_DG_RANK1_CANDIDATE, brief=BASE_STRUCTURED_BRIEF, lang="en"
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert client.chat.completions.create.call_count == 2
+        injected = memo["key_evidence"][1]
+        assert injected["signal"] == _DG_SIGNAL_EN
+        assert injected["value"] == "74/100"
+        assert injected["polarity"] == "positive"
+        assert injected["source"] == "deterministic_injection"
+        assert injected["implication"]
+        # Exactly one injected row.
+        assert sum(
+            1 for r in memo["key_evidence"]
+            if r.get("source") == "deterministic_injection"
+        ) == 1
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_ar_injection_uses_rule7_term_with_latin_digits(
+        self, mock_get_client, monkeypatch
+    ):
+        _enable_structured_memo(monkeypatch)
+        first = _memo_with_headline("نوصي — موقع قوي")
+        second = _memo_with_headline("نوصي — موقع قوي مجدداً")
+        client = _two_response_client(first, second)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_DG_RANK1_CANDIDATE, brief=BASE_STRUCTURED_BRIEF, lang="ar"
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        injected = memo["key_evidence"][1]
+        assert injected["signal"] == _DG_SIGNAL_AR
+        assert injected["value"] == "74/100"  # Latin digits (Rule 8)
+        assert injected["source"] == "deterministic_injection"
+        # Implication is Arabic with no Eastern-Arabic digits.
+        assert any("؀" <= ch <= "ۿ" for ch in injected["implication"])
+        assert not any("٠" <= ch <= "٩" for ch in injected["value"])
+
+    @patch("app.services.llm_decision_memo._get_client")
+    def test_dg_retry_with_regressed_headline_keeps_first_and_injects(
+        self, mock_get_client, monkeypatch
+    ):
+        """Edge: first response has a valid headline but no dg row; the
+        retry produces the row but an invalid headline. The first response
+        wins and the row is injected deterministically."""
+        _enable_structured_memo(monkeypatch)
+        first = _memo_with_headline("Recommend — strong site, valid headline")
+        second = _memo_with_dg_row("consider due to mixed signals")
+        client = _two_response_client(first, second)
+        mock_get_client.return_value = client
+
+        ctx = build_memo_context(
+            candidate=_DG_RANK1_CANDIDATE, brief=BASE_STRUCTURED_BRIEF, lang="en"
+        )
+        memo = generate_structured_memo(ctx)
+
+        assert memo is not None
+        assert memo["headline_recommendation"] == (
+            "Recommend — strong site, valid headline"
+        )
+        assert memo["key_evidence"][1]["source"] == "deterministic_injection"
+
+
+class TestDgInjectionHelper:
+    """Direct unit tests on the injection primitive — idempotence and the
+    null-out guard."""
+
+    def test_injects_at_index_1_after_rent_anchor(self):
+        from app.services.llm_decision_memo import _inject_dg_evidence_row
+
+        memo = {"key_evidence": [
+            {"signal": "annual rent", "value": "SAR 480,000/yr",
+             "implication": "x", "polarity": "positive"},
+            {"signal": "frontage", "value": "24 m corner",
+             "implication": "x", "polarity": "positive"},
+        ]}
+        assert _inject_dg_evidence_row(memo, composite_rounded=74, locale="en")
+        assert memo["key_evidence"][0]["signal"] == "annual rent"
+        assert memo["key_evidence"][1]["signal"] == _DG_SIGNAL_EN
+        assert memo["key_evidence"][2]["signal"] == "frontage"
+
+    def test_idempotent_never_double_injects(self):
+        from app.services.llm_decision_memo import _inject_dg_evidence_row
+
+        memo = {"key_evidence": [
+            {"signal": "annual rent", "value": "SAR 480,000/yr",
+             "implication": "x", "polarity": "positive"},
+        ]}
+        assert _inject_dg_evidence_row(memo, composite_rounded=74, locale="en")
+        assert not _inject_dg_evidence_row(memo, composite_rounded=74, locale="en")
+        assert len(memo["key_evidence"]) == 2
+
+    def test_skips_empty_key_evidence_null_out_path(self):
+        from app.services.llm_decision_memo import _inject_dg_evidence_row
+
+        memo = {"key_evidence": []}
+        assert not _inject_dg_evidence_row(memo, composite_rounded=74, locale="en")
+        assert memo["key_evidence"] == []
+
+    def test_polarity_bands(self):
+        from app.services.llm_decision_memo import _dg_required_evidence_row
+
+        assert _dg_required_evidence_row(74, "en")["polarity"] == "positive"
+        assert _dg_required_evidence_row(60, "en")["polarity"] == "positive"
+        assert _dg_required_evidence_row(45, "en")["polarity"] == "neutral"
+        assert _dg_required_evidence_row(30, "en")["polarity"] == "negative"
+
+
+class TestMemoPromptVersionBumpedForV121:
+    """The two non-compliant production memos are cached at v12; the bump
+    forces regeneration on next view."""
+
+    def test_version_is_v12_1(self):
+        from app.services.llm_decision_memo import MEMO_PROMPT_VERSION
+
+        assert MEMO_PROMPT_VERSION == "v12.1-demand-evidence-enforced-2026-06"
+
+
 class TestRenderPromptAdvisoryFailureNoGateFailureAddendum:
     """Bug 1 prompt-side fix — an advisory-only gate failure must NOT
     inject the "GATE FAILURE ... overall_pass=False" addendum."""


### PR DESCRIPTION
Two production v12 regenerations on confirmed dg_index candidates produced
key_evidence with no demand-generator composite row — the prompt mandate
alone does not bind. Two enforcement layers on existing machinery:

1. Soft validation + one corrective retry: when
   demand_score_source == "dg_index" and no key_evidence row references
   the composite (EN signal phrase, AR Rule-7 term, or rounded /100
   value), retry once with a corrective preamble that embeds the exact
   required row for this candidate and restates the population-reach
   non-anchor rule.
2. Deterministic fallback: if the retry still lacks the row, inject the
   locale-correct row server-side at position 2 (inside the frontend's
   top-4 render window), marked source=deterministic_injection.
   Idempotent; skipped when the dg block is absent or the headline
   null-out emptied the body.

MEMO_PROMPT_VERSION bumped to v12.1-demand-evidence-enforced-2026-06 so
the two non-compliant cached v12 memos regenerate on next view. System
prompt text unchanged — prompt-head fixture untouched.

https://claude.ai/code/session_01VZAPxM19YyTXsPk5WaEcUu