### PR TITLE
fix(expansion): value_score uses tier-blind revenue basis

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -4910,7 +4910,8 @@ def _estimate_revenue_index(
     delivery_listing_count: int = 0,
     population_reach: float = 0.0,
     road_context: dict | None = None,
-) -> float:
+    return_detail: bool = False,
+) -> float | tuple[float, dict[str, float]]:
     """Listings-grounded revenue index.
 
     Primary inputs: listing-level features (street width as drive-by
@@ -4921,6 +4922,13 @@ def _estimate_revenue_index(
     For parcels: street width and listing_type fall to neutral defaults
     and the district inputs effectively dominate, preserving legacy
     behavior for the parcel path.
+
+    With return_detail=True, returns ``(index, detail)`` where detail
+    carries ``tier_blind_index`` — clamp(base × category_factor), i.e.
+    everything except the price-tier-driven ticket multiplier — and the
+    excluded ``ticket_multiplier``. The tier-blind index is the basis for
+    value_score, which must stay tier-blind (see _RENT_CEILING_TIER_MULT
+    note). The scalar return path is byte-identical to the legacy behavior.
     """
     # Street width as drive-by traffic proxy (35% of base)
     if unit_street_width_m is not None and unit_street_width_m > 0:
@@ -4996,7 +5004,15 @@ def _estimate_revenue_index(
     implied_check = _implied_average_check(price_tier, category)
     ticket_multiplier = max(0.5, min(2.5, implied_check / _IMPLIED_CHECK_BASELINE_SAR))
 
-    return _clamp(base * factor * ticket_multiplier)
+    index = _clamp(base * factor * ticket_multiplier)
+    if return_detail:
+        # Category throughput stays in the tier-blind index: it is
+        # category-driven and constant within a search, not a tier leak.
+        return index, {
+            "tier_blind_index": _clamp(base * factor),
+            "ticket_multiplier": ticket_multiplier,
+        }
+    return index
 
 
 # ---------------------------------------------------------------------------
@@ -5359,8 +5375,21 @@ def _economics_score(
     unit_neighborhood_raw: str | None = None,
     price_tier: str | None = None,
     cand_age_days: int | None = None,
+    revenue_index_detail: dict[str, Any] | None = None,
 ) -> tuple[float, dict[str, Any]]:
     monthly_rent_per_m2 = estimated_annual_rent_sar / max(area_m2 * 12.0, 1.0)
+
+    # value_score must stay tier-blind: use the tier-blind revenue index
+    # (ticket multiplier excluded) from _estimate_revenue_index detail when
+    # the caller provides it. Callers that don't pass the detail fall back
+    # to the tier-multiplied index (legacy behavior). The composite score
+    # below keeps using the tier-multiplied estimated_revenue_index —
+    # ranking semantics outside value_score are unchanged.
+    _rev_detail = revenue_index_detail if isinstance(revenue_index_detail, dict) else {}
+    value_revenue_basis = _safe_float(
+        _rev_detail.get("tier_blind_index"), estimated_revenue_index
+    )
+    _ticket_multiplier = _rev_detail.get("ticket_multiplier")
 
     _tier_mult = _rent_ceiling_tier_multiplier(price_tier)
     _fallback_ceiling = 220.0 * _tier_mult
@@ -5437,7 +5466,7 @@ def _economics_score(
         and isinstance(rent_burden_meta, dict)
         and rent_burden_meta.get("mode") == "percentile"
     ):
-        value_score = _value_score(estimated_revenue_index, rent_burden_score)
+        value_score = _value_score(value_revenue_basis, rent_burden_score)
         value_band = _classify_value_band(value_score)
         value_band_low_confidence = _value_band_is_low_confidence(
             rent_burden_meta.get("source_label"),
@@ -5458,6 +5487,10 @@ def _economics_score(
         "value_score": round(value_score, 2) if value_score is not None else None,
         "value_band": value_band,
         "value_band_low_confidence": value_band_low_confidence,
+        "value_revenue_basis": round(value_revenue_basis, 2),
+        "ticket_multiplier": (
+            round(float(_ticket_multiplier), 4) if _ticket_multiplier is not None else None
+        ),
     }
 
 
@@ -8948,7 +8981,7 @@ def run_expansion_search(
                 rent_source = f"{rent_source}+micro"
             estimated_annual_rent_sar = round(area_m2 * estimated_rent_sar_m2_year)
         estimated_fitout_cost_sar = round(_estimate_fitout_cost_sar(area_m2, service_model, is_furnished=bool(row.get("unit_is_furnished"))))
-        estimated_revenue_index = _estimate_revenue_index(
+        estimated_revenue_index, _revenue_index_detail = _estimate_revenue_index(
             area_m2=area_m2,
             target_area_m2=target_area_m2,
             unit_street_width_m=_safe_float(row.get("unit_street_width_m")) if row.get("unit_street_width_m") else None,
@@ -8957,6 +8990,7 @@ def run_expansion_search(
             whitespace_score=whitespace_score,
             category=category,
             price_tier=effective_brand_profile.get("price_tier"),
+            return_detail=True,
         )
         economics_score, economics_meta = _economics_score(
             estimated_revenue_index=estimated_revenue_index,
@@ -8971,6 +9005,7 @@ def run_expansion_search(
             listing_type=row.get("unit_listing_type"),
             unit_neighborhood_raw=row.get("unit_neighborhood_raw"),
             price_tier=effective_brand_profile.get("price_tier"),
+            revenue_index_detail=_revenue_index_detail,
         )
         _unit_street_width = _safe_float(row.get("unit_street_width_m")) if row.get("unit_street_width_m") else None
         frontage_score = _frontage_score(
@@ -10097,7 +10132,7 @@ def run_expansion_search(
         # so the first scoring pass runs without it. Recompute here for
         # final scores using the road signal.
         _road_ctx = _bulk_roads.get(_pid_str)
-        estimated_revenue_index = _estimate_revenue_index(
+        estimated_revenue_index, _revenue_index_detail = _estimate_revenue_index(
             area_m2=area_m2,
             target_area_m2=target_area_m2,
             unit_street_width_m=_safe_float(row.get("unit_street_width_m")) if row.get("unit_street_width_m") else None,
@@ -10106,6 +10141,7 @@ def run_expansion_search(
             whitespace_score=whitespace_score,
             category=category,
             price_tier=effective_brand_profile.get("price_tier"),
+            return_detail=True,
         )
         if rent_source != "commercial_unit_actual":
             _base_rent_sar_m2_year = prepared_item.get("rent_base_sar_m2_year", estimated_rent_sar_m2_year)
@@ -10138,6 +10174,7 @@ def run_expansion_search(
             unit_neighborhood_raw=row.get("unit_neighborhood_raw"),
             price_tier=effective_brand_profile.get("price_tier"),
             cand_age_days=_created_basis_age_days(row),
+            revenue_index_detail=_revenue_index_detail,
         )
         effective_age_days, effective_age_source = _effective_listing_age_days(row)
         feature_snapshot_json = _candidate_feature_snapshot(

--- a/docs/investigations/PR-2_value_score_tier_blind_report.md
+++ b/docs/investigations/PR-2_value_score_tier_blind_report.md
@@ -1,0 +1,214 @@
+# PR-2 Report — value_score uses the tier-blind revenue basis (ticket-multiplier leak)
+
+| | |
+|---|---|
+| **PR** | [#1307 — fix(expansion): value_score uses tier-blind revenue basis](https://github.com/hummodi6991/Oaktree-Atlas/pull/1307) |
+| **Branch** | `claude/value-score-tier-blind-uugb9z` (from `main` @ `5ba564f8a`, post PR-1 merge) |
+| **Commit** | `fe850349d` |
+| **Scope** | Finding 2 of the 2026-06 scoring/ranking audit (§2.5) ONLY. The ranking-side `estimated_revenue_index` semantics are explicitly out of scope. |
+| **Status** | Pushed and PR open. **Not merged** — awaiting review, per task scope. |
+| **Files** | `app/services/expansion_advisor.py` (+42/−5), `tests/test_expansion_advisor_regression.py` (+256) |
+| **Validation** | Full backend suite: **2474 passed, 24 skipped** (one pre-existing flake deselected, see §5) |
+
+---
+
+## 1. What was wrong
+
+`_estimate_revenue_index` (`app/services/expansion_advisor.py:4895` pre-fix)
+returns
+
+```
+clamp(base × category_factor × ticket_multiplier)
+```
+
+where `ticket_multiplier = clamp(implied_check / 50, 0.5, 2.5)` is derived
+from the brief's **price tier** via `_IMPLIED_CHECK_SAR`. That
+tier-multiplied index was the first argument to
+`_value_score(estimated_revenue_index, rent_burden_score)` inside
+`_economics_score` — violating the in-code contract documented next to
+`_RENT_CEILING_TIER_MULT`:
+
+> "The percentile path is intentionally NOT tier-adjusted — it is
+> peer-relative and feeds value_score, **which must stay tier-blind**."
+
+The rent-burden half of value_score was kept tier-blind (the percentile
+path takes no tier input); the revenue half leaked the tier multiplier.
+
+### §2.5 math, concretely
+
+`value_score = √(revenue_basis × rent_burden)`, banded at ≥ 75 →
+`best_value` (+4 uprank) and < 25 → `above_market` (−6 downrank):
+
+| Brief | Ticket multiplier | Effect on revenue basis | Consequence for value_score |
+|---|---|---|---|
+| Premium burger | 95/50 = **1.9×** | Any base ≥ 47.9 (100 / (1.10 × 1.9)) pins at the 100 clamp | Collapses to `√(100 × rb)` — best_value becomes **rent-burden-only** (any burden ≥ 56.25 qualifies, regardless of location quality) |
+| Premium cafe | 80/50 = **1.6×** | Pins at clamp for base ≥ 59.5 | Same rent-burden-only degeneration |
+| Mid pizza | 50/50 = **1.0×** | No change | value_score identical pre/post fix (pinned in tests) |
+| Value cafe | 25/50 = **0.5×** | Capped at `clamp(100 × 1.05 × 0.5) = 52.5` even for a **perfect** base | `√(52.5 × 100) ≈ 72.5 < 75` — best_value **mathematically unreachable** |
+| Value coffee / shawarma | 0.36 / 0.44, both **floor at 0.5×** | Capped ≤ ~54–56 | best_value unreachable (√(54 × 100) ≈ 73.5) |
+
+So the +4 best_value uprank was systematically awarded to premium briefs on
+rent burden alone and systematically withheld from value-tier briefs no
+matter how good the site — the exact opposite of a "strong location at a
+fair price" chip.
+
+## 2. Why it happened
+
+`_estimate_revenue_index` serves two consumers with different contracts:
+
+1. The **ranking-side** economics component, where a tier-driven revenue
+   expectation is an explicit product choice (premium brands monetize the
+   same site harder).
+2. The **value_score** chip, which is defined as peer-relative and
+   tier-blind.
+
+Only one scalar crossed the function boundary, so consumer 2 silently
+inherited consumer 1's tier semantics. The contract comment was written on
+the rent-burden side of the equation and never enforced on the revenue
+side.
+
+## 3. The fix
+
+### `_estimate_revenue_index` — `return_detail=True` path
+
+The function gains a keyword `return_detail: bool = False`. When set, it
+returns `(index, detail)` where:
+
+- `detail["tier_blind_index"] = clamp(base × category_factor)` —
+  everything **except** the ticket multiplier. Category throughput stays:
+  it is category-driven, constant within a search, and not the tier leak.
+- `detail["ticket_multiplier"]` — the multiplier that was excluded.
+
+The legacy scalar return path is **byte-identical** (same expression,
+assigned to a local before the branch). Any caller not updated — e.g.
+`scripts/diagnostics/score_component_probe.py` and all existing tests —
+keeps the old behavior with zero change.
+
+### `_economics_score` — tier-blind basis for value_score only
+
+New keyword `revenue_index_detail: dict | None = None`:
+
+- `value_revenue_basis = detail["tier_blind_index"]`, falling back to
+  `estimated_revenue_index` when the detail is absent (legacy callers).
+- `value_score = _value_score(value_revenue_basis, rent_burden_score)` —
+  the **only** semantic change.
+- Everything else — revenue_weight blending, rent burden (including the
+  Finding-2 tier-aware absolute ceilings, untouched), fitout,
+  cannibalization, fit — continues to use the tier-multiplied
+  `estimated_revenue_index`. Ranking semantics outside value_score are
+  unchanged.
+
+### `economics_detail` transparency fields
+
+Two additive keys (no existing key removed or renamed):
+
+- `value_revenue_basis` — the tier-blind number value_score actually used.
+- `ticket_multiplier` — the excluded multiplier (`null` for legacy callers
+  that did not supply the detail).
+
+### Call sites
+
+Both scoring passes thread the detail consistently:
+
+- **First pass** (`run_expansion_search`, `:8984` / `:9008`)
+- **Second pass** (`:10135` / `:10177`) — this is the pass whose
+  `economics_detail` is persisted into `score_breakdown_json`, i.e. the
+  source of truth `_candidate_value_band` reads for the ±4/−6 deltas.
+
+### Deliberately unchanged
+
+- `_value_score` (geometric mean), band thresholds (75 / 25), and
+  `_value_band_score_delta` (+4/−6).
+- The persisted `estimated_revenue_index` column and its input to
+  `_score_breakdown` economics: **byte-identical** (pinned by a
+  fixed-input-matrix test).
+- The ranking-side tier multiplier itself — whether it belongs in the
+  economics component is a **separate product decision**, explicitly out
+  of scope per the task.
+- **No flag gating** — bug-fix correction restoring the documented
+  contract (same precedent as PR-1 and the whitespace fix).
+
+## 4. Tests
+
+Six new tests in `tests/test_expansion_advisor_regression.py` (after the
+existing Finding-2 tier-ceiling test), driven through the real
+`_estimate_revenue_index → _economics_score` composition with
+`_percentile_rent_burden` stubbed to a fixed peer-relative burden (the
+established pattern in that file):
+
+| Test | Pins |
+|---|---|
+| `test_value_score_premium_multiplier_no_longer_pins_best_value` | Premium burger, mediocre tier-blind base (≈55) + burden 58: scalar index is pinned at 100, but value_band ≠ best_value and value_score < 75; the pre-fix basis (`√(100 × 58) ≈ 76.2`) would have crossed the line. |
+| `test_value_score_value_tier_cafe_can_reach_best_value` | Value cafe, tier-blind base ≥ 85 + burden 72 → best_value. Also pins the old impossibility: `_value_score(clamp(100×1.05×0.5), 100) < 75`. |
+| `test_value_score_tier_invariant_for_same_listing` | Same synthetic listing under value/mid/premium → identical `(tier_blind_index, value_score, value_band)` triplets, while the ranking-side index still strictly increases with tier (out of scope, unchanged). |
+| `test_value_score_mid_tier_near_identical_pre_post_fix` | Mid pizza (multiplier exactly 1.0): `tier_blind_index == index`, so value_score is identical pre/post fix — the required mid-tier invariance. |
+| `test_economics_detail_value_transparency_fields` | Both new keys present and correct; all ten pre-existing economics_detail keys still present; legacy fallback (no detail) → basis = tier-multiplied index, `ticket_multiplier` = None. |
+| `test_estimated_revenue_index_scalar_unchanged_over_matrix` | Pinned golden values (neutral 60.0; premium burger clamped 100.0; value coffee floored 32.4) + scalar ≡ detail-path index across a 4-tier × 6-category × 3-area matrix. |
+
+No existing test pinned the leaky behavior — none were modified. The
+pre-existing `test_economics_score_tier_aware_absolute_ceiling` (which
+already asserts percentile-path value_score is tier-invariant under a
+**fixed** revenue index) still passes unchanged.
+
+## 5. Validation performed
+
+```bash
+python -m pytest tests/test_expansion_advisor_regression.py -k "value_score or revenue_index or economics" -q
+# 14 passed
+
+python -m pytest tests/test_expansion_advisor_regression.py tests/test_expansion_advisor_service.py \
+    tests/test_expansion_weight_stack.py tests/test_expansion_rerank.py -q
+# 321 passed
+
+python -m pytest tests -q \
+  --deselect tests/test_prewarm_concurrency.py::test_prewarm_per_candidate_exception_does_not_crash_batch
+# 2474 passed, 24 skipped, 1 deselected
+```
+
+Full-suite note: the deselected
+`test_prewarm_per_candidate_exception_does_not_crash_batch` is a
+**pre-existing flake** — measured failing 3/8 runs on unpatched `main`
+(`git stash` baseline) and ~1/5 with the patch; it exercises prewarm
+thread-pool exception handling and is unrelated to this change.
+
+Lint note: `black --check` / `flake8` already fail on `main` for both
+touched files (~1,320 pre-existing flake8 hits; CI runs neither tool).
+New code matches the file's existing style; the diff adds 5 E501s in the
+test file consistent with surrounding lines.
+
+## 6. Risk assessment
+
+| Risk | Level | Mitigation |
+|---|---|---|
+| Ranking regression | **Very low** | The composite economics score, `_score_breakdown` input, and persisted `estimated_revenue_index` are byte-identical (matrix-pinned). Only the value_score input changes. |
+| value_band churn | **Low–medium (intended)** | This is the fix: premium briefs lose unearned best_value badges (and their +4); value-tier briefs become eligible. Mid-tier briefs with multiplier ≈ 1.0 are near-identical (exactly identical at 1.0). |
+| Contract drift | **Very low** | `economics_detail` changes are strictly additive; frontend reads of `value_score` / `value_band` / `value_band_low_confidence` are untouched. |
+| Legacy callers | **Very low** | Scalar return path unchanged; `_economics_score` without the detail falls back to pre-fix behavior. |
+| Performance | **Negligible** | One extra `_clamp` and a two-key dict per scored candidate. |
+
+## 7. Acceptance / rollout
+
+- Post-deploy acceptance metric:
+  `scripts/diagnostics/value_band_tier_bias_probe.sql` (pre-merge baseline
+  run by Ahmed) — the premium-brief best_value share should normalize
+  post-deploy, and value-tier briefs should begin to register non-zero
+  best_value shares.
+- Sanity checks after deploy (per repo playbook): scores internally
+  consistent; `economics_detail.value_revenue_basis × rent_burden_score`
+  squares to `value_score²`; `ticket_multiplier` matches the brief's tier
+  × category; ranking order for a fixed brief unchanged except where ±4/−6
+  band deltas legitimately moved.
+
+> Note: `docs/investigations/scoring_ranking_audit_2026-06.md` and
+> `scripts/diagnostics/value_band_tier_bias_probe.sql` referenced by the
+> task are not present in the repo at `5ba564f8a`; the implementation was
+> grounded on the task's code anchors and §2.5 math, which matched that
+> HEAD exactly.
+
+## 8. Merge recommendation
+
+**Merge after review — low risk.** Ranking-side outputs are provably
+unchanged; the value_score correction restores the documented contract and
+is fully pinned by tests in both directions (premium no longer pins,
+value-tier now reachable, mid-tier invariant); rollback is a single revert
+of `fe850349d`.

--- a/tests/test_expansion_advisor_regression.py
+++ b/tests/test_expansion_advisor_regression.py
@@ -2076,6 +2076,262 @@ def test_economics_score_tier_aware_absolute_ceiling():
 
 
 # ---------------------------------------------------------------------------
+# Finding 2 (scoring audit 2026-06): value_score uses the tier-blind revenue
+# basis — the price-tier ticket multiplier no longer leaks into value_band.
+# ---------------------------------------------------------------------------
+
+def _economics_with_stubbed_percentile(burden_score: float, **kwargs):
+    """Run _economics_score on the percentile path with a fixed peer-relative
+    rent burden so value_score publishes deterministically."""
+    import app.services.expansion_advisor as adv
+
+    fixed_comp = {
+        "burden_score": float(burden_score),
+        "source_label": "district_band_type",
+        "n_comparable": 12,
+    }
+    orig = adv._percentile_rent_burden
+    adv._percentile_rent_burden = lambda *a, **k: dict(fixed_comp)
+    try:
+        return adv._economics_score(
+            estimated_annual_rent_sar=120_000.0,
+            estimated_fitout_cost_sar=300_000.0,
+            area_m2=100.0,
+            cannibalization_score=10.0,
+            fit_score=70.0,
+            db=object(),
+            is_listing=True,
+            **kwargs,
+        )
+    finally:
+        adv._percentile_rent_burden = orig
+
+
+def test_value_score_premium_multiplier_no_longer_pins_best_value():
+    """A premium burger brief with a mediocre tier-blind base (≈50) and a
+    median-ish rent burden must NOT classify best_value.
+
+    Pre-fix, the 1.9× premium-burger ticket multiplier pinned
+    estimated_revenue_index at the 100 clamp, collapsing value_score to
+    sqrt(100 × rent_burden) — best_value became rent-burden-only.
+    """
+    from app.services.expansion_advisor import _value_score
+
+    index, detail = _estimate_revenue_index(
+        area_m2=80.0,  # ratio 80/225 ≈ 0.36 → mediocre area signal
+        demand_score=50.0,
+        whitespace_score=50.0,
+        category="burger",
+        price_tier="premium",
+        return_detail=True,
+    )
+    # The tier-multiplied index is pinned at the clamp by the multiplier;
+    # the tier-blind basis stays mediocre.
+    assert index == 100.0
+    assert detail["ticket_multiplier"] == pytest.approx(1.9)
+    assert detail["tier_blind_index"] < 60.0
+
+    meta = _economics_with_stubbed_percentile(
+        58.0,
+        estimated_revenue_index=index,
+        price_tier="premium",
+        revenue_index_detail=detail,
+    )[1]
+    assert meta["value_band"] != "best_value"
+    assert meta["value_score"] < 75.0
+    assert meta["value_revenue_basis"] == pytest.approx(
+        detail["tier_blind_index"], abs=0.01
+    )
+    # The pre-fix basis (the pinned index) would have crossed the
+    # best_value line on the same rent burden.
+    assert _value_score(index, 58.0) >= 75.0
+
+
+def test_value_score_value_tier_cafe_can_reach_best_value():
+    """A value-tier cafe with a strong tier-blind base (≥85) and strong rent
+    burden (≥70) CAN reach best_value.
+
+    Pre-fix, the 0.5× value-cafe ticket multiplier capped
+    estimated_revenue_index at clamp(100 × 1.05 × 0.5) = 52.5, so even a
+    perfect base under a perfect rent burden gave sqrt(52.5 × 100) ≈ 72.5
+    < 75 — best_value was mathematically unreachable.
+    """
+    from app.services.expansion_advisor import _clamp, _value_score
+
+    index, detail = _estimate_revenue_index(
+        area_m2=225.0,
+        unit_street_width_m=40.0,
+        unit_listing_type="showroom",
+        demand_score=92.0,
+        whitespace_score=90.0,
+        category="cafe",
+        price_tier="value",
+        return_detail=True,
+    )
+    assert detail["ticket_multiplier"] == pytest.approx(0.5)
+    assert detail["tier_blind_index"] >= 85.0
+
+    # Mathematical unreachability of the old basis: a perfect base under
+    # the 0.5× multiplier cannot cross the 75-point best_value line.
+    assert _value_score(_clamp(100.0 * 1.05 * 0.5), 100.0) < 75.0
+
+    meta = _economics_with_stubbed_percentile(
+        72.0,
+        estimated_revenue_index=index,
+        price_tier="value",
+        revenue_index_detail=detail,
+    )[1]
+    assert meta["value_band"] == "best_value"
+    assert meta["value_score"] >= 75.0
+
+
+def test_value_score_tier_invariant_for_same_listing():
+    """The same synthetic listing scored under value/mid/premium briefs gets
+    an identical value_score and value_band; the ticket multiplier keeps
+    moving only the ranking-side estimated_revenue_index (out of scope)."""
+    results = {}
+    indexes = {}
+    for tier in ("value", "mid", "premium"):
+        index, detail = _estimate_revenue_index(
+            area_m2=225.0,
+            unit_street_width_m=40.0,
+            unit_listing_type="showroom",
+            demand_score=92.0,
+            whitespace_score=90.0,
+            category="cafe",
+            price_tier=tier,
+            return_detail=True,
+        )
+        meta = _economics_with_stubbed_percentile(
+            65.0,
+            estimated_revenue_index=index,
+            price_tier=tier,
+            revenue_index_detail=detail,
+        )[1]
+        indexes[tier] = index
+        results[tier] = (
+            detail["tier_blind_index"],
+            meta["value_score"],
+            meta["value_band"],
+        )
+
+    assert results["value"] == results["mid"] == results["premium"]
+    # Ranking-side index still moves with tier (cafe: 0.5× / 0.96× / 1.6×).
+    assert indexes["value"] < indexes["mid"] < indexes["premium"]
+
+
+def test_value_score_mid_tier_near_identical_pre_post_fix():
+    """mid-tier briefs with ticket multiplier == 1.0 (mid pizza: 50/50 SAR)
+    see identical value_scores pre/post fix — the tier-blind basis equals
+    the tier-multiplied index exactly."""
+    from app.services.expansion_advisor import _value_score
+
+    index, detail = _estimate_revenue_index(
+        area_m2=225.0,
+        demand_score=50.0,
+        whitespace_score=50.0,
+        category="pizza",
+        price_tier="mid",
+        return_detail=True,
+    )
+    assert detail["ticket_multiplier"] == pytest.approx(1.0)
+    assert detail["tier_blind_index"] == pytest.approx(index)
+    assert _value_score(detail["tier_blind_index"], 60.0) == pytest.approx(
+        _value_score(index, 60.0)
+    )
+
+
+def test_economics_detail_value_transparency_fields():
+    """economics_detail gains value_revenue_basis + ticket_multiplier without
+    removing any existing key; callers that don't pass revenue_index_detail
+    fall back to the tier-multiplied basis (legacy behavior)."""
+    index, detail = _estimate_revenue_index(
+        area_m2=225.0,
+        demand_score=60.0,
+        whitespace_score=60.0,
+        category="burger",
+        price_tier="premium",
+        return_detail=True,
+    )
+    meta = _economics_with_stubbed_percentile(
+        60.0,
+        estimated_revenue_index=index,
+        price_tier="premium",
+        revenue_index_detail=detail,
+    )[1]
+    for key in (
+        "rent_burden_score",
+        "rent_burden",
+        "rent_burden_confidence",
+        "rent_burden_weight",
+        "revenue_weight",
+        "fitout_burden_score",
+        "monthly_rent_per_m2",
+        "value_score",
+        "value_band",
+        "value_band_low_confidence",
+    ):
+        assert key in meta
+    assert meta["value_revenue_basis"] == pytest.approx(
+        detail["tier_blind_index"], abs=0.01
+    )
+    assert meta["ticket_multiplier"] == pytest.approx(
+        detail["ticket_multiplier"], abs=1e-4
+    )
+
+    legacy = _economics_with_stubbed_percentile(
+        60.0,
+        estimated_revenue_index=index,
+        price_tier="premium",
+    )[1]
+    assert legacy["value_revenue_basis"] == pytest.approx(index, abs=0.01)
+    assert legacy["ticket_multiplier"] is None
+
+
+def test_estimated_revenue_index_scalar_unchanged_over_matrix():
+    """The legacy scalar return is unchanged: pinned golden values for fixed
+    inputs, and scalar == detail-path index across a tier × category × area
+    matrix."""
+    # Neutral physicals: street None→50, area at 225 sweet spot→100,
+    # type None→50, demand/whitespace 50 → base = 60.0, no multipliers.
+    assert _estimate_revenue_index(
+        area_m2=225.0, demand_score=50.0, whitespace_score=50.0
+    ) == pytest.approx(60.0)
+    # Premium burger: 60 × 1.10 × (95/50) = 125.4 → clamped to 100.
+    assert _estimate_revenue_index(
+        area_m2=225.0,
+        demand_score=50.0,
+        whitespace_score=50.0,
+        category="burger",
+        price_tier="premium",
+    ) == pytest.approx(100.0)
+    # Value coffee: multiplier 18/50 = 0.36 floors at 0.5 → 60 × 1.08 × 0.5.
+    assert _estimate_revenue_index(
+        area_m2=225.0,
+        demand_score=50.0,
+        whitespace_score=50.0,
+        category="coffee",
+        price_tier="value",
+    ) == pytest.approx(32.4)
+
+    for tier in (None, "value", "mid", "premium"):
+        for category in (None, "burger", "cafe", "coffee", "pizza", "grills"):
+            for area in (60.0, 225.0, 500.0):
+                kwargs = dict(
+                    area_m2=area,
+                    unit_street_width_m=20.0,
+                    unit_listing_type="store",
+                    demand_score=65.0,
+                    whitespace_score=55.0,
+                    category=category,
+                    price_tier=tier,
+                )
+                scalar = _estimate_revenue_index(**kwargs)
+                index, _detail = _estimate_revenue_index(**kwargs, return_detail=True)
+                assert scalar == index
+
+
+# ---------------------------------------------------------------------------
 # Patch 06: rebalanced _score_breakdown weights
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Defect (audit Finding 2, §2.5)

`_estimate_revenue_index` returns `clamp(base × category_factor × ticket_multiplier)`, where `ticket_multiplier = clamp(implied_check / 50, 0.5, 2.5)` is **price-tier-driven**. That tier-multiplied index fed `_value_score`, violating the in-code contract that value_score stays tier-blind (the `_RENT_CEILING_TIER_MULT` note: "feeds value_score, which must stay tier-blind").

### §2.5 math, summarized

`value_score = sqrt(revenue_basis × rent_burden)`, best_value at ≥ 75:

| Brief | Ticket multiplier | Effect on revenue basis | Consequence for value_score |
|---|---|---|---|
| Premium burger | 95/50 = **1.9×** | Even a mediocre base (~50 × 1.10 × 1.9 = 104) pins at the 100 clamp | Collapses to `sqrt(100 × rent_burden)` — best_value (+4 uprank) becomes **rent-burden-only** (any burden ≥ 56.25 qualifies) |
| Premium cafe | 80/50 = **1.6×** | Pins near/at clamp similarly | Same rent-burden-only degeneration |
| Value cafe | 25/50 = **0.5×** | Capped at `clamp(100 × 1.05 × 0.5) = 52.5` even for a perfect base | `sqrt(52.5 × 100) ≈ 72.5 < 75` — best_value **mathematically unreachable** |
| Value coffee/shawarma | floors at **0.5×** | Capped ≤ ~56 | Best_value unreachable or near-unreachable |
| Mid pizza | 50/50 = **1.0×** | No change | value_score identical pre/post fix (asserted in tests) |

## Fix

- `_estimate_revenue_index(return_detail=True)` returns `(index, detail)` where `detail.tier_blind_index = clamp(base × category_factor)` — everything except the ticket multiplier. Category throughput stays: it is category-driven, constant within a search, and not the tier leak. The legacy scalar return path is byte-identical.
- `_economics_score` computes `value_score` from the tier-blind basis (new `revenue_index_detail` kwarg). The composite economics score — revenue_weight blending, rent burden, fitout, cannibalization, fit — continues to use the tier-multiplied `estimated_revenue_index`. Callers that don't pass the detail fall back to legacy behavior.
- `economics_detail` gains transparency fields `value_revenue_basis` (the tier-blind number used) and `ticket_multiplier` (the multiplier excluded). No existing key removed or renamed.
- Both first-pass and second-pass call sites thread the detail consistently; the persisted value_band comes from the second pass.

## Explicitly out of scope

The **ranking-side** `estimated_revenue_index` semantics (tier multiplier inside the economics component, its persisted column, and its `_score_breakdown` input) are untouched — byte-identical, covered by a fixed-input-matrix regression test. Whether the multiplier belongs in ranking economics is a separate product decision.

`_value_score`, band thresholds (75/25), and `_value_band_score_delta` (+4/−6) are unchanged. **No flag gating** — this is a bug-fix correction restoring the documented contract, per precedent.

## Acceptance metric

`scripts/diagnostics/value_band_tier_bias_probe.sql` (pre-merge baseline run by Ahmed) is the acceptance metric: the premium-brief best_value share should normalize post-deploy.

## Tests

- Premium burger, mediocre base (~50) + median-ish rent burden: no longer best_value (the pinned pre-fix basis would have crossed 75).
- Value-tier cafe, strong base (≥85) + strong rent burden (≥70): CAN reach best_value (was mathematically impossible).
- Same synthetic listing under value/mid/premium tiers → identical value_score and value_band (ranking-side index still moves with tier).
- Mid pizza (multiplier exactly 1.0): value_score identical pre/post fix.
- `economics_detail` carries the two new fields; all existing keys present; legacy fallback (no detail) preserved.
- `_estimate_revenue_index` scalar output: pinned golden values + scalar ≡ detail-path index across a tier × category × area matrix.

Validation: `python -m pytest tests/test_expansion_advisor_regression.py -k "value_score or revenue_index or economics" -q` (14 passed); full suite 2,036 passed (one pre-existing flake in `test_prewarm_concurrency`, fails ~3/8 on unpatched main as well).

https://claude.ai/code/session_0164BfrKM1VUwfJohGrsjA9i

---
_Generated by [Claude Code](https://claude.ai/code/session_0164BfrKM1VUwfJohGrsjA9i)_