### PR TITLE
fix(memo): read component raw scores from score_breakdown.inputs; align v1 weights with scorer

### DIFF
--- a/app/services/llm_decision_memo.py
+++ b/app/services/llm_decision_memo.py
@@ -50,7 +50,7 @@ TEMPERATURE = 0.3
 # Bumped whenever STRUCTURED_MEMO_SYSTEM_PROMPT changes meaningfully.
 # Cached memos with a different version are treated as cache-miss and
 # regenerated lazily on next view.
-MEMO_PROMPT_VERSION = "v12.2-listing-age-leverage-2026-06"
+MEMO_PROMPT_VERSION = "v12.3-component-lookup-2026-06"
 
 # Soft daily ceiling in USD.  Raises RuntimeError before calling OpenAI
 # if the running total for today exceeds this value.
@@ -381,22 +381,26 @@ def generate_decision_memo(
 
 # ── Structured decision memo (Phase 1) ──────────────────────────────
 #
-# The structured memo path is additive: it sits on top of the 9-component
-# deterministic scorer, does NOT modify scoring/gating/ranking, and can be
+# The structured memo path is additive: it sits on top of the deterministic
+# component scorer, does NOT modify scoring/gating/ranking, and can be
 # toggled off via ``settings.EXPANSION_MEMO_STRUCTURED_ENABLED`` to revert
 # to the legacy ``generate_decision_memo`` output byte-for-byte.
 
-# Deterministic scorer weights — kept in sync with the 9-component weights
+# Deterministic scorer weights — kept in sync with the v1 component weights
 # in ``app.services.expansion_advisor`` (see _score_breakdown). Editing
 # these here does NOT change scoring; these are used only to compute
 # memo-display contributions. 2026-05-07 rebalance: listing_quality lifted
 # 0.11 → 0.22 to elevate CEO-directive recency and momentum signals; every
-# other component rescaled by 78/89 = 0.8764045.
+# other component rescaled by 78/89 = 0.8764045. Patch B then carved
+# chain_strength out of competition_whitespace (values below assume the
+# EXPANSION_CHAIN_STRENGTH_WEIGHT default of 3.0; _active_component_weights
+# applies the live env-driven split so memo weights track the scorer).
 COMPONENT_WEIGHTS: dict[str, float] = {
     "occupancy_economics": 0.262924,
     "listing_quality": 0.22,
     "brand_fit": 0.096404,
-    "competition_whitespace": 0.087640,
+    "competition_whitespace": 0.05764,
+    "chain_strength": 0.03,
     "demand_potential": 0.087640,
     "access_visibility": 0.087640,
     "landlord_signal": 0.070112,
@@ -422,11 +426,18 @@ COMPONENT_WEIGHTS_V2: dict[str, float] = {
 
 
 def _active_component_weights() -> dict[str, float]:
-    """Memo-display weights for the active weight stack. v1 (default)
-    returns COMPONENT_WEIGHTS unchanged so memo output stays byte-identical."""
+    """Memo-display weights for the active weight stack, aligned with the
+    scorer's ``_score_breakdown`` dicts. Under v1 the chain_strength /
+    competition_whitespace split mirrors the scorer's env-driven Patch-B
+    carve-out (EXPANSION_CHAIN_STRENGTH_WEIGHT, v1-only) so memo weights
+    track the scorer even when the env var is recalibrated."""
     if str(getattr(settings, "EXPANSION_WEIGHT_STACK", "v1")) == "v2":
         return COMPONENT_WEIGHTS_V2
-    return COMPONENT_WEIGHTS
+    weights = dict(COMPONENT_WEIGHTS)
+    _chain_pct = float(getattr(settings, "EXPANSION_CHAIN_STRENGTH_WEIGHT", 3.0))
+    weights["chain_strength"] = round(_chain_pct / 100.0, 6)
+    weights["competition_whitespace"] = round((8.7640 - _chain_pct) / 100.0, 6)
+    return weights
 
 # Feature-snapshot fields that actually drive a decision. Used to truncate
 # oversized snapshots to a compact LLM-friendly payload.
@@ -841,9 +852,18 @@ def _component_score_value(
     candidate: dict | None,
     comp: str,
 ) -> float:
-    """Best-effort lookup of a per-component score (0..100) by trying the
-    canonical key, then ``<comp>_score``, then the flat candidate dict."""
+    """Best-effort lookup of a per-component raw input score (0..100).
+
+    Precedence: ``score_breakdown["inputs"][comp]`` (the canonical
+    ``_score_breakdown`` shape — covers every component of both weight
+    stacks, including v2's ``district_momentum`` and the display-only
+    ``confidence``), then the legacy top-level / ``<comp>_score`` /
+    ``components`` shapes, then the flat candidate dict, then 0.
+    """
     bd = score_breakdown or {}
+    inputs = bd.get("inputs")
+    if isinstance(inputs, dict) and isinstance(inputs.get(comp), (int, float)):
+        return float(inputs[comp])
     if isinstance(bd.get(comp), (int, float)):
         return float(bd[comp])
     score_key = f"{comp}_score"
@@ -1416,7 +1436,7 @@ _STRUCTURED_MEMO_PREAMBLE = """You are a senior real-estate advisor in Riyadh wr
 
 Write like an advisor, not a junior analyst. Lead with the strongest investment argument grounded in a specific number. Synthesize the score breakdown into a thesis — never restate the breakdown back at the reader as a list of percentages. Be direct. Be specific to this candidate, this listing, this catchment. Density beats length.
 
-You will receive a JSON object describing the brand profile, the candidate's feature snapshot, the score_breakdown (9 components with weights and contributions), the gate buckets (gates.passed / gates.failed / gates.unknown — tri-state), deterministic anchors (overall_pass, final_rank, final_score, deterministic_verdict), comparable competitors, the rank-2 alternative (next_candidate_summary), and optionally a realized_demand block.
+You will receive a JSON object describing the brand profile, the candidate's feature snapshot, the score_breakdown (weighted components with weights and contributions), the gate buckets (gates.passed / gates.failed / gates.unknown — tri-state), deterministic anchors (overall_pass, final_rank, final_score, deterministic_verdict), comparable competitors, the rank-2 alternative (next_candidate_summary), and optionally a realized_demand block.
 
 Return ONLY a single JSON object — no markdown fences, no commentary before or after. The object must contain EXACTLY these ten top-level keys:
 

--- a/tests/data/pr4a_structured_memo_system_prompt_en_head.txt
+++ b/tests/data/pr4a_structured_memo_system_prompt_en_head.txt
@@ -2,7 +2,7 @@ You are a senior real-estate advisor in Riyadh writing an investment memo for a 
 
 Write like an advisor, not a junior analyst. Lead with the strongest investment argument grounded in a specific number. Synthesize the score breakdown into a thesis — never restate the breakdown back at the reader as a list of percentages. Be direct. Be specific to this candidate, this listing, this catchment. Density beats length.
 
-You will receive a JSON object describing the brand profile, the candidate's feature snapshot, the score_breakdown (9 components with weights and contributions), the gate buckets (gates.passed / gates.failed / gates.unknown — tri-state), deterministic anchors (overall_pass, final_rank, final_score, deterministic_verdict), comparable competitors, the rank-2 alternative (next_candidate_summary), and optionally a realized_demand block.
+You will receive a JSON object describing the brand profile, the candidate's feature snapshot, the score_breakdown (weighted components with weights and contributions), the gate buckets (gates.passed / gates.failed / gates.unknown — tri-state), deterministic anchors (overall_pass, final_rank, final_score, deterministic_verdict), comparable competitors, the rank-2 alternative (next_candidate_summary), and optionally a realized_demand block.
 
 Return ONLY a single JSON object — no markdown fences, no commentary before or after. The object must contain EXACTLY these ten top-level keys:
 

--- a/tests/test_llm_decision_memo.py
+++ b/tests/test_llm_decision_memo.py
@@ -371,6 +371,7 @@ BASE_STRUCTURED_CANDIDATE = {
         "listing_quality": 70,
         "brand_fit": 80,
         "competition_whitespace": 60,
+        "chain_strength": 40,
         "demand_potential": 75,
         "access_visibility": 65,
         "landlord_signal": 55,
@@ -409,7 +410,7 @@ def _mock_client_returning(content, input_tokens: int = 400, output_tokens: int 
 class TestBuildMemoContextContributionsMath:
     """Step 8, test 9."""
 
-    def test_contributions_equal_weight_times_score_for_all_nine(self):
+    def test_contributions_equal_weight_times_score_for_all_components(self):
         ctx = build_memo_context(
             candidate=BASE_STRUCTURED_CANDIDATE,
             brief=BASE_STRUCTURED_BRIEF,
@@ -417,7 +418,7 @@ class TestBuildMemoContextContributionsMath:
         )
         scores = BASE_STRUCTURED_CANDIDATE["score_breakdown_json"]
         contributions = ctx.score_breakdown["contributions"]
-        # All nine components represented
+        # Every weighted component represented
         assert set(contributions.keys()) == set(COMPONENT_WEIGHTS.keys())
         for comp, weight in COMPONENT_WEIGHTS.items():
             expected = round(weight * scores[comp], 3)
@@ -428,6 +429,145 @@ class TestBuildMemoContextContributionsMath:
         assert contributions["occupancy_economics"] == 23.663
         # Weights sub-dict carried through for the LLM
         assert ctx.score_breakdown["weights"] == dict(COMPONENT_WEIGHTS)
+
+
+# ── Component-score lookup: inputs precedence + weight parity ───────
+
+
+def _scorer_breakdown(**overrides):
+    """Call the deterministic scorer's _score_breakdown with neutral
+    inputs; pure function, no DB."""
+    from app.services import expansion_advisor as expansion_service
+
+    kwargs = dict(
+        demand_score=80,
+        whitespace_score=70,
+        brand_fit_score=75,
+        economics_score=60,
+        provider_intelligence_composite=65,
+        access_visibility_score=55,
+        confidence_score=50,
+        listing_quality_score=60,
+        landlord_signal_score=40,
+        chain_strength_score=30,
+    )
+    kwargs.update(overrides)
+    return expansion_service._score_breakdown(**kwargs)
+
+
+def _set_weight_stack(monkeypatch, value: str) -> None:
+    # Patch the settings instance each module actually holds, not the
+    # canonical app.core.config.settings: test_parcel_table_overrides
+    # reloads app.core.config mid-suite, replacing the singleton, while
+    # these modules keep their pre-reload reference (see conftest note).
+    import app.services.llm_decision_memo as memo_mod
+    from app.services import expansion_advisor as expansion_service
+
+    monkeypatch.setattr(
+        memo_mod.settings, "EXPANSION_WEIGHT_STACK", value, raising=False
+    )
+    monkeypatch.setattr(
+        expansion_service.settings, "EXPANSION_WEIGHT_STACK", value, raising=False
+    )
+
+
+class TestComponentLookupReadsInputs:
+    """`_component_score_value` must read the canonical
+    ``score_breakdown["inputs"]`` shape produced by the scorer — not fall
+    through to the flat-candidate fallback and report 0."""
+
+    def test_memo_component_lookup_reads_inputs(self):
+        breakdown = _scorer_breakdown()
+        candidate = {
+            "id": "cand-inputs-v1",
+            "score_breakdown_json": breakdown,
+        }
+        ctx = build_memo_context(
+            candidate=candidate, brief=BASE_STRUCTURED_BRIEF, lang="en"
+        )
+        contributions = ctx.score_breakdown["contributions"]
+        inputs = breakdown["inputs"]
+        # The two components that previously zeroed out via the flat
+        # fallback now carry the real raw input scores.
+        assert contributions["occupancy_economics"] == round(
+            0.262924 * inputs["occupancy_economics"], 3
+        )
+        assert contributions["demand_potential"] == round(
+            0.087640 * inputs["demand_potential"], 3
+        )
+        assert contributions["occupancy_economics"] > 0
+        assert contributions["demand_potential"] > 0
+
+    def test_memo_component_lookup_reads_inputs_v2(self, monkeypatch):
+        from app.services.llm_decision_memo import (
+            COMPONENT_WEIGHTS_V2,
+            _component_score_value,
+        )
+
+        _set_weight_stack(monkeypatch, "v2")
+        breakdown = _scorer_breakdown(district_momentum_score=72.0)
+        candidate = {
+            "id": "cand-inputs-v2",
+            "score_breakdown_json": breakdown,
+        }
+        ctx = build_memo_context(
+            candidate=candidate, brief=BASE_STRUCTURED_BRIEF, lang="en"
+        )
+        contributions = ctx.score_breakdown["contributions"]
+        assert set(contributions.keys()) == set(COMPONENT_WEIGHTS_V2.keys())
+        # district_momentum carries the real value, not the zero fallback.
+        assert contributions["district_momentum"] == round(0.07 * 72.0, 3)
+        # confidence is unweighted under v2 (display-only) — absent from
+        # contributions, but a direct lookup still reads the real value.
+        assert "confidence" not in contributions
+        assert _component_score_value(breakdown, candidate, "confidence") == 50.0
+
+    def test_memo_lookup_fallback_order(self):
+        from app.services.llm_decision_memo import _component_score_value
+
+        # inputs takes precedence over the legacy top-level key.
+        both = {"inputs": {"brand_fit": 81.0}, "brand_fit": 12.0}
+        assert _component_score_value(both, None, "brand_fit") == 81.0
+        # Missing from inputs → legacy top-level / <comp>_score lookups.
+        legacy = {"inputs": {}, "brand_fit": 66.0, "demand_potential_score": 44.0}
+        assert _component_score_value(legacy, None, "brand_fit") == 66.0
+        assert _component_score_value(legacy, None, "demand_potential") == 44.0
+        # Missing from the breakdown entirely → flat candidate fallback.
+        candidate = {"listing_quality_score": 58.0}
+        assert _component_score_value({}, candidate, "listing_quality") == 58.0
+        # Fully missing → 0.0, no exception (existing behavior unchanged).
+        assert _component_score_value({}, None, "occupancy_economics") == 0.0
+        assert _component_score_value(None, None, "occupancy_economics") == 0.0
+
+
+class TestMemoWeightsMatchScorer:
+    """Memo-display weights must equal the scorer's component weights for
+    both stacks — drift here renders fabricated contributions."""
+
+    def test_memo_weights_match_scorer(self, monkeypatch):
+        from app.services.llm_decision_memo import (
+            COMPONENT_WEIGHTS_V2,
+            _active_component_weights,
+        )
+
+        # v1 (default stack), including the chain_strength Patch-B split.
+        scorer_v1 = _scorer_breakdown()["weights"]
+        memo_v1 = _active_component_weights()
+        assert set(memo_v1.keys()) == set(scorer_v1.keys())
+        assert "chain_strength" in memo_v1
+        for comp, pct in scorer_v1.items():
+            assert memo_v1[comp] * 100 == pytest.approx(pct, abs=1e-6), comp
+
+        # v2 stack.
+        _set_weight_stack(monkeypatch, "v2")
+        scorer_v2 = _scorer_breakdown(district_momentum_score=70.0)["weights"]
+        memo_v2 = _active_component_weights()
+        assert memo_v2 == COMPONENT_WEIGHTS_V2
+        assert set(memo_v2.keys()) == set(scorer_v2.keys())
+        assert "district_momentum" in memo_v2
+        assert "confidence" not in memo_v2
+        for comp, pct in scorer_v2.items():
+            assert memo_v2[comp] * 100 == pytest.approx(pct, abs=1e-6), comp
 
 
 # ── PR #3: typed advisory-section assembly ──────────────────────────
@@ -2852,7 +2992,7 @@ class TestMemoPromptVersionBumpedForV121:
     def test_version_is_v12_1(self):
         from app.services.llm_decision_memo import MEMO_PROMPT_VERSION
 
-        assert MEMO_PROMPT_VERSION == "v12.2-listing-age-leverage-2026-06"
+        assert MEMO_PROMPT_VERSION == "v12.3-component-lookup-2026-06"
 
 
 class TestRenderPromptAdvisoryFailureNoGateFailureAddendum:


### PR DESCRIPTION
- _component_score_value now resolves each component's raw input score
  from score_breakdown["inputs"] (the canonical _score_breakdown shape)
  first, before the legacy top-level / <comp>_score / components shapes
  and the flat-candidate fallback. Fixes occupancy_economics and
  demand_potential contributions rendering as 0 in v1 memos, and
  unblocks the v2 flag flip (district_momentum and display-only
  confidence resolve to real values).
- COMPONENT_WEIGHTS (v1) now includes chain_strength and the Patch-B
  competition_whitespace split; _active_component_weights mirrors the
  scorer's env-driven EXPANSION_CHAIN_STRENGTH_WEIGHT carve-out so memo
  weights track the scorer exactly. COMPONENT_WEIGHTS_V2 confirmed equal
  to scorer v2 by test.
- Removed the stale '9 components' literal from the memo prompt preamble
  (and the EN byte-identity snapshot fixture).
- MEMO_PROMPT_VERSION v12.2-listing-age-leverage-2026-06 →
  v12.3-component-lookup-2026-06 (rendered v1 memo content changes:
  real component values replace zeros).

Tests: inputs-precedence lookup (v1 + v2), fallback-order regression,
memo-vs-scorer weight parity for both stacks. Full suite green.

https://claude.ai/code/session_01SQ7o2SiZJzmhfvHrytRipT