### PR TITLE
fix(expansion): measured-zero population no longer bypasses viability floors

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -5929,9 +5929,13 @@ def _apply_market_viability_pass(
     for c in candidates:
         fs = c.get("feature_snapshot_json") if isinstance(c, dict) else None
 
-        # Population floor: pass when disabled, when value is missing/zero
-        # (don't drop on absent data — the soft pop leg below already
-        # handles low-population demotion), or when value meets the floor.
+        # Population floor: pass when disabled, or when the value is truly
+        # unmeasured (None — no population-grid coverage in the catchment;
+        # don't drop on absent data, the soft pop leg handles low-pop
+        # demotion). A MEASURED value — including a genuine 0.0 — is
+        # evaluated against the floor: a 0-pop covered site must fail the
+        # same floor that drops a 19,999-pop site (it no longer bypasses it
+        # via a None-vs-0 merge). The rpc/soft legs keep their own guards.
         pop_raw = fs.get("population_reach") if isinstance(fs, dict) else None
         if pop_floor <= 0:
             population_floor_pass = True
@@ -5941,8 +5945,7 @@ def _apply_market_viability_pass(
             try:
                 pop_val = float(pop_raw)
             except (TypeError, ValueError):
-                pop_val = 0.0
-            if pop_val <= 0:
+                # Unparseable measured value → treat as unmeasured (pass).
                 population_floor_pass = True
             else:
                 population_floor_pass = pop_val >= pop_floor
@@ -6264,7 +6267,10 @@ def _apply_market_viability_pass(
             pop_raw = fs.get("population_reach")
             if pop_raw is not None:
                 pop_reach = _safe_float(pop_raw, default=-1.0)
-                pop_confident = pop_reach > 0
+                # Confident when a value is PRESENT (not None), so a measured
+                # 0.0 can demote. -1.0 is the parse-failure sentinel from
+                # _safe_float and stays non-confident (treated as unmeasured).
+                pop_confident = pop_reach >= 0
                 pop_low = pop_reach < pop_threshold
                 pop_demote = bool(
                     pop_confident and pop_low and not growth_rescue
@@ -6994,7 +7000,10 @@ def _query_candidate_location_pool(
                 0 AS delivery_listing_count,
                 0 AS delivery_cat_count,
                 0 AS delivery_platform_count,
-                0 AS population_reach,
+                -- Placeholder; overwritten by _bulk_enrich_population. NULL
+                -- (not 0) so a row that never gets enriched reads as
+                -- "unmeasured", never "measured zero", on the viability path.
+                CAST(NULL AS double precision) AS population_reach,
                 ROW_NUMBER() OVER (
                     PARTITION BY cl.district_ar
                     ORDER BY
@@ -7210,7 +7219,10 @@ def _query_commercial_unit_candidates(
             0 AS delivery_listing_count,
             0 AS delivery_cat_count,
             0 AS delivery_platform_count,
-            0 AS population_reach
+            -- Placeholder; overwritten by _bulk_enrich_population. NULL
+            -- (not 0) so a row that never gets enriched reads as
+            -- "unmeasured", never "measured zero", on the viability path.
+            CAST(NULL AS double precision) AS population_reach
         FROM commercial_unit cu
         WHERE {where_clause}
         ORDER BY cu.restaurant_score DESC NULLS LAST, cu.price_sar_annual ASC NULLS LAST
@@ -7228,10 +7240,16 @@ def _bulk_enrich_population(
     demand_radius_m: float | None = None,
     *,
     service_model: str | None = None,
-) -> dict[str, float]:
+) -> dict[str, float | None]:
     """Bulk-compute population_reach for a set of candidate locations.
 
-    Returns {parcel_id: population_reach} for all rows that have lat/lon.
+    Returns ``{parcel_id: population_reach}`` for all rows that have
+    lat/lon. ``population_reach`` is ``None`` when the catchment has **no**
+    population-grid coverage (zero grid rows), and a real summed value
+    (including a genuine ``0.0``) when at least one grid row is in range.
+    This lets callers distinguish "unmeasured" from "measured zero" — the
+    viability floor/soft-leg must treat them differently. Scoring reads
+    coalesce ``None`` → ``0.0`` via ``_safe_float`` and are unaffected.
     Uses a single SQL query with unnest + LATERAL to avoid N+1.
 
     The catchment radius comes from one of three sources, in priority
@@ -7296,10 +7314,13 @@ def _bulk_enrich_population(
                     )
                     SELECT
                         i.parcel_id,
-                        COALESCE(pop.population_reach, 0) AS population_reach
+                        COALESCE(pop.population_reach, 0) AS population_reach,
+                        COALESCE(pop.coverage_count, 0) AS coverage_count
                     FROM inputs i
                     LEFT JOIN LATERAL (
-                        SELECT COALESCE(SUM(pd.population), 0) AS population_reach
+                        SELECT
+                            COALESCE(SUM(pd.population), 0) AS population_reach,
+                            COUNT(*) AS coverage_count
                         FROM population_density pd
                         WHERE {_pd_where}
                           AND ST_DWithin(
@@ -7312,7 +7333,16 @@ def _bulk_enrich_population(
                 {"pids": pids, "lons": lons, "lats": lats, "radius_m": demand_radius_m},
             ).mappings().all()
 
-        return {str(r["parcel_id"]): float(r["population_reach"]) for r in result}
+        # coverage_count == 0 → no grid rows in catchment → unmeasured (None).
+        # coverage_count > 0 → measured sum (which may legitimately be 0.0).
+        return {
+            str(r["parcel_id"]): (
+                float(r["population_reach"])
+                if int(r["coverage_count"] or 0) > 0
+                else None
+            )
+            for r in result
+        }
     except Exception as exc:
         logger.warning("Bulk population enrichment failed: %s", exc, exc_info=True)
         return {}
@@ -8727,7 +8757,15 @@ def run_expansion_search(
         _source_tier = row.get("source_tier")
         if _source_tier == 3 and max_area_m2 and area_m2 and area_m2 > max_area_m2:
             area_m2 = max_area_m2
+        # Scoring read: None/garbage → 0.0 (ranking math byte-identical).
         population_reach = _safe_float(row.get("population_reach"))
+        # Snapshot read: preserve None (no population-grid coverage) so the
+        # persisted feature_snapshot_json distinguishes "unmeasured" from a
+        # genuine "measured 0.0". Only the viability pass keys off this.
+        _pop_reach_raw = row.get("population_reach")
+        population_reach_measured: float | None = (
+            population_reach if _pop_reach_raw is not None else None
+        )
         competitor_count = _safe_int(row.get("competitor_count"))
         # F4: confidence flag emitted by _bulk_enrich_competitors. Falls
         # through as None on the ARCGIS-fallback candidate-pool SQL path
@@ -9100,6 +9138,7 @@ def run_expansion_search(
                 "row": dict(row),
                 "area_m2": area_m2,
                 "population_reach": population_reach,
+                "population_reach_measured": population_reach_measured,
                 "competitor_count": competitor_count,
                 "competitor_count_confident": competitor_count_confident,
                 "max_chain_strength": max_chain_strength,
@@ -9991,6 +10030,9 @@ def run_expansion_search(
         _pid_str = str(row.get("parcel_id") or "")
         area_m2 = prepared_item["area_m2"]
         population_reach = prepared_item["population_reach"]
+        # None when the catchment had no population-grid coverage; the
+        # scoring `population_reach` above is the 0.0-coalesced counterpart.
+        population_reach_measured = prepared_item.get("population_reach_measured")
         competitor_count = prepared_item["competitor_count"]
         competitor_count_confident = prepared_item.get("competitor_count_confident")
         max_chain_strength = prepared_item.get("max_chain_strength")
@@ -10711,8 +10753,12 @@ def run_expansion_search(
             feature_snapshot_json["display_annual_rent_sar"] = round(
                 estimated_annual_rent_sar, 2
             )
-        if population_reach is not None:
-            feature_snapshot_json["population_reach"] = population_reach
+        # Persist the MEASURED value (null when no population-grid coverage)
+        # so the viability floor/soft-leg can tell "unmeasured" from
+        # "measured zero". Scoring readers (_population_score, demand blend,
+        # dg-index, _safe_float reads) keep coalescing null → 0.0, so
+        # ranking is byte-identical for covered candidates.
+        feature_snapshot_json["population_reach"] = population_reach_measured
         if delivery_listing_count is not None:
             feature_snapshot_json["delivery_listing_count"] = delivery_listing_count
         if access_visibility_score is not None:

--- a/docs/investigations/PR-3_measured_zero_population_report.md
+++ b/docs/investigations/PR-3_measured_zero_population_report.md
@@ -1,0 +1,144 @@
+# PR-3 Report — Distinguish measured-zero population from missing coverage
+
+| | |
+|---|---|
+| **Branch** | `claude/measured-zero-pop-floors-nw4hsv` (from latest `main`) |
+| **Scope** | Finding 5 of the 2026-06 scoring/ranking audit. No other changes. |
+| **Status** | Pushed. **Not merged** — awaiting review, per task scope. |
+| **Files** | `app/services/expansion_advisor.py`, `tests/test_expansion_advisor_service.py`, `frontend/src/features/expansion-advisor/scoreComponentMeta.test.ts` |
+| **Migration** | None (JSON/float column semantics only). `scripts/validate_alembic_chain.py` ✓ (91 revisions valid). |
+| **Validation** | Full backend suite: **2478 passed, 24 skipped**, 0 failures. Frontend `tsc` ✓, affected Vitest suites green. |
+
+---
+
+## 1. The merged-cohort defect
+
+`_bulk_enrich_population` returned `COALESCE(SUM(pd.population), 0)` and the
+listing-pool SQL defaulted `0 AS population_reach`, so **"no population-grid
+coverage in the catchment"** and **"a real measured zero"** both arrived at the
+viability pass as `0.0`. They are not the same thing and must not be treated
+the same way.
+
+The hard floor had a `pop_val <= 0 → pass` escape hatch and the soft pop leg
+required `pop_reach > 0` to be "confident". The combined effect: a site with
+`population_reach == 0` **bypassed** the very floor that drops a 19,999-pop
+site, and could never be demoted by the soft leg. The defensive `None`
+branches in the viability pass were effectively dead for listing candidates,
+because listing candidates never carried `None` — they carried a coalesced
+`0.0`.
+
+## 2. The `None`-vs-`0` contract
+
+| State | `population_reach` value | Hard floor | Soft pop leg | Scoring |
+|---|---|---|---|---|
+| **No grid coverage** (unmeasured) | `None` (null) | **pass** (defensive) | does **not** fire | `None → 0.0` |
+| **Measured zero** (covered, sum 0) | `0.0` | evaluated → **fails** a `>0` floor | **can** fire | `0.0` |
+| **Measured positive** | e.g. `41000.0` | evaluated | fires if below cohort p25 | `41000.0` |
+
+Implementation:
+
+- **Enrichment coverage signal.** `_bulk_enrich_population` now returns
+  `dict[str, float | None]`. The LATERAL subquery additionally selects
+  `COUNT(*) AS coverage_count`; the Python comprehension maps
+  `coverage_count == 0 → None`, `> 0 → float(sum)` (which may legitimately be
+  `0.0`).
+- **Listing-pool SQL placeholders.** Both active listing paths —
+  `_query_candidate_location_pool` and the direct `_query_commercial_unit_candidates`
+  fallback — now default `CAST(NULL AS double precision) AS population_reach`
+  instead of `0`. So a row that is never enriched reads as *unmeasured*, never
+  *measured zero*.
+- **Floor path.** The `pop_val <= 0 → pass` branch is deleted. `pop_raw is None`
+  keeps today's defensive pass; a measured value (including `0.0`) is evaluated
+  against the floor (`0.0 >= 20000` → fail). An unparseable value stays a
+  defensive pass.
+- **Soft leg.** `pop_confident` is now "value is present" (`pop_reach >= 0`,
+  guarding the `-1.0` parse-failure sentinel) instead of `> 0`, so a measured
+  zero can demote.
+- **rpc leg unchanged.** It keeps `pop_v > 0` — that is a division guard, not a
+  viability semantic, and is correct as-is.
+
+## 3. Scoring-unchanged guarantee
+
+Ranking math is **byte-identical for covered candidates**. The first-pass
+scoring read keeps `population_reach = _safe_float(row.get("population_reach"))`
+(`None → 0.0`), and `_population_score`, the demand blend, the dg-index
+population sub-signal, and every `_safe_float(...)` scoring read continue to
+coalesce `None → 0.0`. Only the **viability pass** semantics change, and only
+for the two states it previously could not tell apart.
+
+The snapshot now carries the *measured* value: a new
+`population_reach_measured` (None-preserving) is threaded first-pass →
+`prepared_item` → second-pass and written to
+`feature_snapshot_json["population_reach"]`, while the scoring variable stays
+the `0.0`-coalesced counterpart. The top-level `expansion_candidate.population_reach`
+column is unchanged (still the coalesced scoring value).
+
+## 4. Snapshot null-safety (frontend)
+
+`feature_snapshot_json["population_reach"]` may now be `null`. Frontend was
+already null-safe and required **no code change**:
+
+- `frontend/src/lib/api/expansionAdvisor.ts` — typed `population_reach: number | null`.
+- `scoreComponentMeta.ts` — `asNumber(null) → null`; the Demand card renders
+  `null` via `formatInputValue` / `fmtScore` as an em-dash ("unmeasured"),
+  never a fabricated `0`.
+- `AdvisorySectionCards.tsx` — `if (section.population_reach != null)` guard.
+
+A regression test was added to `scoreComponentMeta.test.ts` locking the
+contract: a measured `0` resolves to `0`, a `null` resolves to `null` (em-dash),
+never coerced.
+
+Memo wording (e.g. "population reach around 0") is **out of scope** (v12
+workstream); the memo builders still receive the coalesced `0.0` and do not
+crash on the unmeasured state.
+
+## 5. Tests added (`tests/test_expansion_advisor_service.py`)
+
+- `test_hard_floor_distinguishes_measured_zero_from_unmeasured` — with a
+  20,000 floor, of `{20000, 19999, 0.0, None}` only `20000` and the
+  unmeasured `None` survive.
+- `test_soft_pop_leg_demotes_measured_zero_but_not_unmeasured` — floor
+  disabled: a measured `0.0` fires `population_below_quartile`; an unmeasured
+  `None` does not fire the pop leg.
+- `test_unmeasured_population_snapshot_roundtrips_with_none` — `None`
+  round-trips through `_normalize_feature_snapshot` → `_safe_json_dumps` →
+  reload as `null`; `_safe_float` still coalesces to `0.0`.
+
+The pre-existing `test_viability_pass_diagnostics_records_hard_floor_drops_per_leg`
+continues to pass.
+
+## 6. Post-deploy validation note
+
+After deploy, run a fresh **QSR / Burger** regression search and confirm the
+shortlist is sensible (no zero-population sites surviving the active floor).
+Then check the persisted distribution:
+
+```sql
+SELECT
+  COUNT(*)                                                            AS total,
+  COUNT(*) FILTER (
+    WHERE feature_snapshot_json->>'population_reach' IS NULL
+  )                                                                    AS pop_null,
+  COUNT(*) FILTER (
+    WHERE (gate_status_json->>'population_floor_pass') = 'true'
+  )                                                                    AS floor_pass,
+  COUNT(*) FILTER (
+    WHERE (gate_status_json->>'population_floor_pass') = 'false'
+  )                                                                    AS floor_fail
+FROM expansion_candidate
+WHERE search_id = '<new_search_id>';
+```
+
+Expectation: the `pop_null` share reflects genuine no-coverage catchments
+(small in dense Riyadh), and `floor_fail` now includes measured-zero /
+sub-floor covered sites that previously slipped through.
+
+## 7. Risk
+
+**Low.** The change is confined to the viability-pass semantics for two
+previously-indistinguishable states; covered-candidate ranking is unchanged.
+The only behavioral shift is intended: measured-zero / sub-floor covered
+listing sites now correctly fail the population hard floor (when configured
+`> 0`) and can be demoted by the soft leg, while genuinely unmeasured sites
+keep their defensive pass. The dead `_build_candidate_sql*` ARCGIS parcel-pool
+path is untouched.

--- a/frontend/src/features/expansion-advisor/scoreComponentMeta.test.ts
+++ b/frontend/src/features/expansion-advisor/scoreComponentMeta.test.ts
@@ -74,6 +74,30 @@ describe("scoreComponentMeta — listing-derived source attributes to the candid
   });
 });
 
+const populationReachInput = PER_COMPONENT_INPUTS.demand_potential.find(
+  (d) => d.key === "population_reach",
+)!;
+
+describe("scoreComponentMeta — population_reach distinguishes unmeasured from zero", () => {
+  it("resolves a measured population_reach (including 0) to that number", () => {
+    expect(
+      populationReachInput.resolve(ctx({ featureSnapshot: { population_reach: 41000 } })).value,
+    ).toBe(41000);
+    // A measured zero stays a number (not coerced to null/em-dash).
+    expect(
+      populationReachInput.resolve(ctx({ featureSnapshot: { population_reach: 0 } })).value,
+    ).toBe(0);
+  });
+
+  it("resolves a null population_reach (no grid coverage) to null, not 0", () => {
+    // PR-3: an unmeasured candidate carries null; the demand card renders an
+    // em-dash for null and must never paper over it with a fabricated 0.
+    expect(
+      populationReachInput.resolve(ctx({ featureSnapshot: { population_reach: null } })).value,
+    ).toBeNull();
+  });
+});
+
 /* ─── PR-D: dg_index demand inputs ───────────────────────────────────────── */
 
 function dgSnapshot(): Record<string, unknown> {

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -4297,6 +4297,101 @@ def test_viability_pass_diagnostics_records_hard_floor_drops_per_leg(monkeypatch
     }
 
 
+def test_hard_floor_distinguishes_measured_zero_from_unmeasured(monkeypatch):
+    """PR-3 / Finding 5: a measured 0.0 population is a real value and must
+    FAIL the population hard floor exactly like a 19,999 site, while a
+    truly unmeasured (None — no population-grid coverage) candidate still
+    passes the floor defensively. Pre-fix, None and measured-0.0 were merged
+    at 0.0 and the ``pop_val <= 0 → pass`` branch let a 0-pop site bypass the
+    floor that drops a 19,999-pop site.
+    """
+    import app.services.expansion_advisor as svc
+
+    monkeypatch.setattr(
+        svc.settings, "EXPANSION_VIABILITY_POPULATION_HARD_FLOOR", 20000
+    )
+    monkeypatch.setattr(
+        svc.settings, "EXPANSION_VIABILITY_BRAND_PRESENCE_HARD_FLOOR", 0
+    )
+    monkeypatch.setattr(
+        svc.settings, "EXPANSION_VIABILITY_CONSTRUCTION_BUFFER_M", 0
+    )
+
+    def _cand(cid: str, pop):
+        fs: dict = {}
+        # Mirror production: an unmeasured candidate carries an explicit
+        # null population_reach (no grid coverage), not an absent key.
+        fs["population_reach"] = pop
+        return {
+            "id": cid,
+            "parcel_id": cid,
+            "final_score": 80.0,
+            "score_breakdown_json": {},
+            "feature_snapshot_json": fs,
+        }
+
+    cohort = [
+        _cand("at_floor", 20000.0),       # meets floor → survives
+        _cand("below_floor", 19999.0),    # below floor → dropped
+        _cand("measured_zero", 0.0),      # measured 0.0 → dropped (the fix)
+        _cand("unmeasured", None),        # no coverage → defensive pass
+    ]
+
+    out = _apply_market_viability_pass(list(cohort), search_id="t")
+    survivors = {c["id"] for c in out}
+    assert survivors == {"at_floor", "unmeasured"}
+
+
+def test_soft_pop_leg_demotes_measured_zero_but_not_unmeasured(
+    disable_market_viability_floors,
+):
+    """With the hard floor disabled, the soft percentile pop leg can demote a
+    MEASURED 0.0 (confidence is now "value present", not ">0"), but leaves a
+    truly unmeasured (None) candidate alone (defensive — pop_demote stays
+    False when there is no coverage).
+    """
+    # Measured zero: below the cohort p25 (~7000) → soft pop leg fires.
+    cohort_zero = _viability_cohort(target_pop_reach=0.0, target_rent_pct=0.40)
+    out_zero = _apply_market_viability_pass(list(cohort_zero), search_id="t")
+    target_zero = next(c for c in out_zero if c["id"] == "target")
+    flag_zero = target_zero["score_breakdown_json"].get("market_viability_flag")
+    assert flag_zero is not None and flag_zero["population_demote"] is True
+    assert "population_below_quartile" in target_zero["viability_legs_fired"]
+
+    # Unmeasured: population_reach absent/None → pop leg defensively skipped.
+    cohort_none = _viability_cohort(target_pop_reach=4500.0, target_rent_pct=0.40)
+    target_in = next(c for c in cohort_none if c["id"] == "target")
+    target_in["feature_snapshot_json"]["population_reach"] = None
+    out_none = _apply_market_viability_pass(list(cohort_none), search_id="t")
+    target_none = next(c for c in out_none if c["id"] == "target")
+    # No leg fired at all → no flag block, pop leg did not demote.
+    assert "population_below_quartile" not in target_none.get(
+        "viability_legs_fired", []
+    )
+    flag_none = target_none["score_breakdown_json"].get("market_viability_flag")
+    assert flag_none is None or flag_none.get("population_demote") is False
+
+
+def test_unmeasured_population_snapshot_roundtrips_with_none(monkeypatch):
+    """A feature snapshot whose population_reach is None survives the
+    normalize + JSON dump + reload round-trip as null (never coerced to 0),
+    so the persisted contract preserves the unmeasured signal.
+    """
+    import json
+
+    snapshot = expansion_service._normalize_feature_snapshot(
+        {"population_reach": None, "area_m2": 120.0}
+    )
+    assert snapshot["population_reach"] is None
+
+    dumped = expansion_service._safe_json_dumps(snapshot)
+    reloaded = json.loads(dumped)
+    assert reloaded["population_reach"] is None
+
+    # Scoring reads keep coalescing null → 0.0 (ranking unchanged).
+    assert expansion_service._safe_float(reloaded.get("population_reach")) == 0.0
+
+
 def test_viability_pass_diagnostics_unchanged_when_caller_omits_kwarg(
     disable_market_viability_floors,
 ):


### PR DESCRIPTION
Finding 5 of the 2026-06 scoring/ranking audit.

`_bulk_enrich_population` returned COALESCE(SUM(pd.population), 0) and the
listing-pool SQL defaulted `0 AS population_reach`, merging "no population-grid
coverage" with "measured zero" at 0.0. The hard floor's `pop_val <= 0 -> pass`
branch and the soft leg's `pop_reach > 0` confidence check let a 0-pop site
bypass the floor that drops a 19,999-pop site; the defensive None branches were
dead for listing candidates.

- _bulk_enrich_population returns float | None: a COUNT(*) coverage signal maps
  zero coverage -> None, positive coverage -> the summed value (incl. genuine
  0.0).
- Both listing-pool SQL placeholders (candidate_location + commercial_unit)
  default to NULL instead of 0, so an un-enriched row reads as unmeasured.
- Viability floor: drop the `pop_val <= 0 -> pass` branch; None keeps the
  defensive pass, a measured value (incl. 0.0) is evaluated against the floor.
- Soft pop leg: pop_confident becomes "value present" (>= 0) so measured zero
  can demote; rpc leg keeps its `> 0` division guard.
- Snapshot carries the measured (None-preserving) value via a new
  population_reach_measured thread; scoring reads stay 0.0-coalesced so ranking
  is byte-identical for covered candidates.

Frontend already null-safe (typed number | null, asNumber/fmtScore render an
em-dash for null); added a regression test locking the contract.

No migration (JSON/float semantics only); alembic chain validated as a no-op.

https://claude.ai/code/session_012qxPbMNeR2BnTSG1Y5nr4V