### PR TITLE
F5 Stage 1 — Arabic gate labels (frontend)

### DIFF
--- a/frontend/src/features/expansion-advisor/GateLabelI18n.test.tsx
+++ b/frontend/src/features/expansion-advisor/GateLabelI18n.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+import "../../i18n";
+import i18n from "../../i18n";
+import GateSummary from "./GateSummary";
+import { humanGateLabel } from "./formatHelpers";
+
+beforeEach(async () => {
+  if (i18n.language !== "en") await i18n.changeLanguage("en");
+});
+
+afterEach(async () => {
+  if (i18n.language !== "en") await i18n.changeLanguage("en");
+});
+
+/* ─── F5 Stage 1 — Arabic gate labels (frontend) ──────────────────────── */
+
+describe("F5 Stage 1 — humanGateLabel localization", () => {
+  // Backend GATE_LABELS["ar"] parity — see app/services/expansion_advisor_i18n.py
+  const AR: Record<string, string> = {
+    zoning_fit_pass: "ملاءمة التنطيق",
+    area_fit_pass: "ملاءمة المساحة",
+    frontage_access_pass: "الواجهة/الوصول",
+    parking_pass: "مواقف السيارات",
+    district_pass: "الحي",
+    cannibalization_pass: "التهام المبيعات",
+    delivery_market_pass: "سوق التوصيل",
+    economics_pass: "الجدوى الاقتصادية",
+    radiance_growth_pass: "إشارة نمو السوق",
+    population_floor_pass: "الحد الأدنى للوصول السكاني",
+    commercial_floor_pass: "الحد الأدنى للنشاط التجاري",
+    construction_proximity_pass: "الحد الأدنى للقرب الإنشائي",
+  };
+
+  it("returns the Arabic label for every canonical gate key", () => {
+    const t = i18n.getFixedT("ar");
+    for (const [key, label] of Object.entries(AR)) {
+      expect(humanGateLabel(key, t)).toBe(label);
+    }
+  });
+
+  it("returns the legacy English label when t is the EN TFunction", () => {
+    const t = i18n.getFixedT("en");
+    expect(humanGateLabel("zoning_fit_pass", t)).toBe("Zoning fit");
+    expect(humanGateLabel("frontage_access_pass", t)).toBe("Frontage / access");
+    expect(humanGateLabel("delivery_market_pass", t)).toBe("Delivery market");
+    expect(humanGateLabel("economics_pass", t)).toBe("Economics");
+  });
+
+  it("is byte-identical to the no-arg English derivation in EN", () => {
+    const t = i18n.getFixedT("en");
+    for (const key of Object.keys(AR)) {
+      expect(humanGateLabel(key, t)).toBe(humanGateLabel(key));
+    }
+  });
+
+  it("falls back to the legacy English derivation for an unknown key — no crash", () => {
+    const arT = i18n.getFixedT("ar");
+    expect(humanGateLabel("some_new_gate_pass", arT)).toBe("Some new gate");
+    expect(humanGateLabel("some_new_gate_pass")).toBe("Some new gate");
+  });
+});
+
+describe("F5 Stage 1 — GateSummary renders localized chips", () => {
+  const gates = { zoning_fit_pass: true, parking_pass: false };
+
+  it("renders Arabic gate chips in AR locale", async () => {
+    await i18n.changeLanguage("ar");
+    const html = renderToStaticMarkup(<GateSummary gates={gates} />);
+    expect(html).toContain("ملاءمة التنطيق");
+    expect(html).toContain("مواقف السيارات");
+    expect(html).not.toContain("Zoning fit");
+  });
+
+  it("renders English gate chips in EN locale", () => {
+    const html = renderToStaticMarkup(<GateSummary gates={gates} />);
+    expect(html).toContain("Zoning fit");
+    expect(html).toContain("Parking");
+  });
+});

--- a/frontend/src/features/expansion-advisor/GateSummary.tsx
+++ b/frontend/src/features/expansion-advisor/GateSummary.tsx
@@ -33,9 +33,9 @@ export default function GateSummary({ gates, unknownGates }: GateSummaryProps) {
           <span
             key={key}
             className={`ea-gate-item ea-gate-item--${status}`}
-            title={humanGateLabel(key)}
+            title={humanGateLabel(key, t)}
           >
-            {gateIcon(status)} {humanGateLabel(key)}
+            {gateIcon(status)} {humanGateLabel(key, t)}
           </span>
         );
       })}

