### PR TITLE
F5 Stage 2 — Arabic parity for get_recommendation_report recommendation strings

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -12520,33 +12520,71 @@ def get_recommendation_report(db: Session, search_id: str, lang: str = "en") -> 
 
     # Build recommendation language — consistent with strict pass_count.
     # Three states: pass (gates clear), validation-clear (no blocking failures but unresolved), fail.
+    # Each string is routed through expansion_advisor_i18n.render() for the
+    # requested lang; render() returns "" on any failure, in which case we
+    # fall back to the English f-string below. The fallback path keeps the
+    # English output byte-identical to HEAD (F5 Stage 2 — AR parity only).
+    from app.services.expansion_advisor_i18n import render as _render_i18n
+
+    def _localized(template_id: str, params: dict[str, Any], fallback: str) -> str:
+        rendered = _render_i18n({"id": template_id, "params": params}, lang)
+        return rendered or fallback
+
     best_district = best.get("district_display") or best.get("district") or "the top district"
     runner_district = (runner_item.get("district_display") or runner_item.get("district")) if runner_item else "backup options"
     if pass_candidates:
         # At least one candidate truly passes all gates
-        why_best = f"Highest blended final score with brand fit {_safe_float(best.get('brand_fit_score')):.1f}/100 and economics {_safe_float(best.get('economics_score')):.1f}/100."
-        summary_text = f"Recommend {best_district} first, then sequence {runner_district} as runner-up."
+        _bf = _safe_float(best.get("brand_fit_score"))
+        _ec = _safe_float(best.get("economics_score"))
+        why_best = _localized(
+            "report.why_best.pass",
+            {"bf": _bf, "ec": _ec},
+            f"Highest blended final score with brand fit {_bf:.1f}/100 and economics {_ec:.1f}/100.",
+        )
+        summary_text = _localized(
+            "report.summary.pass",
+            {"best": best_district, "runner": runner_district},
+            f"Recommend {best_district} first, then sequence {runner_district} as runner-up.",
+        )
         report_summary_text = summary_text
     elif unknown_candidates:
         # No strict passes, but some candidates have no blocking failures — needs field validation
