### PR TITLE
feat(expansion): weight stack v2 — single-paid momentum, dead-weight removal, demand reallocation

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -397,9 +397,22 @@ class Settings:
     # Set to 0 to disable the chain_strength leg without code changes; if
     # changed, EXPANSION_COMPETITION_WHITESPACE_WEIGHT must be adjusted in
     # lockstep — the runtime assertion in _score_breakdown catches drift.
+    # v1-only: under EXPANSION_WEIGHT_STACK=v2 the chain_strength weight is
+    # the fixed 4.0 of the v2 stack and this env var is ignored.
     EXPANSION_CHAIN_STRENGTH_WEIGHT: float = float(
         os.getenv("EXPANSION_CHAIN_STRENGTH_WEIGHT", "3.0")
     )
+
+    # Weight-stack selector for the Expansion Advisor scoring composite.
+    # "v1" (default) keeps the production stack byte-identical; "v2" applies
+    # the 2026-06 rebalance: district_momentum becomes its own single-paid
+    # top-level component (removed from listing_quality and from the +2
+    # sort-time bonus), confidence becomes display-only (weight 0), and
+    # weight mass moves toward the high-discrimination components.
+    # Evidence: June 2026 production probes (scripts/diagnostics/
+    # weight_discrimination.sql et al.) — confidence p90−p10 = 0.00,
+    # momentum double-paid, discrimination inverted vs nominal weights.
+    EXPANSION_WEIGHT_STACK: str = os.getenv("EXPANSION_WEIGHT_STACK", "v1")
 
     # Strong-chain SHARE calibration for the chain_strength leg input.
     # Replaces the MAX-over-radius leg input (which saturated at 100 for any

--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -2985,6 +2985,17 @@ _MOMENTUM_SAMPLE_FLOOR = 20
 # threshold and math are unchanged.
 _MOMENTUM_DISPLAY_THRESHOLD = 70.0
 
+# Weight stack v2: district momentum is paid once, as its own top-level
+# component (see _score_breakdown). This helper is the extracted momentum
+# sub-signal historically embedded in _listing_quality_score — same 0-100
+# raw value (district-level 30-day Aqar activity percentile), with unknown
+# (None) resolving to a neutral 50.0 per the tri-state convention.
+def _district_momentum_component(district_momentum_score: float | None) -> float:
+    if district_momentum_score is None:
+        return 50.0
+    return _clamp(float(district_momentum_score))
+
+
 # Phase 4 display-only freshness window. Phase 4.1: a listing earns
 # "New" when aqar_created_at is within this window, and "Updated" when
 # it is older than the window but aqar_updated_at is within it.