--- a/frontend/src/features/expansion-advisor/formatHelpers.ts
+++ b/frontend/src/features/expansion-advisor/formatHelpers.ts
@@ -1,3 +1,4 @@
+import type { TFunction } from "i18next";
 import { formatCurrencySAR, formatNumber, formatInteger } from "../../i18n/format";
 import { toNumeric } from "../../lib/api/coerceNumeric";
 
@@ -228,8 +229,45 @@ const GATE_LABEL_MAP: Record<string, string> = {
   economics: "Economics",
 };
 
-/** Return a clean human-readable label for a gate key. */
-export function humanGateLabel(key: string): string {
+/**
+ * Maps the 12 canonical gate keys to i18n resource keys so the chip label
+ * follows the current locale. Mirrors GATE_LABELS in
+ * app/services/expansion_advisor_i18n.py (single backend source of truth for
+ * the AR strings). The en.json values are byte-identical to the legacy
+ * English output of humanGateLabel below, so EN rendering is unchanged.
+ */
+const GATE_LABEL_I18N_KEYS: Record<string, string> = {
+  zoning_fit_pass: "expansionAdvisor.gateLabel.zoningFit",
+  area_fit_pass: "expansionAdvisor.gateLabel.areaFit",
+  frontage_access_pass: "expansionAdvisor.gateLabel.frontageAccess",
+  parking_pass: "expansionAdvisor.gateLabel.parking",
+  district_pass: "expansionAdvisor.gateLabel.district",
+  cannibalization_pass: "expansionAdvisor.gateLabel.cannibalization",
+  delivery_market_pass: "expansionAdvisor.gateLabel.deliveryMarket",
+  economics_pass: "expansionAdvisor.gateLabel.economics",
+  radiance_growth_pass: "expansionAdvisor.gateLabel.radianceGrowth",
+  population_floor_pass: "expansionAdvisor.gateLabel.populationFloor",
+  commercial_floor_pass: "expansionAdvisor.gateLabel.commercialFloor",
+  construction_proximity_pass: "expansionAdvisor.gateLabel.constructionProximity",
+};
+
+/**
+ * Return a clean human-readable label for a gate key.
+ *
+ * When a locale-bound `t` (from useTranslation) is supplied, canonical gate
+ * keys are localized via the i18n resources (same mechanism as
+ * humanizeScoreLabel). Without `t` — or for keys absent from the i18n map —
+ * the legacy English derivation is used, so existing callers stay
+ * byte-identical and unknown keys never crash.
+ */
+export function humanGateLabel(key: string, t?: TFunction): string {
+  if (t) {
+    const i18nKey = GATE_LABEL_I18N_KEYS[key];
+    if (i18nKey) {
+      const translated = t(i18nKey);
+      if (translated !== i18nKey) return translated;
+    }
+  }
   if (GATE_LABEL_MAP[key]) return GATE_LABEL_MAP[key];
   return key
     .replace(/_/g, " ")

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -786,6 +786,20 @@
       "parking": "مواقف السيارات",
       "cannibalization": "التهام الفروع"
     },
+    "gateLabel": {
+      "zoningFit": "ملاءمة التنطيق",
+      "areaFit": "ملاءمة المساحة",
+      "frontageAccess": "الواجهة/الوصول",
+      "parking": "مواقف السيارات",
+      "district": "الحي",
+      "cannibalization": "التهام المبيعات",
+      "deliveryMarket": "سوق التوصيل",
+      "economics": "الجدوى الاقتصادية",
+      "radianceGrowth": "إشارة نمو السوق",
+      "populationFloor": "الحد الأدنى للوصول السكاني",
+      "commercialFloor": "الحد الأدنى للنشاط التجاري",
+      "constructionProximity": "الحد الأدنى للقرب الإنشائي"
+    },
     "selectCandidates": "اختر ٢\u2013٤ مرشحين للمقارنة",
     "compareSelected": "مقارنة ({{count}})",
     "executiveReport": "التقرير التنفيذي",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -734,6 +734,20 @@
       "parking": "Parking",
       "cannibalization": "Cannibalization"
     },