-        why_best = (
-            f"Top-ranked candidate scores {_safe_float(best.get('final_score')):.1f}/100 "
-            f"with {validation_clear_count} candidate(s) pending gate validation."
+        _fs = _safe_float(best.get("final_score"))
+        why_best = _localized(
+            "report.why_best.validation_clear",
+            {"fs": _fs, "n": validation_clear_count},
+            (
+                f"Top-ranked candidate scores {_fs:.1f}/100 "
+                f"with {validation_clear_count} candidate(s) pending gate validation."
+            ),
         )
-        summary_text = (
-            f"No candidate has fully passed all gates yet. "
-            f"{validation_clear_count} candidate(s) have no blocking failures but need field validation. "
-            f"Consider {best_district} as the exploratory lead."
+        summary_text = _localized(
+            "report.summary.validation_clear",
+            {"n": validation_clear_count, "best": best_district},
+            (
+                f"No candidate has fully passed all gates yet. "
+                f"{validation_clear_count} candidate(s) have no blocking failures but need field validation. "
+                f"Consider {best_district} as the exploratory lead."
+            ),
         )
         report_summary_text = summary_text
     else:
-        why_best = (
-            f"Top-ranked candidate scores {_safe_float(best.get('final_score')):.1f}/100 "
-            f"but does not yet pass all gates — unresolved items need validation."
+        _fs = _safe_float(best.get("final_score"))
+        why_best = _localized(
+            "report.why_best.fail",
+            {"fs": _fs},
+            (
+                f"Top-ranked candidate scores {_fs:.1f}/100 "
+                f"but does not yet pass all gates — unresolved items need validation."
+            ),
         )
-        summary_text = (
-            f"No candidate currently passes all required gates ({pass_count} of {len(normalized_candidates)} pass). "
-            f"Consider {best_district} as an exploratory lead pending further validation."
+        summary_text = _localized(
+            "report.summary.fail",
+            {"pc": pass_count, "total": len(normalized_candidates), "best": best_district},
+            (
+                f"No candidate currently passes all required gates ({pass_count} of {len(normalized_candidates)} pass). "
+                f"Consider {best_district} as an exploratory lead pending further validation."
+            ),
         )
         report_summary_text = summary_text
 
@@ -12587,7 +12625,12 @@ def get_recommendation_report(db: Session, search_id: str, lang: str = "en") -> 
             "pass_count": pass_count,
             "validation_clear_count": validation_clear_count,
             "why_best": why_best,
-            "main_risk": (best.get("key_risks_json") or ["Validate lease and execution assumptions"])[0],
+            # Primary value is key_risks_json[0] (already AR-localized
+            # upstream); only the fallback literal is localized here.
+            "main_risk": (
+                best.get("key_risks_json")
+                or [_localized("report.main_risk_fallback", {}, "Validate lease and execution assumptions")]
+            )[0],
             "best_format": _recommended_use_case(str(search.get("service_model") or "qsr"), _safe_float(best.get("area_m2")), lang=lang),
             "summary": summary_text,
             "report_summary": report_summary_text,

--- a/app/services/expansion_advisor_i18n.py
+++ b/app/services/expansion_advisor_i18n.py
@@ -231,6 +231,57 @@ TEMPLATES: dict[str, dict[str, str]] = {
             " أبرز مخاطر تجارية: مخاطر التنفيذ تستلزم الإدارة خلال "
             "مرحلتَي التأجير والتصميم."),
     },
+    # ── F5 Stage 2: get_recommendation_report recommendation strings ──
+    # why_best / summary / report_summary across the three report
+    # branches (pass / validation-clear / fail), plus the main_risk
+    # English fallback. The en side is byte-identical to the producer's
+    # f-strings in get_recommendation_report at HEAD (same placeholders,
+    # formatting, punctuation, and the U+2014 em-dash). The ar side
+    # follows the module conventions: Latin digits, em-dash preserved,
+    # district names ({best}/{runner}) pass through already-localized.
+    # report.summary.* doubles as report_summary (identical at HEAD).
+    "report.why_best.pass": {
+        "en": "Highest blended final score with brand fit {bf:.1f}/100 and economics {ec:.1f}/100.",
+        "ar": "أعلى نتيجة نهائية مركّبة مع ملاءمة علامة تجارية {bf:.1f}/100 وجدوى اقتصادية {ec:.1f}/100.",
+    },
+    "report.summary.pass": {
+        "en": "Recommend {best} first, then sequence {runner} as runner-up.",
+        "ar": "يُوصى بـ{best} أولاً، ثم {runner} كخيار ثانٍ.",
+    },
+    "report.why_best.validation_clear": {
+        "en": "Top-ranked candidate scores {fs:.1f}/100 with {n} candidate(s) pending gate validation.",
+        "ar": "المرشّح الأعلى ترتيباً يسجّل {fs:.1f}/100 مع {n} مرشّح بانتظار التحقق من المعايير.",
+    },
+    "report.summary.validation_clear": {
+        "en": (
+            "No candidate has fully passed all gates yet. "
+            "{n} candidate(s) have no blocking failures but need field validation. "
+            "Consider {best} as the exploratory lead."
+        ),
+        "ar": (
+            "لم يجتَز أي مرشّح كل المعايير بالكامل بعد. "
+            "{n} مرشّح بلا إخفاقات حاجبة لكن يحتاج تحققاً ميدانياً. "
+            "يمكن اعتبار {best} الخيار الاستكشافي الأول."
+        ),
+    },
+    "report.why_best.fail": {
+        "en": "Top-ranked candidate scores {fs:.1f}/100 but does not yet pass all gates — unresolved items need validation.",
+        "ar": "المرشّح الأعلى ترتيباً يسجّل {fs:.1f}/100 لكنه لا يجتاز كل المعايير بعد — هناك بنود غير محسومة تحتاج تحققاً.",
+    },
+    "report.summary.fail": {
+        "en": (
+            "No candidate currently passes all required gates ({pc} of {total} pass). "
+            "Consider {best} as an exploratory lead pending further validation."
+        ),
+        "ar": (
+            "لا يجتاز أي مرشّح حالياً كل المعايير المطلوبة ({pc} من {total}). "
+            "يمكن اعتبار {best} خياراً استكشافياً بانتظار مزيد من التحقق."
+        ),
+    },
+    "report.main_risk_fallback": {
+        "en": "Validate lease and execution assumptions",
+        "ar": "تحقّق من افتراضات الإيجار والتنفيذ",
+    },
 }
 
 

--- a/tests/test_pr2b_arabic_render.py
+++ b/tests/test_pr2b_arabic_render.py
@@ -67,6 +67,14 @@ _MINIMAL_PARAMS: dict[str, dict] = {
         "risk_kind": "execution",
         "risk_text_en": "",
     },
+    # F5 Stage 2: get_recommendation_report recommendation strings.
+    "report.why_best.pass": {"bf": 78.5, "ec": 62.3},
+    "report.summary.pass": {"best": "Al Olaya", "runner": "Al Malaz"},
+    "report.why_best.validation_clear": {"fs": 71.2, "n": 3},
+    "report.summary.validation_clear": {"n": 3, "best": "Al Olaya"},
+    "report.why_best.fail": {"fs": 55.0},
+    "report.summary.fail": {"pc": 0, "total": 5, "best": "Al Olaya"},
+    "report.main_risk_fallback": {},
 }
 
 


### PR DESCRIPTION
F5 Stage 2 — Arabic parity for `get_recommendation_report` recommendation strings (`why_best` / `summary` / `report_summary` across pass / validation-clear / fail branches, plus the `main_risk` English fallback). Routed through `expansion_advisor_i18n.TEMPLATES` + `render()` with English f-string fallback. English output byte-identical; only the AR branch added. No scoring/logic change.

## What was wrong

`get_recommendation_report(db, search_id, lang)` already threads `lang` into `_recommended_use_case(..., lang=lang)`, but the recommendation-language strings were hardcoded English f-strings regardless of `lang`:

- `why_best` (pass / validation-clear / fail variants)
- `summary_text` / `report_summary_text` (identical at HEAD)
- `main_risk` — only the **fallback** literal `"Validate lease and execution assumptions"` (the primary `key_risks_json[0]` value is already AR-localized upstream)

So an Arabic-locale report rendered Arabic everywhere except the recommendation headline/summary block (surfaced via `ExpansionReportPanel.tsx`, `StudyHeader.tsx`, `studyAdapters.ts`).

## The fix (Option A — preferred)

Added seven `TEMPLATES` ids to `expansion_advisor_i18n.py` (`report.why_best.{pass,validation_clear,fail}`, `report.summary.{pass,validation_clear,fail}`, `report.main_risk_fallback`), each with `{en, ar}`. The `en` value reproduces the live f-string byte-for-byte (same placeholders, `:.1f` formatting, punctuation, U+2014 em-dash). The `ar` value follows the module's AR conventions (Latin digits, em-dash preserved, district names pass through already-localized).

In `get_recommendation_report`, each string is built as a structured record and rendered via `render(record, lang)`; on any failure `render` returns `""` and the code falls back to the **existing English f-string** — preserving exact English output AND fixing AR.

Routed through the established i18n module (single i18n home, matching the existing pattern) rather than an inline `if lang == "ar"` branch.

## Validation

- `python -m py_compile app/services/expansion_advisor.py app/services/expansion_advisor_i18n.py` ✅
- EN byte-identity confirmed for all seven strings (fallback path is character-identical to pre-patch). ✅
- AR path renders Arabic with correct score/district/count interpolation; Latin digits and em-dash preserved. ✅
- Fallback safety: a missing/malformed param makes `render` return `""` → code falls back to the English f-string (no crash, no empty string surfaced). ✅
- Codepoint check: new AR strings use U+064A yeh / U+0647 heh (no Persian variants). ✅
- `pytest tests/test_pr2b_arabic_render.py tests/test_expansion_advisor_service.py tests/test_expansion_advisor_regression.py tests/test_expansion_advisor_api.py -q` → **449 passed**. Added minimal-param entries for the new ids to the `test_pr2b_arabic_render.py` parametrized completeness test.

## Notes / parked

- `report_summary` equals `summary` in all three branches at HEAD (confirmed) — reuses the same rendered string, no separate template.
- `studyAdapters.ts` builds some English sentence fragments client-side around report fields; if any recommendation string is re-derived on the frontend rather than rendered as-is, that's a frontend follow-up — **not** addressed here.

No scoring, logic, or threshold change.

https://claude.ai/code/session_01RCWXhmip6N8exsH1wHw9A5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCWXhmip6N8exsH1wHw9A5)_