@@ -3103,7 +3114,20 @@ def _listing_quality_score(
     # Furnished: faster open, lower risk
     furnished_signal = 100.0 if is_furnished else 50.0
 
-    if _MOMENTUM_ENABLED:
+    if str(getattr(settings, "EXPANSION_WEIGHT_STACK", "v1")) == "v2":
+        # Weight stack v2: momentum is paid once, as the top-level
+        # district_momentum component in _score_breakdown — it no longer
+        # contributes here. The remaining momentum-enabled sub-weights
+        # (0.30 / 0.20 / 0.10 / 0.05) renormalize by /0.65 so the tuple
+        # still sums to 1.0 (≈ 0.4615 / 0.3077 / 0.1538 / 0.0769). The
+        # +5 drive-thru bump and the parcel neutral-50 path are unchanged.
+        composite = (
+            freshness * (0.30 / 0.65)
+            + suitability * (0.20 / 0.65)
+            + image_signal * (0.10 / 0.65)
+            + furnished_signal * (0.05 / 0.65)
+        )
+    elif _MOMENTUM_ENABLED:
         # Sub-weight rebalance — 2026-05-07 (CEO directive elevation).
         # Audit (branch claude/audit-advisor-ranking-4prR3) found momentum
         # contributing only ~1.65% and freshness only ~2.81% of final_score,
@@ -3119,10 +3143,7 @@ def _listing_quality_score(
         # rises from ~1.65% to ~7.7% and freshness from ~2.81% to ~6.6%.
         # Unknown momentum → neutral 50.0 per the tri-state convention
         # used by freshness and suitability above.
-        if district_momentum_score is None:
-            momentum_signal = 50.0
-        else:
-            momentum_signal = _clamp(float(district_momentum_score))
+        momentum_signal = _district_momentum_component(district_momentum_score)
         composite = (
             freshness * 0.30
             + suitability * 0.20
@@ -3419,6 +3440,9 @@ _REWEIGHTABLE_COMPONENTS: tuple[str, ...] = (
     "access_visibility",
     "delivery_demand",
     "confidence",
+    # Weight stack v2 component. No brand-brief knob maps to it yet, so its
+    # multiplier stays 1.0; it still participates in the renormalization.
+    "district_momentum",
 )
 
 
@@ -3499,6 +3523,7 @@ def _score_breakdown(
     chain_strength_max: float | None = None,
     brand_profile: dict[str, Any] | None = None,
     service_model: str | None = None,
+    district_momentum_score: float | None = None,
 ) -> dict[str, Any]:
     """Listings-first weight distribution.
 
@@ -3523,6 +3548,19 @@ def _score_breakdown(
     sum to 100. Patch B then carved 3.0 points out of competition_whitespace
     for the new chain_strength leg (pro-presence: established-brand
     validation), keeping the total at 100.
+
+    Weight stack v2 (``EXPANSION_WEIGHT_STACK=v2``, 2026-06): district
+    momentum becomes its own single-paid top-level component
+    (``district_momentum``, raw input via ``district_momentum_score``),
+    confidence is excluded from the weighted sum (raw value kept in the
+    breakdown JSON for the UI data-quality grade), and weight mass moves
+    toward the high-discrimination components:
+      occupancy_economics 20, demand_potential 18, competition_whitespace 12,
+      access_visibility 11, listing_quality 9, brand_fit 8,
+      district_momentum 7, delivery_demand 6, landlord_signal 5,
+      chain_strength 4 (fixed — EXPANSION_CHAIN_STRENGTH_WEIGHT is v1-only).
+    Under v1 (default) ``district_momentum_score`` is ignored and the
+    output is byte-identical to the pre-v2 behavior.
     """
     # Top-level weight rebalance — 2026-05-07 (CEO directive elevation).
     # Audit (branch claude/audit-advisor-ranking-4prR3) found that even
@@ -3550,20 +3588,39 @@ def _score_breakdown(
     # competition_whitespace. The chain_strength weight is env-driven so
     # it can be calibrated without a code change; competition_whitespace
     # absorbs the equal-and-opposite move so the total stays at 100.
-    _chain_strength_weight = float(settings.EXPANSION_CHAIN_STRENGTH_WEIGHT)
-    _competition_whitespace_weight = round(8.7640 - _chain_strength_weight, 4)
-    component_weights = {
-        "occupancy_economics": 26.2924,
-        "listing_quality": 22.0,
-        "brand_fit": 9.6404,
-        "landlord_signal": 7.0112,
-        "competition_whitespace": _competition_whitespace_weight,
-        "chain_strength": _chain_strength_weight,
-        "demand_potential": 8.7640,
-        "access_visibility": 8.7640,
-        "delivery_demand": 4.3820,
-        "confidence": 4.3820,
-    }
+    _stack_v2 = str(getattr(settings, "EXPANSION_WEIGHT_STACK", "v1")) == "v2"
+    if _stack_v2:
+        # Weight stack v2 — 2026-06 probe-driven rebalance (see docstring).
+        # confidence is intentionally absent: weight 0, display-only.
+        # chain_strength is the fixed 4.0 of the v2 stack; the
+        # EXPANSION_CHAIN_STRENGTH_WEIGHT env var is v1-only.
+        component_weights = {
+            "occupancy_economics": 20.0,
+            "demand_potential": 18.0,
+            "competition_whitespace": 12.0,
+            "access_visibility": 11.0,
+            "listing_quality": 9.0,
+            "brand_fit": 8.0,
+            "district_momentum": 7.0,
+            "delivery_demand": 6.0,
+            "landlord_signal": 5.0,
+            "chain_strength": 4.0,
+        }
+    else:
+        _chain_strength_weight = float(settings.EXPANSION_CHAIN_STRENGTH_WEIGHT)
+        _competition_whitespace_weight = round(8.7640 - _chain_strength_weight, 4)
+        component_weights = {
+            "occupancy_economics": 26.2924,
+            "listing_quality": 22.0,
+            "brand_fit": 9.6404,
+            "landlord_signal": 7.0112,
+            "competition_whitespace": _competition_whitespace_weight,
+            "chain_strength": _chain_strength_weight,
+            "demand_potential": 8.7640,
+            "access_visibility": 8.7640,
+            "delivery_demand": 4.3820,
+            "confidence": 4.3820,
+        }
     # Finding 1: brand-brief knobs re-weight components, then renormalize to 100.
     _w_mult = _brand_weight_multipliers(brand_profile, service_model)
     if any(abs(m - 1.0) > 1e-9 for m in _w_mult.values()):
@@ -3605,6 +3662,10 @@ def _score_breakdown(
         "delivery_demand": round(_safe_float(provider_intelligence_composite), 2),
         "confidence": round(_safe_float(confidence_score), 2),
     }
+    if _stack_v2:
+        raw_inputs["district_momentum"] = round(
+            _district_momentum_component(district_momentum_score), 2
+        )
     weighted_components = {
         name: round(_safe_float(raw_inputs[name]) * component_weights[name] / 100.0, 2)
         for name in component_weights
@@ -3618,7 +3679,7 @@ def _score_breakdown(
         }
         for name in component_weights
     }
-    return {
+    breakdown = {
         "weights": component_weights,
         "inputs": {
             **raw_inputs,
@@ -3632,6 +3693,17 @@ def _score_breakdown(
         "display": display,
         "final_score": round(_clamp(final_score), 2),
     }
+    if _stack_v2:
+        # Confidence is computed and surfaced (inputs.confidence + this
+        # block) but contributes 0 weighted points — the UI renders it as
+        # a data-quality grade, not a weighted row.
+        breakdown["display_only"] = {
+            "confidence": {
+                "raw_input_score": raw_inputs["confidence"],
+                "weight_percent": 0.0,
+            }
+        }
+    return breakdown
 
 
 def _top_positives_and_risks(
@@ -5302,7 +5374,13 @@ def _apply_score_deltas_and_sort(
 
     Sort is strict: ``(-final_score, parcel_id)``. The parcel_id tie-break
     guarantees identical orderings on re-runs even when scores collide.
+
+    Weight stack v2: the +2 momentum bonus is removed (momentum is paid
+    once, via the district_momentum component in ``_score_breakdown``) and
+    ``bonus_detail`` omits the ``momentum_bonus`` key. All other deltas
+    (freshness, value band, viability) are unchanged in both stacks.
     """
+    _stack_v2 = str(getattr(settings, "EXPANSION_WEIGHT_STACK", "v1")) == "v2"
     for _c in candidates:
         base = _safe_float(_c.get("final_score"), 0.0)
 
@@ -5339,17 +5417,22 @@ def _apply_score_deltas_and_sort(
             freshness_bonus = 0.0
             freshness_label = None
 
-        momentum = fs.get("district_momentum") or {}
-        momentum_score = momentum.get("momentum_score")
-        if (
-            isinstance(momentum_score, (int, float))
-            and not isinstance(momentum_score, bool)
-            and float(momentum_score) >= _MOMENTUM_DISPLAY_THRESHOLD
-            and momentum.get("sample_floor_applied") is False
-        ):
-            momentum_bonus = 2.0
-        else:
+        if _stack_v2:
+            # v2: momentum is already paid via the district_momentum
+            # component; the +2 bonus would double-pay it.
             momentum_bonus = 0.0
+        else:
+            momentum = fs.get("district_momentum") or {}
+            momentum_score = momentum.get("momentum_score")
+            if (
+                isinstance(momentum_score, (int, float))
+                and not isinstance(momentum_score, bool)
+                and float(momentum_score) >= _MOMENTUM_DISPLAY_THRESHOLD
+                and momentum.get("sample_floor_applied") is False
+            ):
+                momentum_bonus = 2.0
+            else:
+                momentum_bonus = 0.0
 
         total_delta = (
             value_band_delta + viability_delta + freshness_bonus + momentum_bonus
@@ -5369,7 +5452,8 @@ def _apply_score_deltas_and_sort(
             "viability_delta": float(viability_delta),
             "freshness_bonus": float(freshness_bonus),
             "freshness_label": freshness_label,
-            "momentum_bonus": float(momentum_bonus),
+            # v2 omits momentum_bonus entirely — the leg no longer exists.
+            **({} if _stack_v2 else {"momentum_bonus": float(momentum_bonus)}),
             "total_delta": float(total_delta),
             "final_score_clamped": bool(final_clamped),
         }
@@ -8687,6 +8771,7 @@ def run_expansion_search(
             chain_strength_max=max_chain_strength,
             brand_profile=effective_brand_profile,
             service_model=service_model,
+            district_momentum_score=_district_momentum_score_val,
         )
         prepared.append(
             {
@@ -10122,6 +10207,7 @@ def run_expansion_search(
             chain_strength_max=max_chain_strength,
             brand_profile=effective_brand_profile,
             service_model=service_model,
+            district_momentum_score=_final_momentum_score_val,
         )
         score_breakdown_json["inputs"]["rent_fallback_used"] = rent_fallback_used
         # F4: surface the whitespace confidence flag so the API response

--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -404,6 +404,30 @@ COMPONENT_WEIGHTS: dict[str, float] = {
     "confidence": 0.043820,
 }
 
+# Weight stack v2 (EXPANSION_WEIGHT_STACK=v2) — mirrors the v2 dict in
+# _score_breakdown: district_momentum is its own single-paid component and
+# confidence is display-only (weight 0, hence absent from the weighted set).
+COMPONENT_WEIGHTS_V2: dict[str, float] = {
+    "occupancy_economics": 0.20,
+    "demand_potential": 0.18,
+    "competition_whitespace": 0.12,
+    "access_visibility": 0.11,
+    "listing_quality": 0.09,
+    "brand_fit": 0.08,
+    "district_momentum": 0.07,
+    "delivery_demand": 0.06,
+    "landlord_signal": 0.05,
+    "chain_strength": 0.04,
+}
+
+
+def _active_component_weights() -> dict[str, float]:
+    """Memo-display weights for the active weight stack. v1 (default)
+    returns COMPONENT_WEIGHTS unchanged so memo output stays byte-identical."""
+    if str(getattr(settings, "EXPANSION_WEIGHT_STACK", "v1")) == "v2":
+        return COMPONENT_WEIGHTS_V2
+    return COMPONENT_WEIGHTS
+
 # Feature-snapshot fields that actually drive a decision. Used to truncate
 # oversized snapshots to a compact LLM-friendly payload.
 #
@@ -843,10 +867,11 @@ def _build_contributions(
     score_breakdown: dict,
     candidate: dict | None = None,
 ) -> dict[str, float]:
-    """Return ``{component: weight × component_score}`` for all 9 components."""
+    """Return ``{component: weight × component_score}`` for every component
+    of the active weight stack."""
     return {
         comp: round(weight * _component_score_value(score_breakdown, candidate, comp), 3)
-        for comp, weight in COMPONENT_WEIGHTS.items()
+        for comp, weight in _active_component_weights().items()
     }
 
 
@@ -915,7 +940,7 @@ def build_memo_context(
     contributions = _build_contributions(raw_breakdown, candidate)
     # Do not mutate caller's dict.
     score_breakdown = dict(raw_breakdown)
-    score_breakdown["weights"] = dict(COMPONENT_WEIGHTS)
+    score_breakdown["weights"] = dict(_active_component_weights())
     score_breakdown["contributions"] = contributions
 
     # Tri-state-preserving gate verdicts. When the candidate carries both

--- a/frontend/src/features/expansion-advisor/DecisionLogicCard.tsx
+++ b/frontend/src/features/expansion-advisor/DecisionLogicCard.tsx
@@ -45,9 +45,14 @@ type Props = {
 // Canonical component order + labels matching
 // app/services/expansion_advisor.py:_score_breakdown (10 components summing
 // to 100% after the Patch B chain_strength split-off).
+// Rows render only for keys present in weighted_components, so the union
+// covers both weight stacks: district_momentum appears under
+// EXPANSION_WEIGHT_STACK=v2 and confidence (weight 0, display-only under
+// v2) automatically drops out of the weighted rows.
 const SCORE_COMPONENT_ORDER: readonly string[] = [
   "occupancy_economics",
   "listing_quality",
+  "district_momentum",
   "brand_fit",
   "landlord_signal",
   "competition_whitespace",

--- a/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
+++ b/frontend/src/features/expansion-advisor/ExpansionMemoPanel.tsx
@@ -27,6 +27,7 @@ const SCORE_LABEL_KEYS: Record<string, string> = {
   listing_quality: "expansionAdvisor.scoreLabel.listingQuality",
   landlord_signal: "expansionAdvisor.scoreLabel.landlordSignal",
   chain_strength: "expansionAdvisor.scoreLabel.chainStrength",
+  district_momentum: "expansionAdvisor.scoreLabel.districtMomentum",
   provider_density: "expansionAdvisor.scoreLabel.providerDensity",
   provider_whitespace: "expansionAdvisor.scoreLabel.marketGap",
   multi_platform_presence: "expansionAdvisor.scoreLabel.multiPlatform",

--- a/frontend/src/features/expansion-advisor/expansion-advisor.css
+++ b/frontend/src/features/expansion-advisor/expansion-advisor.css
@@ -4334,6 +4334,7 @@
   --oak-ea-seg-delivery_demand: #a86ba8;
   --oak-ea-seg-confidence: #7f7f7f;
   --oak-ea-seg-chain_strength: #b8553a;
+  --oak-ea-seg-district_momentum: #2f9e8f;
 
   margin-block: 12px;
   padding-block: 12px;
@@ -4472,6 +4473,7 @@
 .ea-decision-logic__bar-segment--delivery_demand       { background: var(--oak-ea-seg-delivery_demand); }
 .ea-decision-logic__bar-segment--confidence            { background: var(--oak-ea-seg-confidence); }
 .ea-decision-logic__bar-segment--chain_strength        { background: var(--oak-ea-seg-chain_strength); }
+.ea-decision-logic__bar-segment--district_momentum     { background: var(--oak-ea-seg-district_momentum); }
 .ea-decision-logic__legend {
   margin: 0;
   padding: 0;

--- a/frontend/src/features/expansion-advisor/scoreComponentMeta.ts
+++ b/frontend/src/features/expansion-advisor/scoreComponentMeta.ts
@@ -272,6 +272,33 @@ export const PER_COMPONENT_INPUTS: Record<string, InputDescriptor[]> = {
     },
   ],
 
+  // Weight stack v2: district momentum as its own top-level component.
+  // Reads the same feature_snapshot_json.district_momentum block that the
+  // listing_quality input row uses for v1 candidates.
+  district_momentum: [
+    {
+      key: "momentum_score",
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "district_momentum", "momentum_score")),
+        source: "oaktree_internal",
+      }),
+    },
+    {
+      key: "activity_30d",
+      resolve: ({ featureSnapshot }) => ({
+        value: asNumber(readNested(featureSnapshot, "district_momentum", "activity_30d")),
+        source: "aqar",
+      }),
+    },
+    {
+      key: "sample_floor_applied",
+      resolve: ({ featureSnapshot }) => ({
+        value: asBool(readNested(featureSnapshot, "district_momentum", "sample_floor_applied")),
+        source: "oaktree_internal",
+      }),
+    },
+  ],
+
   brand_fit: [
     {
       key: "district",

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -752,6 +752,7 @@
       "listingQuality": "جودة الإعلان",
       "landlordSignal": "سلوك المالك",
       "chainStrength": "قوة السلاسل المنافسة",
+      "districtMomentum": "زخم الحي",
       "providerDensity": "كثافة مزودي التوصيل",
       "marketGap": "الفجوة السوقية",
       "multiPlatform": "تعدد المنصات",
@@ -1221,6 +1222,15 @@
           "is_furnished": { "label": "مفروش" },
           "has_drive_thru": { "label": "خدمة السيارات" },
           "district_momentum_score": { "label": "درجة زخم الحي" }
+        }
+      },
+      "district_momentum": {
+        "label": "زخم الحي",
+        "definition": "مدى نشاط سوق القوائم التجارية في الحي خلال آخر 30 يومًا، مرتبًا مئويًا عبر أحياء الرياض. الأحياء دون الحد الأدنى للعينة تُقرأ كقيمة محايدة.",
+        "inputs": {
+          "momentum_score": { "label": "درجة زخم الحي" },
+          "activity_30d": { "label": "القوائم النشطة خلال آخر 30 يومًا" },
+          "sample_floor_applied": { "label": "دون الحد الأدنى للعينة" }
         }
       },
       "brand_fit": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -700,6 +700,7 @@
       "listingQuality": "Listing Quality",
       "landlordSignal": "Landlord Signal",
       "chainStrength": "Chain Strength",
+      "districtMomentum": "District Momentum",
       "providerDensity": "Provider Density",
       "marketGap": "Market Gap",
       "multiPlatform": "Multi-platform",
@@ -1241,6 +1242,15 @@
           "is_furnished": { "label": "Furnished" },
           "has_drive_thru": { "label": "Drive-thru" },
           "district_momentum_score": { "label": "District momentum score" }
+        }
+      },
+      "district_momentum": {
+        "label": "District Momentum",
+        "definition": "How active the district's commercial listing market has been over the trailing 30 days, percentile-ranked across Riyadh districts. Districts below the sample floor read as neutral.",
+        "inputs": {
+          "momentum_score": { "label": "District momentum score" },
+          "activity_30d": { "label": "Listings active in last 30 days" },
+          "sample_floor_applied": { "label": "Below sample floor" }
         }
       },
       "brand_fit": {

--- a/scripts/diagnostics/contribution_vs_realized_demand.sql
+++ b/scripts/diagnostics/contribution_vs_realized_demand.sql
@@ -1,0 +1,133 @@
+\pset footer off
+--
+-- contribution_vs_realized_demand.sql  (Probe B — weight-stack investigation)
+--
+-- For candidates where the realized-demand signal populates
+-- (feature_snapshot_json->'realized_demand_30d' present AND
+-- realized_demand_branches >= 3, the same gate the snapshot writer applies —
+-- in practice mostly QSR runs), compute a per-search Spearman rank
+-- correlation between each component's contribution (pts) and
+-- realized_demand_30d, then average across searches. Also: final_score vs
+-- realized_demand_30d.
+--
+-- Spearman is computed as Pearson corr over per-search ranks
+-- (rank() OVER ...), which matches Spearman up to tie handling.
+--
+-- CAVEATS (read before interpreting):
+--  * realized_demand_30d is itself an INPUT to demand_potential (the
+--    realized leg of _delivery_score), so demand_potential's positive
+--    correlation here is partly mechanical, not validation.
+--  * realized_demand_30d is rating velocity of EXISTING same-category
+--    branches in the catchment — an outcome proxy for the AREA, not for the
+--    specific listing. It says nothing about rent economics ex post.
+--  * The interesting cells are the heavy non-demand components
+--    (occupancy_economics 26.3%, listing_quality 22%, landlord_signal 7%
+--    under the v1 stack): near-zero or negative mean Spearman at >= 7%
+--    weight is the flag.
+--
+-- Weight-stack aware by construction: components are exploded from each
+-- row's weighted_components / weights, so v2 rows (EXPANSION_WEIGHT_STACK=v2)
+-- contribute district_momentum and simply have no confidence row (weight 0,
+-- display-only) without any change here.
+--
+\echo ''
+\echo '=== A. Per-component Spearman vs realized_demand_30d (last 30 days) ==='
+WITH base AS (
+  SELECT
+    c.search_id,
+    c.id AS candidate_id,
+    (c.feature_snapshot_json->>'realized_demand_30d')::numeric AS rd,
+    c.score_breakdown_json->'weighted_components'              AS wc
+  FROM expansion_candidate c
+  JOIN expansion_search s ON s.id = c.search_id
+  WHERE s.created_at >= now() - interval '30 days'
+    AND c.feature_snapshot_json ? 'realized_demand_30d'
+    AND (c.feature_snapshot_json->>'realized_demand_30d') IS NOT NULL
+    AND COALESCE((c.feature_snapshot_json->>'realized_demand_branches')::numeric, 0) >= 3
+    AND c.score_breakdown_json ? 'weighted_components'
+),
+long AS (
+  SELECT b.search_id, b.candidate_id, b.rd,
+         kv.key AS component, (kv.value)::numeric AS pts
+  FROM base b
+  CROSS JOIN LATERAL jsonb_each_text(b.wc) AS kv(key, value)
+),
+ranked AS (
+  SELECT search_id, component,
+         rank() OVER (PARTITION BY search_id, component ORDER BY pts) AS r_pts,
+         rank() OVER (PARTITION BY search_id, component ORDER BY rd)  AS r_rd
+  FROM long
+),
+per_search AS (
+  SELECT search_id, component,
+         corr(r_pts::float8, r_rd::float8) AS spearman,
+         COUNT(*) AS n
+  FROM ranked
+  GROUP BY search_id, component
+  HAVING COUNT(*) >= 8
+),
+weights AS (
+  SELECT kv.key AS component, AVG((kv.value)::numeric) AS weight_pct
+  FROM base b2
+  JOIN expansion_candidate c2 ON c2.id = b2.candidate_id
+  CROSS JOIN LATERAL jsonb_each_text(c2.score_breakdown_json->'weights') AS kv(key, value)
+  GROUP BY kv.key
+)
+SELECT
+  p.component,
+  COUNT(*)                                  AS n_searches,
+  ROUND(w.weight_pct, 2)                    AS weight_pct,
+  ROUND(AVG(p.spearman)::numeric, 3)        AS mean_spearman_vs_rd,
+  ROUND(MIN(p.spearman)::numeric, 3)        AS min_spearman,
+  ROUND(MAX(p.spearman)::numeric, 3)        AS max_spearman,
+  CASE
+    WHEN w.weight_pct >= 7.0 AND AVG(p.spearman) < 0.10
+      THEN '<< FLAG: >=7% weight, near-zero/negative corr'
+    ELSE ''
+  END AS flag
+FROM per_search p
+JOIN weights w ON w.component = p.component
+GROUP BY p.component, w.weight_pct
+ORDER BY w.weight_pct DESC;
+
+\echo ''
+\echo '=== B. final_score (and deterministic base) Spearman vs realized_demand_30d ==='
+WITH base AS (
+  SELECT
+    c.search_id,
+    (c.feature_snapshot_json->>'realized_demand_30d')::numeric AS rd,
+    c.final_score::numeric                                     AS final_score,
+    COALESCE(
+      (c.score_breakdown_json->'bonus_detail'->>'base_deterministic')::numeric,
+      c.final_score::numeric
+    ) AS base_score
+  FROM expansion_candidate c
+  JOIN expansion_search s ON s.id = c.search_id
+  WHERE s.created_at >= now() - interval '30 days'
+    AND c.feature_snapshot_json ? 'realized_demand_30d'
+    AND (c.feature_snapshot_json->>'realized_demand_30d') IS NOT NULL
+    AND COALESCE((c.feature_snapshot_json->>'realized_demand_branches')::numeric, 0) >= 3
+),
+ranked AS (
+  SELECT search_id,
+         rank() OVER (PARTITION BY search_id ORDER BY final_score) AS r_final,
+         rank() OVER (PARTITION BY search_id ORDER BY base_score)  AS r_base,
+         rank() OVER (PARTITION BY search_id ORDER BY rd)          AS r_rd
+  FROM base
+),
+per_search AS (
+  SELECT search_id,
+         corr(r_final::float8, r_rd::float8) AS sp_final,
+         corr(r_base::float8,  r_rd::float8) AS sp_base,
+         COUNT(*) AS n
+  FROM ranked
+  GROUP BY search_id
+  HAVING COUNT(*) >= 8
+)
+SELECT
+  COUNT(*)                              AS n_searches,
+  ROUND(AVG(sp_final)::numeric, 3)      AS mean_spearman_final_vs_rd,
+  ROUND(AVG(sp_base)::numeric, 3)       AS mean_spearman_base_vs_rd,
+  ROUND(MIN(sp_final)::numeric, 3)      AS min_final,
+  ROUND(MAX(sp_final)::numeric, 3)      AS max_final
+FROM per_search;

--- a/scripts/diagnostics/economics_concentration.sql
+++ b/scripts/diagnostics/economics_concentration.sql
@@ -1,0 +1,127 @@
+\pset footer off
+--
+-- economics_concentration.sql  (Probe D — weight-stack investigation)
+--
+-- occupancy_economics carries 26.3% of final_score (v1 stack; 20.0 under
+-- EXPANSION_WEIGHT_STACK=v2 — the probe reads the component by name, which
+-- exists in both stacks, so no change is needed per stack). Is that weight producing
+-- genuine candidate separation, or are most candidates clustered in a narrow
+-- band (e.g. rent-percentile compressing, revenue_index dominated by
+-- near-constant inputs)?
+--
+-- Sections:
+--   A. distribution of the economics CONTRIBUTION (pts) and raw input,
+--      pooled and per-search-averaged.
+--   B. clustering: share of candidates within +/-2 pts of their search's
+--      median economics contribution.
+--   C. rent_burden mode/source mix + rent_burden_score and percentile
+--      distribution from score_breakdown_json->'economics_detail'.
+--   D. rent_burden_weight actually applied (rb_confidence damping) — when
+--      this collapses to 0, economics is ~58% revenue_index by construction.
+--
+\echo ''
+\echo '=== A. Economics contribution distribution (recent ~10 searches) ==='
+WITH recent_searches AS (
+  SELECT s.id FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC LIMIT 10
+),
+econ AS (
+  SELECT
+    c.search_id,
+    (c.score_breakdown_json->'weighted_components'->>'occupancy_economics')::numeric AS pts,
+    (c.score_breakdown_json->'inputs'->>'occupancy_economics')::numeric              AS raw
+  FROM expansion_candidate c
+  JOIN recent_searches rs ON rs.id = c.search_id
+  WHERE c.score_breakdown_json ? 'weighted_components'
+)
+SELECT
+  COUNT(*)                                                          AS n_candidates,
+  ROUND(AVG(pts)::numeric, 2)                                       AS mean_pts,
+  ROUND(STDDEV_SAMP(pts)::numeric, 2)                               AS sd_pts,
+  ROUND(percentile_cont(0.10) WITHIN GROUP (ORDER BY pts)::numeric, 2) AS p10_pts,
+  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY pts)::numeric, 2) AS p50_pts,
+  ROUND(percentile_cont(0.90) WITHIN GROUP (ORDER BY pts)::numeric, 2) AS p90_pts,
+  ROUND(AVG(raw)::numeric, 2)                                       AS mean_raw,
+  ROUND(STDDEV_SAMP(raw)::numeric, 2)                               AS sd_raw
+FROM econ;
+
+\echo ''
+\echo '=== B. Clustering: share within +/-2 pts of per-search median ==='
+WITH recent_searches AS (
+  SELECT s.id FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC LIMIT 10
+),
+econ AS (
+  SELECT c.search_id,
+         (c.score_breakdown_json->'weighted_components'->>'occupancy_economics')::numeric AS pts
+  FROM expansion_candidate c
+  JOIN recent_searches rs ON rs.id = c.search_id
+  WHERE c.score_breakdown_json ? 'weighted_components'
+),
+med AS (
+  SELECT search_id,
+         percentile_cont(0.5) WITHIN GROUP (ORDER BY pts) AS med_pts,
+         COUNT(*) AS n
+  FROM econ GROUP BY search_id HAVING COUNT(*) >= 8
+)
+SELECT
+  COUNT(DISTINCT e.search_id)                                              AS n_searches,
+  COUNT(*)                                                                 AS n_candidates,
+  ROUND(100.0 * SUM(CASE WHEN ABS(e.pts - m.med_pts) <= 2.0 THEN 1 ELSE 0 END) / COUNT(*), 1)
+                                                                           AS pct_within_2pts_of_median,
+  ROUND(100.0 * SUM(CASE WHEN ABS(e.pts - m.med_pts) <= 1.0 THEN 1 ELSE 0 END) / COUNT(*), 1)
+                                                                           AS pct_within_1pt_of_median
+FROM econ e
+JOIN med m ON m.search_id = e.search_id;
+
+\echo ''
+\echo '=== C. rent_burden mode / source mix + percentile distribution ==='
+WITH recent_searches AS (
+  SELECT s.id FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC LIMIT 10
+),
+rb AS (
+  SELECT
+    c.score_breakdown_json->'economics_detail'->'rent_burden'->>'mode'         AS mode,
+    c.score_breakdown_json->'economics_detail'->'rent_burden'->>'source_label' AS source_label,
+    (c.score_breakdown_json->'economics_detail'->>'rent_burden_score')::numeric AS rent_burden_score,
+    (c.score_breakdown_json->'economics_detail'->'rent_burden'->>'percentile')::numeric AS rent_percentile
+  FROM expansion_candidate c
+  JOIN recent_searches rs ON rs.id = c.search_id
+  WHERE c.score_breakdown_json ? 'economics_detail'
+)
+SELECT
+  COALESCE(mode, '(missing)')          AS mode,
+  COALESCE(source_label, '(none)')     AS source_label,
+  COUNT(*)                             AS n,
+  ROUND(AVG(rent_burden_score)::numeric, 1)                                            AS mean_burden,
+  ROUND(STDDEV_SAMP(rent_burden_score)::numeric, 1)                                    AS sd_burden,
+  ROUND(percentile_cont(0.10) WITHIN GROUP (ORDER BY rent_percentile)::numeric, 3)     AS pctile_p10,
+  ROUND(percentile_cont(0.50) WITHIN GROUP (ORDER BY rent_percentile)::numeric, 3)     AS pctile_p50,
+  ROUND(percentile_cont(0.90) WITHIN GROUP (ORDER BY rent_percentile)::numeric, 3)     AS pctile_p90
+FROM rb
+GROUP BY mode, source_label
+ORDER BY n DESC;
+
+\echo ''
+\echo '=== D. Applied rent_burden_weight (rb_confidence damping) distribution ==='
+-- rent_burden_weight = 0.20 * rb_confidence; the deficit is absorbed by
+-- revenue_index. 0.20 = full rent signal; 0.05/0.03 = damped citywide comps;
+-- 0.00 = rent signal fully dropped (economics ~58% revenue_index).
+WITH recent_searches AS (
+  SELECT s.id FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC LIMIT 10
+)
+SELECT
+  (c.score_breakdown_json->'economics_detail'->>'rent_burden_weight')::numeric AS rent_burden_weight,
+  (c.score_breakdown_json->'economics_detail'->>'revenue_weight')::numeric     AS revenue_weight,
+  COUNT(*) AS n
+FROM expansion_candidate c
+JOIN recent_searches rs ON rs.id = c.search_id
+WHERE c.score_breakdown_json ? 'economics_detail'
+GROUP BY 1, 2
+ORDER BY n DESC;

--- a/scripts/diagnostics/listing_quality_decomposition.sql
+++ b/scripts/diagnostics/listing_quality_decomposition.sql
@@ -1,0 +1,196 @@
+\pset footer off
+--
+-- listing_quality_decomposition.sql  (Probe C — weight-stack investigation)
+--
+-- score_breakdown_json does NOT persist listing_quality sub-signals (only
+-- the 0-100 composite under inputs->listing_quality), so this probe
+-- RECONSTRUCTS them from feature_snapshot_json + the commercial_unit row,
+-- exactly mirroring _listing_quality_score in app/services/expansion_advisor.py.
+--
+-- Weight-stack aware: rows scored under EXPANSION_WEIGHT_STACK=v2 are
+-- detected via score_breakdown_json->'weights' ? 'district_momentum' and use
+-- the v2 renormalized sub-weights (freshness 0.30/0.65, suitability
+-- 0.20/0.65, image 0.10/0.65, furnished 0.05/0.65, momentum EXCLUDED —
+-- it is paid once as the top-level district_momentum component). v1 rows
+-- use the momentum-enabled tuple (0.30 / 0.20 / 0.10 / 0.05 / 0.35).
+-- Both stacks keep the +5 drive-thru bonus.
+--
+-- Join key: commercial_unit.aqar_id = expansion_candidate.parcel_id.
+-- Verified against the live schema: commercial_unit has no integer PK —
+-- aqar_id varchar(64) is the key — and expansion_candidate.parcel_id holds
+-- the Aqar listing ID for listing candidates (the candidate query emits
+-- COALESCE(source_id, id::text) AS parcel_id). No status filter on the
+-- join — the unit may have gone inactive since the search; cu.status is
+-- emitted for transparency in section C.
+--
+-- Classification used in the report:
+--   freshness  -> listing-artifact   (posting/refresh behavior on Aqar)
+--   image      -> listing-artifact   (photo / LLM listing-quality read)
+--   suitability-> mixed              (LLM read of the listing describing the site)
+--   furnished  -> unit-intrinsic
+--   momentum   -> district market signal (neither site nor listing; v1 rows only)
+--
+-- Section A reports per-sub-signal weighted-contribution variance (within
+-- listing_quality, in listing-quality points). Variance shares ignore
+-- covariance between sub-signals — they are a first-order attribution, not
+-- an exact decomposition; section A also emits the recomposed composite vs
+-- the stored input as a reconstruction check (mean_abs_diff should be ~0;
+-- small drift = momentum entry changed between passes).
+--
+\echo ''
+\echo '=== A. Sub-signal contribution stats across recent listing candidates ==='
+WITH recent_searches AS (
+  SELECT s.id
+  FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC
+  LIMIT 10
+),
+sub AS (
+  SELECT
+    c.search_id,
+    c.id AS candidate_id,
+    (c.score_breakdown_json->'inputs'->>'listing_quality')::numeric AS stored_lq,
+    -- weight-stack flag: v2 rows carry district_momentum as a component
+    (c.score_breakdown_json->'weights' ? 'district_momentum') AS is_v2,
+    -- freshness band, from the persisted effective age
+    CASE
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days') IS NULL THEN 50.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 14  THEN 100.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 30  THEN 92.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 60  THEN 80.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 120 THEN 65.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 240 THEN 45.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 365 THEN 28.0
+      ELSE 15.0
+    END AS freshness,
+    -- suitability: LLM verdict, else structural restaurant_score * 2, else 50
+    COALESCE(
+      LEAST(100.0, GREATEST(0.0, cu.llm_suitability_score::numeric)),
+      CASE WHEN cu.restaurant_score IS NOT NULL AND cu.restaurant_score > 0
+           THEN LEAST(100.0, GREATEST(0.0, cu.restaurant_score::numeric * 2.0)) END,
+      50.0
+    ) AS suitability,
+    -- image signal: LLM listing-quality, else binary image presence
+    COALESCE(
+      LEAST(100.0, GREATEST(0.0, cu.llm_listing_quality_score::numeric)),
+      CASE WHEN c.image_url IS NOT NULL AND c.image_url <> '' THEN 100.0 ELSE 30.0 END
+    ) AS image_signal,
+    CASE WHEN cu.is_furnished IS TRUE THEN 100.0 ELSE 50.0 END AS furnished_signal,
+    COALESCE(
+      (c.feature_snapshot_json->'district_momentum'->>'momentum_score')::numeric,
+      50.0
+    ) AS momentum_signal,
+    CASE WHEN cu.has_drive_thru IS TRUE THEN 5.0 ELSE 0.0 END AS drive_thru_bonus
+  FROM expansion_candidate c
+  JOIN recent_searches rs ON rs.id = c.search_id
+  LEFT JOIN commercial_unit cu ON cu.aqar_id = c.parcel_id
+  WHERE c.commercial_unit_id IS NOT NULL          -- listings only
+    AND c.score_breakdown_json ? 'inputs'
+),
+weighted AS (
+  SELECT *,
+    freshness        * CASE WHEN is_v2 THEN 0.30/0.65 ELSE 0.30 END AS w_freshness,
+    suitability      * CASE WHEN is_v2 THEN 0.20/0.65 ELSE 0.20 END AS w_suitability,
+    image_signal     * CASE WHEN is_v2 THEN 0.10/0.65 ELSE 0.10 END AS w_image,
+    furnished_signal * CASE WHEN is_v2 THEN 0.05/0.65 ELSE 0.05 END AS w_furnished,
+    momentum_signal  * CASE WHEN is_v2 THEN 0.0       ELSE 0.35 END AS w_momentum,
+    (  freshness        * CASE WHEN is_v2 THEN 0.30/0.65 ELSE 0.30 END
+     + suitability      * CASE WHEN is_v2 THEN 0.20/0.65 ELSE 0.20 END
+     + image_signal     * CASE WHEN is_v2 THEN 0.10/0.65 ELSE 0.10 END
+     + furnished_signal * CASE WHEN is_v2 THEN 0.05/0.65 ELSE 0.05 END
+     + momentum_signal  * CASE WHEN is_v2 THEN 0.0       ELSE 0.35 END
+     + drive_thru_bonus) AS recomposed
+  FROM sub
+)
+SELECT * FROM (
+  SELECT 'freshness (artifact, v1 0.30 / v2 0.4615)' AS sub_signal, ROUND(AVG(w_freshness)::numeric,2)  AS mean_pts, ROUND(VAR_SAMP(w_freshness)::numeric,2)  AS variance, ROUND(STDDEV_SAMP(w_freshness)::numeric,2)  AS stddev FROM weighted
+  UNION ALL
+  SELECT 'suitability (mixed, v1 0.20 / v2 0.3077)',    ROUND(AVG(w_suitability)::numeric,2), ROUND(VAR_SAMP(w_suitability)::numeric,2), ROUND(STDDEV_SAMP(w_suitability)::numeric,2) FROM weighted
+  UNION ALL
+  SELECT 'image (artifact, v1 0.10 / v2 0.1538)',       ROUND(AVG(w_image)::numeric,2),       ROUND(VAR_SAMP(w_image)::numeric,2),       ROUND(STDDEV_SAMP(w_image)::numeric,2)       FROM weighted
+  UNION ALL
+  SELECT 'furnished (unit, v1 0.05 / v2 0.0769)',       ROUND(AVG(w_furnished)::numeric,2),   ROUND(VAR_SAMP(w_furnished)::numeric,2),   ROUND(STDDEV_SAMP(w_furnished)::numeric,2)   FROM weighted
+  UNION ALL
+  SELECT 'momentum (market, v1 0.35 / v2 EXCLUDED)',    ROUND(AVG(w_momentum)::numeric,2),    ROUND(VAR_SAMP(w_momentum)::numeric,2),    ROUND(STDDEV_SAMP(w_momentum)::numeric,2)    FROM weighted
+  UNION ALL
+  SELECT 'RECONSTRUCTION CHECK (abs diff)', ROUND(AVG(ABS(recomposed - stored_lq))::numeric,2), NULL, NULL FROM weighted
+) t;
+
+\echo ''
+\echo '=== B. Variance share: listing-artifact vs site/unit vs market ==='
+-- First-order attribution (covariances ignored): share of summed sub-signal
+-- variances. artifact = freshness + image; mixed = suitability;
+-- unit = furnished; market = momentum (0 by construction for v2 rows).
+WITH recent_searches AS (
+  SELECT s.id FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC LIMIT 10
+),
+sub AS (
+  SELECT
+    CASE
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days') IS NULL THEN 50.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 14  THEN 100.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 30  THEN 92.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 60  THEN 80.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 120 THEN 65.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 240 THEN 45.0
+      WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days')::numeric <= 365 THEN 28.0
+      ELSE 15.0
+    END * CASE WHEN (c.score_breakdown_json->'weights' ? 'district_momentum') THEN 0.30/0.65 ELSE 0.30 END AS w_freshness,
+    COALESCE(
+      LEAST(100.0, GREATEST(0.0, cu.llm_suitability_score::numeric)),
+      CASE WHEN cu.restaurant_score IS NOT NULL AND cu.restaurant_score > 0
+           THEN LEAST(100.0, GREATEST(0.0, cu.restaurant_score::numeric * 2.0)) END,
+      50.0
+    ) * CASE WHEN (c.score_breakdown_json->'weights' ? 'district_momentum') THEN 0.20/0.65 ELSE 0.20 END AS w_suitability,
+    COALESCE(
+      LEAST(100.0, GREATEST(0.0, cu.llm_listing_quality_score::numeric)),
+      CASE WHEN c.image_url IS NOT NULL AND c.image_url <> '' THEN 100.0 ELSE 30.0 END
+    ) * CASE WHEN (c.score_breakdown_json->'weights' ? 'district_momentum') THEN 0.10/0.65 ELSE 0.10 END AS w_image,
+    CASE WHEN cu.is_furnished IS TRUE THEN 100.0 ELSE 50.0 END
+      * CASE WHEN (c.score_breakdown_json->'weights' ? 'district_momentum') THEN 0.05/0.65 ELSE 0.05 END AS w_furnished,
+    COALESCE((c.feature_snapshot_json->'district_momentum'->>'momentum_score')::numeric, 50.0)
+      * CASE WHEN (c.score_breakdown_json->'weights' ? 'district_momentum') THEN 0.0 ELSE 0.35 END AS w_momentum
+  FROM expansion_candidate c
+  JOIN recent_searches rs ON rs.id = c.search_id
+  LEFT JOIN commercial_unit cu ON cu.aqar_id = c.parcel_id
+  WHERE c.commercial_unit_id IS NOT NULL
+),
+v AS (
+  SELECT
+    VAR_SAMP(w_freshness)  AS v_fresh,
+    VAR_SAMP(w_suitability) AS v_suit,
+    VAR_SAMP(w_image)      AS v_img,
+    VAR_SAMP(w_furnished)  AS v_furn,
+    VAR_SAMP(w_momentum)   AS v_mom
+  FROM sub
+)
+SELECT
+  ROUND(((v_fresh + v_img) / NULLIF(v_fresh+v_suit+v_img+v_furn+v_mom,0) * 100)::numeric, 1) AS artifact_pct,
+  ROUND((v_suit            / NULLIF(v_fresh+v_suit+v_img+v_furn+v_mom,0) * 100)::numeric, 1) AS mixed_llm_pct,
+  ROUND((v_furn            / NULLIF(v_fresh+v_suit+v_img+v_furn+v_mom,0) * 100)::numeric, 1) AS unit_intrinsic_pct,
+  ROUND((v_mom             / NULLIF(v_fresh+v_suit+v_img+v_furn+v_mom,0) * 100)::numeric, 1) AS market_momentum_pct
+FROM v;
+
+\echo ''
+\echo '=== C. Coverage: how often each sub-signal is real vs neutral fallback ==='
+WITH recent_searches AS (
+  SELECT s.id FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC LIMIT 10
+)
+SELECT
+  COUNT(*)                                                                          AS n_listing_candidates,
+  SUM(CASE WHEN cu.aqar_id IS NULL THEN 1 ELSE 0 END)                               AS unit_join_misses,
+  SUM(CASE WHEN cu.status IS DISTINCT FROM 'active' THEN 1 ELSE 0 END)              AS unit_not_active_now,
+  SUM(CASE WHEN (c.feature_snapshot_json->'listing_age'->>'effective_age_days') IS NULL THEN 1 ELSE 0 END) AS age_unknown,
+  SUM(CASE WHEN cu.llm_suitability_score IS NULL THEN 1 ELSE 0 END)                 AS llm_suitability_null,
+  SUM(CASE WHEN cu.llm_listing_quality_score IS NULL THEN 1 ELSE 0 END)             AS llm_quality_null,
+  SUM(CASE WHEN cu.llm_landlord_signal_score IS NULL THEN 1 ELSE 0 END)             AS llm_landlord_null,
+  SUM(CASE WHEN COALESCE((c.feature_snapshot_json->'district_momentum'->>'sample_floor_applied')::boolean, true) THEN 1 ELSE 0 END) AS momentum_neutral
+FROM expansion_candidate c
+JOIN recent_searches rs ON rs.id = c.search_id
+LEFT JOIN commercial_unit cu ON cu.aqar_id = c.parcel_id
+WHERE c.commercial_unit_id IS NOT NULL;

--- a/scripts/diagnostics/weight_discrimination.sql
+++ b/scripts/diagnostics/weight_discrimination.sql
@@ -1,0 +1,120 @@
+\pset footer off
+--
+-- weight_discrimination.sql  (Probe A — weight-stack investigation)
+--
+-- Core question: do nominal component weights translate into actual ranking
+-- influence? A high-weight component whose contribution barely varies across
+-- candidates within a search is dead weight; a low-weight component with a
+-- wide spread punches above its class.
+--
+-- Method: take the most recent ~10 expansion_search rows that actually have
+-- candidates, explode score_breakdown_json->'weighted_components' (the
+-- per-component contribution in POINTS of final_score), compute per-search
+-- stddev / p10 / p90 / (p90-p10), then average those per-search stats across
+-- searches. Searches with < 8 candidates are skipped (too few rows for a
+-- meaningful spread).
+--
+-- discrimination_index = mean per-search stddev of the contribution (pts).
+--
+-- NOTE: persisted final_score = weighted sum + bonus deltas
+-- (score_breakdown_json->'bonus_detail'); the weighted_components here are
+-- the pre-delta deterministic contributions, which is what we want.
+--
+-- Weight-stack aware by construction: components are exploded from each
+-- row's weighted_components, so v2 rows (EXPANSION_WEIGHT_STACK=v2)
+-- contribute district_momentum and simply have no confidence row (weight 0,
+-- display-only) without any change here.
+--
+\echo ''
+\echo '=== A. Per-component contribution discrimination (recent ~10 searches) ==='
+WITH recent_searches AS (
+  SELECT s.id
+  FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC
+  LIMIT 10
+),
+contrib AS (
+  SELECT
+    c.search_id,
+    kv.key                                                   AS component,
+    (kv.value)::numeric                                      AS pts,
+    (c.score_breakdown_json->'weights'->>kv.key)::numeric    AS weight_pct
+  FROM expansion_candidate c
+  JOIN recent_searches rs ON rs.id = c.search_id
+  CROSS JOIN LATERAL jsonb_each_text(c.score_breakdown_json->'weighted_components') AS kv(key, value)
+  WHERE c.score_breakdown_json ? 'weighted_components'
+),
+per_search AS (
+  SELECT
+    search_id,
+    component,
+    COUNT(*)                                                       AS n,
+    AVG(weight_pct)                                                AS weight_pct,
+    AVG(pts)                                                       AS mean_pts,
+    STDDEV_SAMP(pts)                                               AS sd_pts,
+    percentile_cont(0.10) WITHIN GROUP (ORDER BY pts)              AS p10,
+    percentile_cont(0.90) WITHIN GROUP (ORDER BY pts)              AS p90
+  FROM contrib
+  GROUP BY search_id, component
+  HAVING COUNT(*) >= 8
+)
+SELECT
+  component,
+  COUNT(*)                                          AS n_searches,
+  ROUND(AVG(weight_pct), 2)                         AS nominal_weight_pct,
+  ROUND(AVG(mean_pts)::numeric, 2)                  AS mean_contribution,
+  ROUND(AVG(p90 - p10)::numeric, 2)                 AS spread_p90_p10,
+  ROUND(AVG(sd_pts)::numeric, 2)                    AS stddev,
+  ROUND(AVG(sd_pts)::numeric, 2)                    AS discrimination_index,
+  -- spread per weight point: how hard each nominal weight pct works
+  ROUND((AVG(sd_pts) / NULLIF(AVG(weight_pct), 0))::numeric, 3) AS sd_per_weight_pct
+FROM per_search
+GROUP BY component
+ORDER BY nominal_weight_pct DESC;
+
+\echo ''
+\echo '=== B. Rank influence: per-search corr(component pts, deterministic base) ==='
+-- Pearson corr between each component contribution and the deterministic
+-- base score (bonus_detail.base_deterministic when present, else
+-- score_breakdown final_score). A high-weight component with near-zero corr
+-- to the score that actually orders candidates is not driving rank.
+WITH recent_searches AS (
+  SELECT s.id
+  FROM expansion_search s
+  WHERE EXISTS (SELECT 1 FROM expansion_candidate c WHERE c.search_id = s.id)
+  ORDER BY s.created_at DESC
+  LIMIT 10
+),
+contrib AS (
+  SELECT
+    c.search_id,
+    kv.key              AS component,
+    (kv.value)::numeric AS pts,
+    COALESCE(
+      (c.score_breakdown_json->'bonus_detail'->>'base_deterministic')::numeric,
+      (c.score_breakdown_json->>'final_score')::numeric,
+      c.final_score::numeric
+    ) AS base_score
+  FROM expansion_candidate c
+  JOIN recent_searches rs ON rs.id = c.search_id
+  CROSS JOIN LATERAL jsonb_each_text(c.score_breakdown_json->'weighted_components') AS kv(key, value)
+  WHERE c.score_breakdown_json ? 'weighted_components'
+),
+per_search AS (
+  SELECT search_id, component,
+         corr(pts::float8, base_score::float8) AS r,
+         COUNT(*) AS n
+  FROM contrib
+  GROUP BY search_id, component
+  HAVING COUNT(*) >= 8
+)
+SELECT
+  component,
+  COUNT(*)                       AS n_searches,
+  ROUND(AVG(r)::numeric, 3)      AS mean_corr_with_base_score,
+  ROUND(MIN(r)::numeric, 3)      AS min_corr,
+  ROUND(MAX(r)::numeric, 3)      AS max_corr
+FROM per_search
+GROUP BY component
+ORDER BY mean_corr_with_base_score DESC;

--- a/tests/test_expansion_weight_stack.py
+++ b/tests/test_expansion_weight_stack.py
@@ -1,0 +1,256 @@
+"""Weight stack v2 (EXPANSION_WEIGHT_STACK) — flag-gated rebalance tests.
+
+Covers the five contract points of the v2 patch:
+  * v1 (default) is inert — weights / contributions / ordering unchanged;
+  * v2 weights sum to exactly 100, pre- and post-brand-multiplier;
+  * momentum is single-paid under v2 (own component, out of listing_quality,
+    no +2 sort-time bonus);
+  * confidence contributes 0 weighted points under v2 but its raw value
+    stays in the breakdown JSON;
+  * listing_quality sub-weights renormalize to 1.0 under v2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services import expansion_advisor as expansion_service
+
+
+def _breakdown_kwargs(**overrides):
+    kwargs = dict(
+        demand_score=80,
+        whitespace_score=70,
+        brand_fit_score=75,
+        economics_score=60,
+        provider_intelligence_composite=65,
+        access_visibility_score=55,
+        confidence_score=50,
+        listing_quality_score=60,
+        landlord_signal_score=40,
+        chain_strength_score=30,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _set_stack(monkeypatch, value: str) -> None:
+    monkeypatch.setattr(
+        expansion_service.settings, "EXPANSION_WEIGHT_STACK", value, raising=False
+    )
+
+
+def _delta_candidate(momentum_score=90.0, sample_floor_applied=False):
+    return {
+        "parcel_id": "p1",
+        "final_score": 70.0,
+        "score_breakdown_json": {},
+        "feature_snapshot_json": {
+            "listing_age": {"created_days": 100, "updated_days": 100},
+            "district_momentum": {
+                "momentum_score": momentum_score,
+                "sample_floor_applied": sample_floor_applied,
+            },
+        },
+    }
+
+
+# ── v1 inertness ─────────────────────────────────────────────────────
+
+
+def test_weight_stack_v1_is_inert(monkeypatch):
+    """Default setting ⇒ weights, contributions, bonus shape, and ordering
+    are byte-identical to the pre-patch v1 stack."""
+    assert expansion_service.settings.EXPANSION_WEIGHT_STACK == "v1"
+
+    breakdown = expansion_service._score_breakdown(**_breakdown_kwargs())
+    # Pinned pre-patch v1 weights (2026-05-07 rebalance + Patch B split).
+    assert breakdown["weights"] == {
+        "occupancy_economics": 26.2924,
+        "listing_quality": 22.0,
+        "brand_fit": 9.6404,
+        "landlord_signal": 7.0112,
+        "competition_whitespace": 5.764,
+        "chain_strength": 3.0,
+        "demand_potential": 8.7640,
+        "access_visibility": 8.7640,
+        "delivery_demand": 4.3820,
+        "confidence": 4.3820,
+    }
+    # Pinned contributions: raw_input × weight / 100, rounded to 2 dp.
+    assert breakdown["weighted_components"] == {
+        "occupancy_economics": 15.78,
+        "listing_quality": 13.2,
+        "brand_fit": 7.23,
+        "landlord_signal": 2.8,
+        "competition_whitespace": 4.03,
+        "chain_strength": 0.9,
+        "demand_potential": 7.01,
+        "access_visibility": 4.82,
+        "delivery_demand": 2.85,
+        "confidence": 2.19,
+    }
+    assert "district_momentum" not in breakdown["weights"]
+    assert "district_momentum" not in breakdown["inputs"]
+    assert "display_only" not in breakdown
+
+    # district_momentum_score is accepted but ignored under v1.
+    with_momentum = expansion_service._score_breakdown(
+        **_breakdown_kwargs(), district_momentum_score=95.0
+    )
+    assert with_momentum == breakdown
+
+    # Sort-time deltas keep the momentum bonus leg and its bonus_detail key.
+    candidates = [
+        _delta_candidate(),
+        {
+            **_delta_candidate(),
+            "parcel_id": "p2",
+            "final_score": 71.0,
+            "score_breakdown_json": {},
+        },
+    ]
+    out = expansion_service._apply_score_deltas_and_sort(candidates)
+    detail = out[0]["score_breakdown_json"]["bonus_detail"]
+    assert detail["momentum_bonus"] == 2.0
+    assert list(detail.keys()) == [
+        "base_deterministic",
+        "value_band_delta",
+        "viability_legs_fired",
+        "viability_delta",
+        "freshness_bonus",
+        "freshness_label",
+        "momentum_bonus",
+        "total_delta",
+        "final_score_clamped",
+    ]
+    assert [c["parcel_id"] for c in out] == ["p2", "p1"]
+
+
+# ── v2 weights ───────────────────────────────────────────────────────
+
+
+def test_weight_stack_v2_sums_100(monkeypatch):
+    _set_stack(monkeypatch, "v2")
+    breakdown = expansion_service._score_breakdown(**_breakdown_kwargs())
+    weights = breakdown["weights"]
+    assert weights == {
+        "occupancy_economics": 20.0,
+        "demand_potential": 18.0,
+        "competition_whitespace": 12.0,
+        "access_visibility": 11.0,
+        "listing_quality": 9.0,
+        "brand_fit": 8.0,
+        "district_momentum": 7.0,
+        "delivery_demand": 6.0,
+        "landlord_signal": 5.0,
+        "chain_strength": 4.0,
+    }
+    assert sum(weights.values()) == 100.0
+
+    # Post-brand-multiplier renormalization also sums to 100.
+    monkeypatch.setattr(
+        expansion_service.settings, "EXPANSION_BRAND_WEIGHT_GAIN", 0.35, raising=False
+    )
+    reweighted = expansion_service._score_breakdown(
+        **_breakdown_kwargs(),
+        brand_profile={"primary_channel": "delivery", "expansion_goal": "flagship"},
+        service_model="qsr",
+    )["weights"]
+    assert abs(sum(reweighted.values()) - 100) < 1e-3
+    assert "district_momentum" in reweighted
+    assert "confidence" not in reweighted
+
+
+def test_v2_momentum_single_payment(monkeypatch):
+    _set_stack(monkeypatch, "v2")
+
+    # Own component, fed by district_momentum_score (None → neutral 50).
+    breakdown = expansion_service._score_breakdown(
+        **_breakdown_kwargs(), district_momentum_score=90.0
+    )
+    assert breakdown["weights"]["district_momentum"] == 7.0
+    assert breakdown["inputs"]["district_momentum"] == 90.0
+    assert breakdown["weighted_components"]["district_momentum"] == 6.3
+    neutral = expansion_service._score_breakdown(**_breakdown_kwargs())
+    assert neutral["inputs"]["district_momentum"] == 50.0
+
+    # listing_quality no longer pays momentum: the composite is invariant
+    # to district_momentum_score under v2.
+    lq_kwargs = dict(
+        is_listing=True,
+        effective_age_days=10,
+        is_furnished=True,
+        unit_restaurant_score=40.0,
+        has_image=True,
+    )
+    assert expansion_service._listing_quality_score(
+        **lq_kwargs, district_momentum_score=100.0
+    ) == expansion_service._listing_quality_score(
+        **lq_kwargs, district_momentum_score=0.0
+    )
+
+    # No +2 sort-time bonus; bonus_detail omits the momentum_bonus key.
+    out = expansion_service._apply_score_deltas_and_sort([_delta_candidate()])
+    detail = out[0]["score_breakdown_json"]["bonus_detail"]
+    assert "momentum_bonus" not in detail
+    assert detail["total_delta"] == 0.0
+    assert out[0]["final_score"] == 70.0
+
+
+def test_v2_confidence_not_weighted(monkeypatch):
+    _set_stack(monkeypatch, "v2")
+    breakdown = expansion_service._score_breakdown(
+        **_breakdown_kwargs(confidence_score=83.0)
+    )
+    assert "confidence" not in breakdown["weights"]
+    assert "confidence" not in breakdown["weighted_components"]
+    # Raw value stays in the breakdown JSON for the UI data-quality grade.
+    assert breakdown["inputs"]["confidence"] == 83.0
+    assert breakdown["display_only"]["confidence"] == {
+        "raw_input_score": 83.0,
+        "weight_percent": 0.0,
+    }
+    # final_score is exactly the sum of the weighted set (no confidence pts).
+    assert breakdown["final_score"] == pytest.approx(
+        sum(breakdown["weighted_components"].values()), abs=0.01
+    )
+
+
+def test_v2_listing_quality_renormalized(monkeypatch):
+    _set_stack(monkeypatch, "v2")
+    # Renormalized sub-weights sum to 1.0 exactly.
+    sub = (0.30 / 0.65, 0.20 / 0.65, 0.10 / 0.65, 0.05 / 0.65)
+    assert sum(sub) == pytest.approx(1.0, abs=1e-12)
+
+    # Fixture: freshness band 100 (10 days), suitability 80 (structural
+    # 40 × 2), image 100, furnished 100 → expected renormalized composite.
+    score = expansion_service._listing_quality_score(
+        is_listing=True,
+        effective_age_days=10,
+        is_furnished=True,
+        unit_restaurant_score=40.0,
+        has_image=True,
+    )
+    expected = 100.0 * sub[0] + 80.0 * sub[1] + 100.0 * sub[2] + 100.0 * sub[3]
+    assert score == pytest.approx(expected, abs=1e-9)
+
+    # Drive-thru bump unchanged (+5) and parcels stay neutral 50.
+    assert expansion_service._listing_quality_score(
+        is_listing=True,
+        effective_age_days=10,
+        is_furnished=True,
+        unit_restaurant_score=40.0,
+        has_image=True,
+        has_drive_thru=True,
+    ) == pytest.approx(min(expected + 5.0, 100.0), abs=1e-9)
+    assert (
+        expansion_service._listing_quality_score(
+            is_listing=False,
+            effective_age_days=None,
+            is_furnished=None,
+            unit_restaurant_score=None,
+            has_image=False,
+        )
+        == 50.0
+    )


### PR DESCRIPTION
Flag-gated by new setting EXPANSION_WEIGHT_STACK (default "v1" =
byte-identical to current production scores). Under "v2":

- D1 district_momentum becomes its own top-level component (7.0),
  extracted from _listing_quality_score (remaining sub-weights
  renormalize 0.30/0.20/0.10/0.05 -> /0.65); the +2 momentum bonus in
  _apply_score_deltas_and_sort is removed and bonus_detail omits the
  momentum_bonus key.
- D2 confidence is removed from the weighted sum but stays computed and
  exposed (inputs.confidence + display_only block) for the UI
  data-quality grade; all local dampeners untouched.
- D3 v2 weights (sum 100): occupancy_economics 20, demand_potential 18,
  competition_whitespace 12, access_visibility 11, listing_quality 9,
  brand_fit 8, district_momentum 7, delivery_demand 6,
  landlord_signal 5, chain_strength 4 (fixed —
  EXPANSION_CHAIN_STRENGTH_WEIGHT is v1-only).

Brand-brief weight multipliers apply identically on both stacks
(district_momentum added to _REWEIGHTABLE_COMPONENTS at 1.0). Memo
weights become stack-aware (COMPONENT_WEIGHTS_V2); no memo-version bump
(default v1 rendering unchanged). Frontend renders a District Momentum
row (EN/AR i18n + swatch) and auto-hides the weighted Data Quality row
when confidence has no weight.

Probe repair: the four weight-stack diagnostics from the June 2026
investigation land on this branch with Probe C's commercial_unit join
fixed to cu.aqar_id = c.parcel_id and made weight-stack-aware; probes
A/B/D explode JSON keys and need no per-stack changes.

Tests: 5 new tests in tests/test_expansion_weight_stack.py (v1
inertness pinned, v2 sum==100, single payment, confidence unweighted,
listing-quality renormalization). Full suite: 2368 passed, 23 skipped.

https://claude.ai/code/session_018KJ1Q4kmfesmaji85AUJd5