### PR TITLE
fix(expansion): run hard floors and score deltas before district selection

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -5700,6 +5700,60 @@ def _value_band_score_delta(c: dict[str, Any]) -> float:
     return 0.0
 
 
+def _select_final_candidates(
+    candidates: list[dict[str, Any]],
+    target_districts: list[str],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Final shortlist selection over the score-sorted viability survivors.
+
+    City-wide / single-district searches (fewer than 2 target districts)
+    take the plain top-``limit`` slice — identical to the pre-balancing
+    behavior.
+
+    Multi-district searches apply a per-district quota of
+    ``max(1, limit // len(target_districts))``. The representation
+    guarantee is best-effort-within-limit and applies to hard-floor
+    SURVIVORS only: a district whose every candidate fails a hard floor in
+    ``_apply_market_viability_pass`` is legitimately unrepresented.
+    Candidates whose district does not normalize to a usable key
+    (``_unknown``) get NO quota — they compete only in the fill phase.
+
+    Selection happens in two walks over the sorted input, and the output is
+    emitted in input order (a filtered subsequence of the sorted list), so
+    the result stays in final_score order by construction:
+
+      1. Quota walk: accept a candidate when its district's quota is
+         unfilled, never exceeding ``limit`` total.
+      2. Fill walk: top up the remaining slots strictly by rank, skipping
+         already-selected candidates.
+    """
+    if len(target_districts) < 2:
+        return candidates[:limit]
+
+    quota = max(1, limit // len(target_districts))
+    taken_per_district: dict[str, int] = {}
+    chosen: set[int] = set()
+
+    for idx, c in enumerate(candidates):
+        if len(chosen) >= limit:
+            break
+        dk = normalize_district_key(c.get("district")) or "_unknown"
+        if dk == "_unknown":
+            continue
+        if taken_per_district.get(dk, 0) >= quota:
+            continue
+        chosen.add(idx)
+        taken_per_district[dk] = taken_per_district.get(dk, 0) + 1
+
+    for idx in range(len(candidates)):
+        if len(chosen) >= limit:
+            break
+        chosen.add(idx)
+
+    return [candidates[idx] for idx in sorted(chosen)]
+
+
 def _apply_market_viability_pass(
     candidates: list[dict[str, Any]],
     *,
@@ -10874,46 +10928,21 @@ def run_expansion_search(
             search_id, _pre_score_dedup, len(candidates),
         )
 
-    # ── District balancing: ensure multi-district searches get representation ──
-    # When target_districts has 2+ districts, guarantee at least min_per_district
-    # candidates from each district that has qualifying parcels, before filling
-    # remaining slots by rank.
-    if len(target_districts) >= 2 and len(candidates) > 0:
-        _min_per_district = max(2, limit // len(target_districts))
-        _by_district: dict[str, list[dict]] = {}
-        for c in candidates:
-            _dk = normalize_district_key(c.get("district")) or "_unknown"
-            _by_district.setdefault(_dk, []).append(c)
-
-        _balanced: list[dict] = []
-        _seen_ids: set[str] = set()
-
-        # First pass: take min_per_district from each district
-        for _dk in _by_district:
-            for c in _by_district[_dk][:_min_per_district]:
-                cid = c.get("parcel_id") or c.get("id") or id(c)
-                if cid not in _seen_ids:
-                    _balanced.append(c)
-                    _seen_ids.add(cid)
-
-        # Second pass: fill remaining slots from the global ranked list
-        for c in candidates:
-            if len(_balanced) >= limit:
-                break
-            cid = c.get("parcel_id") or c.get("id") or id(c)
-            if cid not in _seen_ids:
-                _balanced.append(c)
-                _seen_ids.add(cid)
-
-        candidates = _balanced
-
     # ── Score-delta refactor ──
-    # The viability pass now applies hard-floor drops AND attaches per-leg
+    # The viability pass applies hard-floor drops AND attaches per-leg
     # decisions (viability_legs_fired, viability_delta) on each survivor,
     # without any positional reorder. We then fold the value_band, viability,
     # freshness, and momentum deltas into final_score and re-sort strictly
     # by (final_score DESC, parcel_id ASC). The LLM rerank pass that follows
     # is a no-op in production (EXPANSION_LLM_RERANK_ENABLED=False).
+    #
+    # Pipeline-order fix (2026-06): both passes run on the FULL deduped pool,
+    # BEFORE any truncation or district selection, so that (a) hard-floor
+    # drops are backfilled from the rest of the pool instead of under-filling
+    # the response, (b) the viability percentile cohorts carry the same
+    # statistical meaning for multi-district and city-wide searches, and
+    # (c) district selection operates on final post-delta scores and cannot
+    # be voided by a later re-sort.
     viability_diagnostics: dict[str, Any] = {}
     candidates = _apply_market_viability_pass(
         candidates,
@@ -10923,7 +10952,14 @@ def run_expansion_search(
 
     candidates = _apply_score_deltas_and_sort(candidates)
 
-    candidates = candidates[:limit]
+    # ── Final selection ──
+    # City-wide / single-district: plain top-``limit`` slice, identical to
+    # the pre-balancing behavior. Multi-district: per-district quota over
+    # the score-sorted hard-floor survivors. The representation guarantee
+    # is best-effort-within-limit and applies to floor SURVIVORS only — a
+    # district whose every candidate fails a hard floor is legitimately
+    # unrepresented.
+    candidates = _select_final_candidates(candidates, target_districts, limit)
 
     # Phase 2: bounded LLM shortlist reranking. Annotates every candidate
     # with rerank metadata (deterministic_rank, final_rank, rerank_applied,

--- a/docs/investigations/PR-1_ranking_pipeline_order_report.md
+++ b/docs/investigations/PR-1_ranking_pipeline_order_report.md
@@ -1,0 +1,188 @@
+# PR-1 Report — Pipeline order: hard floors and score deltas before district selection
+
+| | |
+|---|---|
+| **PR** | [#1306 — fix(expansion): run hard floors and score deltas before district selection](https://github.com/hummodi6991/Oaktree-Atlas/pull/1306) |
+| **Branch** | `claude/fix-ranking-pipeline-order-pnkmt0` (from `main` @ `154296c35`) |
+| **Commit** | `249f1e355` |
+| **Scope** | Finding 1 + observation 3 of the 2026-06 scoring/ranking audit. No other changes. |
+| **Status** | Pushed and PR open. **Not merged** — awaiting review, per task scope. |
+| **Files** | `app/services/expansion_advisor.py` (+106/−35), `tests/test_expansion_advisor_service.py` (+240) |
+| **Validation** | Full backend suite: **2469 passed, 24 skipped**, 0 failures |
+
+---
+
+## 1. What was wrong
+
+`run_expansion_search` ran its post-scoring stages in this order
+(`app/services/expansion_advisor.py:10865-10937` at the pre-fix HEAD):
+
+```
+sort(_rank_sort_key)
+  → _dedupe_candidates → _dedupe_score_clones
+  → district balancing            ← TRUNCATES the pool to ~limit
+  → _apply_market_viability_pass  ← hard-floor DROPS + per-leg deltas
+  → _apply_score_deltas_and_sort  ← folds deltas, strict re-sort
+  → [:limit]
+  → _apply_rerank_to_candidates
+```
+
+Four concrete consequences:
+
+1. **Under-filled responses.** Hard-floor drops (population floor,
+   commercial-activity floor, construction-proximity floor) executed AFTER
+   the balancing block had already truncated the pool to roughly `limit`
+   rows. Every drop at that point was a permanently lost slot — there was no
+   backfill from the rest of the pool, so multi-district searches could
+   return fewer rows than `limit` even when hundreds of viable candidates
+   existed.
+
+2. **Inconsistent percentile cohorts.** The viability pass computes
+   per-search percentile thresholds (population bottom-quartile, demand
+   bottom-quartile, rent-per-capita top-quartile) over whatever list it
+   receives. Multi-district searches handed it a ≤limit slice; city-wide
+   searches handed it the full shortlist. The same env-configured
+   thresholds (`EXPANSION_VIABILITY_POP_PERCENTILE`, etc.) therefore had a
+   **different statistical meaning** depending on search type.
+
+3. **Voided representation guarantee.** The balancing block ran before
+   `_apply_score_deltas_and_sort`, which re-sorts strictly by
+   `(final_score DESC, parcel_id ASC)` after folding in value-band,
+   viability, freshness, and momentum deltas. The subsequent bare `[:limit]`
+   could then evict exactly the candidates balancing had seated — the
+   per-district guarantee was silently voided.
+
+4. **No global cap in balancing (audit observation 3).** The balancing
+   first pass took `max(2, limit // n_districts)` from *every* district with
+   no total cap, so with many districts the intermediate list could exceed
+   `limit` before the fill pass's cap applied.
+
+## 2. Why it happened
+
+The balancing block (added for multi-district representation) and the
+score-delta refactor (which moved viability from a positional demote to a
+score delta + strict re-sort) were introduced independently. Each was
+internally correct; their composition was not: balancing assumed it was the
+last positional operation, while the delta fold assumed it received the
+full pool. Neither assumption held once both were in the pipeline.
+
+## 3. The fix
+
+### New order
+
+```
+sort(_rank_sort_key)                                  (unchanged)
+  → _dedupe_candidates → _dedupe_score_clones          (unchanged)
+  → _apply_market_viability_pass   on the FULL deduped pool
+  → _apply_score_deltas_and_sort   on the full survivor list
+  → _select_final_candidates       (NEW — replaces balancing + [:limit])
+  → _apply_rerank_to_candidates                        (unchanged)
+```
+
+### `_select_final_candidates` (new helper, `app/services/expansion_advisor.py:5703`)
+
+- **City-wide / single-district** (`len(target_districts) < 2`):
+  returns `candidates[:limit]` — **byte-identical to pre-fix behavior**.
+- **Multi-district**: per-district quota of
+  `max(1, limit // len(target_districts))` over the score-sorted hard-floor
+  survivors, applied in two walks over the sorted input:
+  1. **Quota walk** — accept a candidate when its normalized district's
+     quota is unfilled; never exceed `limit` total (this adds the global
+     cap that was missing, fixing observation 3).
+  2. **Fill walk** — top up remaining slots strictly by rank, skipping
+     already-selected candidates.
+- Output is emitted as a **filtered subsequence of the sorted input**
+  (selected indices in ascending order), so it stays in `final_score` order
+  by construction — the guarantee can no longer be undone by a later sort.
+- Candidates whose district does not normalize to a usable key
+  (`_unknown`) get **no quota**; they compete only in the fill walk.
+
+### Intentional semantic changes vs the old balancing block
+
+| Aspect | Before | After |
+|---|---|---|
+| Per-district floor | `max(2, limit // n)` | `max(1, limit // n)` |
+| Global cap in quota phase | none | capped at `limit` |
+| Guarantee evaluated on | pre-floor, pre-delta scores | hard-floor survivors with final post-delta scores |
+| Guarantee strength | nominally hard, actually voided by later sort | best-effort within `limit`, actually honored |
+| `_unknown` district | received its own quota bucket | no quota; fill phase only |
+| Floor drops | after truncation, no backfill | before selection, backfilled from full pool |
+
+A district whose every candidate fails a hard floor is now **legitimately
+unrepresented** — the code comments state exactly this.
+
+### Deliberately unchanged
+
+- `viability_diagnostics` / `hard_floors` / `demote_legs` API-meta wiring is
+  intact. Drop counts now reflect the **full pool** rather than a truncated
+  slice — the desired semantics for explaining unsaturated responses.
+- `_apply_score_deltas_and_sort` still runs after the viability pass, so its
+  contract of consuming and dropping the transient `viability_legs_fired` /
+  `viability_delta` fields is preserved.
+- The LLM rerank stage keeps its position and remains a production no-op
+  (`EXPANSION_LLM_RERANK_ENABLED=False`).
+- **No flag gating.** This is a bug-fix correction (same precedent as the
+  whitespace PR): it corrects pipeline-order defects, not scoring semantics.
+
+## 4. Tests
+
+Seven new tests appended to `tests/test_expansion_advisor_service.py`
+(from line 5206). They compose the exact helpers the main flow uses
+(`_apply_market_viability_pass` → `_apply_score_deltas_and_sort` →
+`_select_final_candidates`) on synthetic pools:
+
+| Test | Pins |
+|---|---|
+| `test_pipeline_order_floor_drops_are_backfilled_to_limit` | District A all fails the population floor → response still has `limit` rows, A absent, B/C present; transient viability fields don't leak. |
+| `test_pipeline_order_district_with_survivor_is_represented` | A district with one floor survivor (lowest score in pool) is still seated within `limit`. |
+| `test_select_final_candidates_quota_math_8_districts_limit_15` | 8 districts, limit 15 → quota = 1; total = 15; every survivor-bearing district seated once before any second slot; output stays score-sorted. |
+| `test_select_final_candidates_unknown_district_gets_no_quota` | Top-scoring `_unknown` candidate cannot claim a quota slot; enters via fill only; excluded when quota fills the limit. |
+| `test_viability_cohort_identical_for_city_wide_and_multi_district` | Same pool → identical `demote_legs` thresholds, identical `hard_floors` diagnostics, identical per-candidate `market_viability_flag`, with 0 vs 2+ target districts. |
+| `test_select_final_candidates_city_wide_is_bare_limit_slice` | City-wide and single-district selection return the exact same objects, same order, as `candidates[:limit]`. |
+| `test_pipeline_city_wide_output_matches_pre_fix_order` | Full fixed pipeline output deep-equals the legacy city-wide composition (viability → deltas → `[:limit]`). |
+
+**No existing tests pinned the old balancing-before-floors order — none were
+modified.** (The PR-spec carve-out for touched tests is therefore empty.)
+
+## 5. Validation performed
+
+```bash
+python -m pytest tests/test_expansion_advisor_service.py -q   # 172 passed
+python -m pytest tests -q                                     # 2469 passed, 24 skipped
+```
+
+Lint note: `black --check` / `flake8` already fail on `main` for both
+touched files (~1180 pre-existing flake8 hits in the service module; CI
+runs neither tool). New code matches the file's existing style; no
+reformatting was done, keeping the diff minimal.
+
+## 6. Risk assessment
+
+| Risk | Level | Mitigation |
+|---|---|---|
+| City-wide regression | **Very low** | Selection degenerates to `[:limit]`; byte-identity pinned by two tests. |
+| Multi-district ordering drift | **Low–medium (intended)** | This is the fix: results are now ordered by final post-delta score with honored quotas. Shortlists for multi-district searches *will* change. |
+| Response size change | **Low** | Responses get fuller (backfill), never smaller. |
+| Cohort threshold shift | **Low–medium (intended)** | Multi-district viability thresholds now computed over the full pool — same meaning as city-wide. Demote rates for multi-district searches may shift accordingly. |
+| Performance | **Negligible** | Viability/delta passes now process the full deduped pool for multi-district searches (they already did for city-wide); both are O(n) / O(n log n) over an in-memory list. |
+
+## 7. Acceptance / rollout
+
+- Post-deploy acceptance metric: under-fill counts from
+  `scripts/diagnostics/balancing_order_probe.sql` (pre-merge baseline run
+  by Ahmed) should drop to ~0 for multi-district searches with active
+  hard floors.
+- Sanity checks after deploy (per repo playbook): results still Riyadh-only,
+  scores internally consistent, every survivor-bearing target district
+  represented, response row counts saturate `limit`.
+
+> Note: `docs/investigations/scoring_ranking_audit_2026-06.md` and
+> `scripts/diagnostics/balancing_order_probe.sql` referenced by the task
+> are not present in the repo at `154296c35`; the implementation was
+> grounded on the task's code anchors, which matched that HEAD exactly.
+
+## 8. Merge recommendation
+
+**Merge after review — low risk.** City-wide behavior is provably
+unchanged; multi-district changes are the intended correction; the full
+suite is green; rollback is a single revert of `249f1e355`.

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -5203,3 +5203,243 @@ def test_get_recommendation_report_best_format_arabic(monkeypatch):
         )
         report = get_recommendation_report(FakeDB(), "search-1", lang="ar")
         assert report["recommendation"]["best_format"] == expected, (service_model, area_m2)
+
+
+# ===========================================================================
+# Pipeline-order fix: hard floors and score deltas run on the FULL deduped
+# pool BEFORE final selection. The tests below compose the same post-scoring
+# stages run_expansion_search uses — _apply_market_viability_pass on the
+# full pool, _apply_score_deltas_and_sort, then _select_final_candidates —
+# and pin: (1) floor drops are backfilled to limit, (2) per-district quota
+# math, (3) viability cohorts identical regardless of target_districts,
+# (4) city-wide selection byte-identical to the bare [:limit] slice.
+# ===========================================================================
+
+import copy  # noqa: E402
+
+from app.services.expansion_advisor import _select_final_candidates  # noqa: E402
+
+
+def _ps_candidate(
+    *,
+    parcel_id: str,
+    district: str | None,
+    final_score: float,
+    pop_reach: float | None = None,
+) -> dict:
+    fs: dict = {}
+    if pop_reach is not None:
+        fs["population_reach"] = pop_reach
+    return {
+        "id": parcel_id,
+        "parcel_id": parcel_id,
+        "district": district,
+        "final_score": final_score,
+        "score_breakdown_json": {},
+        "feature_snapshot_json": fs,
+    }
+
+
+def _run_post_scoring_pipeline(
+    pool: list[dict],
+    *,
+    target_districts: list[str],
+    limit: int,
+    diagnostics: dict | None = None,
+    population_hard_floor: int = 0,
+    commercial_hard_floor: int = 0,
+    construction_buffer_m: float = 0.0,
+) -> list[dict]:
+    """Mirror run_expansion_search's post-scoring stages in the fixed order:
+    viability pass (hard floors + leg annotation) on the FULL pool, score
+    deltas folded + sorted, then final selection."""
+    out = _apply_market_viability_pass(
+        list(pool),
+        search_id="t",
+        diagnostics=diagnostics,
+        population_hard_floor=population_hard_floor,
+        commercial_hard_floor=commercial_hard_floor,
+        construction_buffer_m=construction_buffer_m,
+    )
+    out = _apply_score_deltas_and_sort(out)
+    return _select_final_candidates(out, target_districts, limit)
+
+
+def test_pipeline_order_floor_drops_are_backfilled_to_limit():
+    # District A's candidates ALL fail the population hard floor. Pre-fix,
+    # balancing truncated to ~limit BEFORE the floors ran, so the floor
+    # drops left the response under-filled. Post-fix the floors run on the
+    # full pool and selection backfills from B/C survivors.
+    pool = (
+        [_ps_candidate(parcel_id=f"a{i}", district="Alpha", final_score=95.0 - i,
+                       pop_reach=1000.0) for i in range(3)]
+        + [_ps_candidate(parcel_id=f"b{i}", district="Beta", final_score=90.0 - 2 * i,
+                         pop_reach=50000.0) for i in range(5)]
+        + [_ps_candidate(parcel_id=f"c{i}", district="Gamma", final_score=89.0 - 2 * i,
+                         pop_reach=50000.0) for i in range(5)]
+    )
+    pool.sort(key=lambda c: -c["final_score"])
+    out = _run_post_scoring_pipeline(
+        pool,
+        target_districts=["Alpha", "Beta", "Gamma"],
+        limit=6,
+        population_hard_floor=20000,
+    )
+    assert len(out) == 6  # backfilled despite 3 floor drops
+    districts = {c["district"] for c in out}
+    assert "Alpha" not in districts  # every Alpha candidate failed the floor
+    assert {"Beta", "Gamma"} <= districts
+    # Transient viability working fields must not leak past the delta fold.
+    assert all("viability_legs_fired" not in c for c in out)
+    assert all("viability_delta" not in c for c in out)
+
+
+def test_pipeline_order_district_with_survivor_is_represented():
+    # Same shape, but Alpha has ONE floor survivor with the lowest score in
+    # the pool. The quota walk must still seat it within limit.
+    pool = (
+        [_ps_candidate(parcel_id=f"a{i}", district="Alpha", final_score=95.0 - i,
+                       pop_reach=1000.0) for i in range(2)]
+        + [_ps_candidate(parcel_id="a-survivor", district="Alpha",
+                         final_score=70.0, pop_reach=50000.0)]
+        + [_ps_candidate(parcel_id=f"b{i}", district="Beta", final_score=90.0 - 2 * i,
+                         pop_reach=50000.0) for i in range(5)]
+        + [_ps_candidate(parcel_id=f"c{i}", district="Gamma", final_score=89.0 - 2 * i,
+                         pop_reach=50000.0) for i in range(5)]
+    )
+    pool.sort(key=lambda c: -c["final_score"])
+    out = _run_post_scoring_pipeline(
+        pool,
+        target_districts=["Alpha", "Beta", "Gamma"],
+        limit=6,
+        population_hard_floor=20000,
+    )
+    assert len(out) == 6
+    assert any(c["parcel_id"] == "a-survivor" for c in out)
+
+
+def test_select_final_candidates_quota_math_8_districts_limit_15():
+    # 8 districts, limit 15 → quota = max(1, 15 // 8) = 1. Every
+    # survivor-bearing district gets its first slot before any district
+    # gets a second one via the fill walk, total never exceeds limit, and
+    # the output stays in final_score order (filtered subsequence).
+    pool = [
+        _ps_candidate(parcel_id=f"d1-{i}", district="D1", final_score=99.0 - i)
+        for i in range(5)
+    ]
+    score = 80.0
+    for d in range(2, 9):
+        for i in range(2):
+            pool.append(_ps_candidate(
+                parcel_id=f"d{d}-{i}", district=f"D{d}", final_score=score
+            ))
+            score -= 1.0
+    pool.sort(key=lambda c: (-c["final_score"], c["parcel_id"]))
+
+    out = _select_final_candidates(pool, [f"D{d}" for d in range(1, 9)], 15)
+
+    assert len(out) == 15
+    counts: dict[str, int] = {}
+    for c in out:
+        counts[c["district"]] = counts.get(c["district"], 0) + 1
+    # Every survivor-bearing district seated at least once.
+    assert all(counts.get(f"D{d}", 0) >= 1 for d in range(1, 9))
+    # D1's 4 extra rows came from the fill walk, after all 8 districts had
+    # their quota slot: 8 quota picks + 7 fill picks by rank.
+    assert counts["D1"] == 5
+    scores = [c["final_score"] for c in out]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_select_final_candidates_unknown_district_gets_no_quota():
+    # An unknown-district candidate cannot claim a quota slot even with the
+    # top score — it competes only in the fill walk.
+    pool = [
+        _ps_candidate(parcel_id="u1", district=None, final_score=95.0),
+        _ps_candidate(parcel_id="a1", district="Alpha", final_score=90.0),
+        _ps_candidate(parcel_id="b1", district="Beta", final_score=85.0),
+        _ps_candidate(parcel_id="a2", district="Alpha", final_score=80.0),
+        _ps_candidate(parcel_id="b2", district="Beta", final_score=75.0),
+    ]
+    out = _select_final_candidates(pool, ["Alpha", "Beta"], 3)
+    assert [c["parcel_id"] for c in out] == ["u1", "a1", "b1"]
+    # With limit 2 the quota walk fills both slots and the unknown-district
+    # candidate is excluded entirely.
+    out2 = _select_final_candidates(pool, ["Alpha", "Beta"], 2)
+    assert [c["parcel_id"] for c in out2] == ["a1", "b1"]
+
+
+def test_viability_cohort_identical_for_city_wide_and_multi_district():
+    # Pre-fix, multi-district searches truncated to ~limit BEFORE the
+    # viability pass, so its percentile cohorts had a different statistical
+    # meaning than city-wide ones. Post-fix the pass always sees the full
+    # pool: thresholds and per-candidate flags must be identical whether or
+    # not target_districts has 2+ entries.
+    pops = [5000.0, 10000.0, 20000.0, 40000.0, 60000.0, 80000.0, 100000.0, 120000.0]
+    pool = [
+        _ps_candidate(
+            parcel_id=f"p{i}",
+            district="Alpha" if i % 2 == 0 else "Beta",
+            final_score=90.0 - i,
+            pop_reach=p,
+        )
+        for i, p in enumerate(pops)
+    ]
+    diag_city: dict = {}
+    out_city = _run_post_scoring_pipeline(
+        copy.deepcopy(pool), target_districts=[], limit=4, diagnostics=diag_city
+    )
+    diag_multi: dict = {}
+    out_multi = _run_post_scoring_pipeline(
+        copy.deepcopy(pool), target_districts=["Alpha", "Beta"], limit=4,
+        diagnostics=diag_multi,
+    )
+    assert diag_city["demote_legs"]["thresholds"] == diag_multi["demote_legs"]["thresholds"]
+    assert diag_city["hard_floors"] == diag_multi["hard_floors"]
+    # Per-candidate viability annotations agree wherever both shortlists
+    # carry the same parcel.
+    flags_city = {
+        c["parcel_id"]: c["score_breakdown_json"].get("market_viability_flag")
+        for c in out_city
+    }
+    for c in out_multi:
+        if c["parcel_id"] in flags_city:
+            assert (
+                c["score_breakdown_json"].get("market_viability_flag")
+                == flags_city[c["parcel_id"]]
+            )
+
+
+def test_select_final_candidates_city_wide_is_bare_limit_slice():
+    # City-wide (no target districts) and single-district selection must be
+    # byte-identical to candidates[:limit] — same objects, same order.
+    pool = [
+        _ps_candidate(parcel_id=f"p{i}", district="Olaya", final_score=90.0 - i)
+        for i in range(10)
+    ]
+    for tds in ([], ["Olaya"]):
+        out = _select_final_candidates(pool, tds, 5)
+        assert len(out) == 5
+        assert all(a is b for a, b in zip(out, pool[:5]))
+
+
+def test_pipeline_city_wide_output_matches_pre_fix_order():
+    # The pre-fix city-wide pipeline was: viability → deltas → [:limit]
+    # (the balancing block only ran with 2+ target districts). The fixed
+    # pipeline must produce byte-identical output for that case.
+    pops = [5000.0, 10000.0, 20000.0, 40000.0, 60000.0, 80000.0]
+    pool = [
+        _ps_candidate(parcel_id=f"p{i}", district="Olaya",
+                      final_score=90.0 - i, pop_reach=p)
+        for i, p in enumerate(pops)
+    ]
+    legacy = _apply_market_viability_pass(
+        copy.deepcopy(pool), search_id="t",
+        population_hard_floor=0, commercial_hard_floor=0,
+        construction_buffer_m=0.0,
+    )
+    legacy = _apply_score_deltas_and_sort(legacy)[:4]
+    fixed = _run_post_scoring_pipeline(
+        copy.deepcopy(pool), target_districts=[], limit=4
+    )
+    assert fixed == legacy


### PR DESCRIPTION
## Defect

`run_expansion_search` ran its post-scoring stages in the wrong order:

```
sort → dedupe → district balancing (truncates to ~limit) → viability pass
(hard-floor DROPS + leg deltas) → _apply_score_deltas_and_sort → [:limit]
```

Consequences (Finding 1 + observation 3 of the 2026-06 scoring/ranking audit):

- **Under-filled responses:** hard-floor drops happened AFTER truncation to ~limit, with no backfill from the rest of the pool.
- **Inconsistent cohorts:** viability percentile thresholds (population/demand/rent-per-capita quartiles) were computed over a ≤limit slice for multi-district searches but over the full shortlist for city-wide ones — same env thresholds, different statistical meaning.
- **Voided guarantee:** the per-district representation guarantee was applied before the score-delta fold, so the later strict re-sort + `[:limit]` could silently evict the balanced picks.
- **No global cap:** the balancing first pass had no `limit` cap (observation 3).

## New order

1. `candidates.sort(key=_rank_sort_key)` — unchanged
2. `_dedupe_candidates` → `_dedupe_score_clones` — unchanged
3. `_apply_market_viability_pass` on the **full deduped pool** (floors drop, legs annotate; cohorts now consistent across search types; drop counts in `viability_diagnostics` / `hard_floors` now reflect the full pool, which is the desired semantics)
4. `_apply_score_deltas_and_sort` on the full survivor list (still runs after the viability pass, preserving the dropped-transient-fields contract)
5. **Final selection** — new `_select_final_candidates` helper:
   - City-wide / single-district (`len(target_districts) < 2`): bare `candidates[:limit]`
   - Multi-district: per-district quota of `max(1, limit // len(target_districts))` over the score-sorted survivors, capped at `limit` total, followed by a rank-order fill walk. Output is emitted as a filtered subsequence of the sorted input, so it stays in final_score order by construction. `_unknown`-district candidates get no quota and compete only in the fill phase.
6. `_apply_rerank_to_candidates` — unchanged position

## Guarantees

- **City-wide searches are byte-identical** before/after: the selection helper degenerates to the bare `[:limit]` slice, and the viability + delta stages already ran on the full pool for that path. Pinned by `test_select_final_candidates_city_wide_is_bare_limit_slice` and `test_pipeline_city_wide_output_matches_pre_fix_order`.
- The representation guarantee is now **best-effort-within-limit over hard-floor survivors only**: a district whose every candidate fails a hard floor is legitimately unrepresented. The code comments state exactly this.
- **No flag gating**, following the bug-fix correction precedent (whitespace PR): this corrects pipeline-order defects rather than changing scoring semantics.

## Tests

New tests in `tests/test_expansion_advisor_service.py` compose the same pipeline helpers the main flow uses:

1. Multi-district + floor failures → response backfilled to `limit`; a district is represented iff it has floor survivors (incl. the lowest-score-survivor case).
2. Quota math: 8 districts, limit 15 → total = 15, every survivor-bearing district seated once before fill grants seconds, output stays score-sorted; `_unknown` districts get no quota.
3. Cohort consistency: viability thresholds and per-candidate flags identical for the same pool whether `target_districts` has 0 or 2+ entries.
4. City-wide regression: selection and full-pipeline output byte-identical to pre-fix behavior.

**No existing tests pinned the old balancing-before-floors order — none were modified.** Full backend suite: 2469 passed, 24 skipped.

## Acceptance

`scripts/diagnostics/balancing_order_probe.sql` under-fill counts (pre-merge baseline run by Ahmed) are the post-deploy acceptance metric.

Do not merge yet — pushed for review per task scope.

https://claude.ai/code/session_01MuRYe8yZccc5n6oNgULzY5

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuRYe8yZccc5n6oNgULzY5)_