+    "gateLabel": {
+      "zoningFit": "Zoning fit",
+      "areaFit": "Area fit",
+      "frontageAccess": "Frontage / access",
+      "parking": "Parking",
+      "district": "District",
+      "cannibalization": "Cannibalization",
+      "deliveryMarket": "Delivery market",
+      "economics": "Economics",
+      "radianceGrowth": "Radiance growth",
+      "populationFloor": "Population floor",
+      "commercialFloor": "Commercial floor",
+      "constructionProximity": "Construction proximity"
+    },
     "selectCandidates": "Select 2\u20134 candidates to compare",
     "compareSelected": "Compare ({{count}})",
     "executiveReport": "Executive Report",


### PR DESCRIPTION
## What is wrong now

AR-locale users see **English gate chips** in `GateSummary` (the site-requirements gate badges on the candidate detail panel). The chip label is re-derived client-side from the raw `*_pass` key (`humanGateLabel`) with no locale awareness, even though the backend already owns the Arabic translations in `GATE_LABELS` (`app/services/expansion_advisor_i18n.py`).

## Why it happens

The chip is built from `candidate.gate_status_json` — a **raw boolean map keyed only by gate key** (e.g. `{ zoning_fit_pass: true }`), with no localized label in the payload. `humanGateLabel(key)` mapped the key to a static English string.

## Mechanism chosen: Option B (frontend i18n resources)

Per the investigation (step 4): the gate-chip payload (`gate_status_json`) carries no localized label the frontend could consume, so **Option A is not applicable** for the chips. Stage 1 is frontend-only, so the fix lives in the frontend i18n resources, using the **same mechanism the feature already uses** for score labels (`humanizeScoreLabel(key, t)` → i18next resource key + locale-bound `TFunction`). No second i18n path; no backend change.

## The fix (smallest safe diff)

- Add a `gateLabel` block (12 canonical keys) to `en.json` and `ar.json`.
  - AR values are **byte/codepoint-identical** to `GATE_LABELS["ar"]` (verified by codepoint against the live backend table — U+064A yeh, U+0647 heh).
  - EN values are **byte-identical** to the legacy `humanGateLabel` output, so EN rendering is unchanged.
- `humanGateLabel(key, t?)` localizes canonical keys when a locale-bound `t` is supplied; otherwise (and for unknown keys) it falls back to the legacy English derivation, preserving the `key.replace("_pass","").replace("_"," ")` final fallback. Existing callers that pass no `t` stay byte-identical; unknown keys never crash.
- `GateSummary` passes its `useTranslation()` `t` to `humanGateLabel`.

### Backend → frontend AR label parity (all 12 verified identical)

| key | AR |
|---|---|
| zoning_fit_pass | ملاءمة التنطيق |
| area_fit_pass | ملاءمة المساحة |
| frontage_access_pass | الواجهة/الوصول |
| parking_pass | مواقف السيارات |
| district_pass | الحي |
| cannibalization_pass | التهام المبيعات |
| delivery_market_pass | سوق التوصيل |
| economics_pass | الجدوى الاقتصادية |
| radiance_growth_pass | إشارة نمو السوق |
| population_floor_pass | الحد الأدنى للوصول السكاني |
| commercial_floor_pass | الحد الأدنى للنشاط التجاري |
| construction_proximity_pass | الحد الأدنى للقرب الإنشائي |

## Validation

- `npm run build` — green (exit 0).
- New `GateLabelI18n.test.tsx` — 6/6 pass: AR label parity for all 12 keys, EN byte-identical to the no-arg derivation, unknown-key fallback (`some_new_gate_pass` → `Some new gate`) in both locales, and `GateSummary` rendering Arabic chips in AR / English in EN.
- Existing `humanGateLabel` tests in `ExpansionAdvisorPage.test.tsx` (5) and `Pr4bI18n.test.tsx` — pass. The 15 pre-existing failures in `ExpansionAdvisorPage.test.tsx` are present on `main` (unrelated: Exploratory pill / Data badge) and unchanged by this PR.

## Risk

Low. AR-only behavior is added; the EN path is byte-identical. Translation/i18n wiring only — no scoring, logic, or thresholds touched.

## Adjacent (noted, not actioned — out of Stage 1 scope)

Other `humanGateLabel` callers in `studyAdapters.ts` / `DecisionLogicCard.tsx` compose English sentence fragments (e.g. `"<label> gate"`, `"<label> needs field verification."`). Localizing those needs full sentence templates, not token swaps — a separate follow-up.

https://claude.ai/code/session_01HUB2RbgwQUMNmguqvaLRyq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUB2RbgwQUMNmguqvaLRyq)_