### PR TITLE
F8 — fix dark cafe/coffee POI competitor leg

### DIFF
--- a/app/services/expansion_advisor.py
+++ b/app/services/expansion_advisor.py
@@ -173,14 +173,14 @@ _CATEGORY_ALIAS_MAP: dict[str, dict] = {
         "raw_patterns": ["chicken", "broasted", "fried.chicken", "wings", "دجاج"],
     },
     "cafe": {
-        "keys": ["coffee_bakery"],
+        "keys": ["cafe", "coffee", "bakery", "dessert"],
         "raw_patterns": [
             "cafe", "coffee", "bakery", "dessert", "pastry",
             "قهوة", "مقهى", "كافيه", "مخبز", "حلويات",
         ],
     },
     "coffee": {
-        "keys": ["coffee_bakery"],
+        "keys": ["cafe", "coffee", "bakery", "dessert"],
         "raw_patterns": [
             "coffee", "cafe", "قهوة", "مقهى", "كافيه",
         ],

--- a/scripts/diagnostics/f8_cafe_poi_keys_confirm.sql
+++ b/scripts/diagnostics/f8_cafe_poi_keys_confirm.sql
@@ -1,0 +1,166 @@
+-- F8 confirmation probe: cafe/coffee dark POI competitor leg
+-- ---------------------------------------------------------------------------
+-- Proves the same-category brick-and-mortar competitor leg for cafe/coffee
+-- searches is no longer dark after correcting
+-- _CATEGORY_ALIAS_MAP["cafe"]/["coffee"]["keys"] from the meta-bucket
+-- {coffee_bakery} (never stored in restaurant_poi.category) to the real
+-- granular set {cafe, coffee, bakery, dessert}.
+--
+-- For a sample of recent cafe/coffee candidate centroids (1000 m radius),
+-- this shows same-category restaurant_poi counts under BOTH key sets in a
+-- single query so the before/after is directly comparable.
+--
+--   poi_count_old = lower(category) = ANY('{coffee_bakery}')           -> ~0
+--   poi_count_new = lower(category) = ANY('{cafe,coffee,bakery,dessert}') -> dozens..hundreds
+--
+-- Non-interactive. Run with:
+--   psql -x -f scripts/diagnostics/f8_cafe_poi_keys_confirm.sql "$DATABASE_URL"
+--
+-- Matches the live competitor query: restaurant_poi joined by geography
+-- ST_DWithin at the 1000 m competition radius, excluding non-operational
+-- venues (business_status NULL or 'OPERATIONAL').
+-- ---------------------------------------------------------------------------
+
+\set ON_ERROR_STOP on
+
+-- Tunables (overridable via -v): radius, candidate sample size, lookback.
+\if :{?radius_m}
+\else
+  \set radius_m 1000
+\endif
+\if :{?sample_limit}
+\else
+  \set sample_limit 200
+\endif
+\if :{?lookback_days}
+\else
+  \set lookback_days 90
+\endif
+
+-- ---------------------------------------------------------------------------
+-- [1] Per-candidate before/after counts (head of the sample).
+-- ---------------------------------------------------------------------------
+WITH cand AS (
+    SELECT c.id AS candidate_id,
+           c.search_id,
+           s.category,
+           c.lon,
+           c.lat
+    FROM expansion_candidate c
+    JOIN expansion_search s ON s.id = c.search_id
+    WHERE lower(s.category) IN ('cafe', 'coffee')
+      AND c.lon IS NOT NULL
+      AND c.lat IS NOT NULL
+      AND s.created_at >= now() - make_interval(days => :lookback_days)
+    ORDER BY s.created_at DESC, c.id
+    LIMIT :sample_limit
+),
+counts AS (
+    SELECT cand.candidate_id,
+           cand.category,
+           (
+             SELECT count(*)
+             FROM restaurant_poi rp
+             WHERE (rp.business_status IS NULL
+                    OR rp.business_status = 'OPERATIONAL')
+               AND lower(rp.category) = ANY('{coffee_bakery}')
+               AND ST_DWithin(
+                     rp.geom::geography,
+                     ST_SetSRID(ST_MakePoint(cand.lon, cand.lat), 4326)::geography,
+                     :radius_m
+                   )
+           ) AS poi_count_old,
+           (
+             SELECT count(*)
+             FROM restaurant_poi rp
+             WHERE (rp.business_status IS NULL
+                    OR rp.business_status = 'OPERATIONAL')
+               AND lower(rp.category) = ANY('{cafe,coffee,bakery,dessert}')
+               AND ST_DWithin(
+                     rp.geom::geography,
+                     ST_SetSRID(ST_MakePoint(cand.lon, cand.lat), 4326)::geography,
+                     :radius_m
+                   )
+           ) AS poi_count_new
+    FROM cand
+)
+SELECT candidate_id,
+       category,
+       poi_count_old,
+       poi_count_new,
+       (poi_count_new - poi_count_old) AS delta,
+       CASE WHEN poi_count_old > 0
+            THEN round(poi_count_new::numeric / poi_count_old, 1)
+            ELSE NULL END AS ratio
+FROM counts
+ORDER BY poi_count_new DESC
+LIMIT 25;
+
+-- ---------------------------------------------------------------------------
+-- [2] Aggregate summary: p50/p90 of each key set + dark-leg confirmation.
+-- Expected: p50/p90 old ~ 0; p50/p90 new in the dozens-to-hundreds.
+-- ---------------------------------------------------------------------------
+WITH cand AS (
+    SELECT c.id AS candidate_id,
+           s.category,
+           c.lon,
+           c.lat
+    FROM expansion_candidate c
+    JOIN expansion_search s ON s.id = c.search_id
+    WHERE lower(s.category) IN ('cafe', 'coffee')
+      AND c.lon IS NOT NULL
+      AND c.lat IS NOT NULL
+      AND s.created_at >= now() - make_interval(days => :lookback_days)
+    ORDER BY s.created_at DESC, c.id
+    LIMIT :sample_limit
+),
+counts AS (
+    SELECT cand.category,
+           (
+             SELECT count(*)
+             FROM restaurant_poi rp
+             WHERE (rp.business_status IS NULL
+                    OR rp.business_status = 'OPERATIONAL')
+               AND lower(rp.category) = ANY('{coffee_bakery}')
+               AND ST_DWithin(
+                     rp.geom::geography,
+                     ST_SetSRID(ST_MakePoint(cand.lon, cand.lat), 4326)::geography,
+                     :radius_m
+                   )
+           ) AS poi_count_old,
+           (
+             SELECT count(*)
+             FROM restaurant_poi rp
+             WHERE (rp.business_status IS NULL
+                    OR rp.business_status = 'OPERATIONAL')
+               AND lower(rp.category) = ANY('{cafe,coffee,bakery,dessert}')
+               AND ST_DWithin(
+                     rp.geom::geography,
+                     ST_SetSRID(ST_MakePoint(cand.lon, cand.lat), 4326)::geography,
+                     :radius_m
+                   )
+           ) AS poi_count_new
+    FROM cand
+)
+SELECT category,
+       count(*)                                                       AS candidates,
+       round(avg(poi_count_old), 2)                                   AS old_avg,
+       percentile_cont(0.5) WITHIN GROUP (ORDER BY poi_count_old)     AS old_p50,
+       percentile_cont(0.9) WITHIN GROUP (ORDER BY poi_count_old)     AS old_p90,
+       round(avg(poi_count_new), 2)                                   AS new_avg,
+       percentile_cont(0.5) WITHIN GROUP (ORDER BY poi_count_new)     AS new_p50,
+       percentile_cont(0.9) WITHIN GROUP (ORDER BY poi_count_new)     AS new_p90
+FROM counts
+GROUP BY category
+ORDER BY category;
+
+-- ---------------------------------------------------------------------------
+-- [3] Ground truth: confirm restaurant_poi never stores 'coffee_bakery' and
+-- the four granular cafe categories carry the volume the leg should count.
+-- ---------------------------------------------------------------------------
+SELECT lower(category) AS category,
+       count(*)        AS poi_rows
+FROM restaurant_poi
+WHERE lower(category) IN ('cafe', 'coffee', 'bakery', 'dessert', 'coffee_bakery')
+GROUP BY lower(category)
+ORDER BY poi_rows DESC;

--- a/tests/test_expansion_advisor_service.py
+++ b/tests/test_expansion_advisor_service.py
@@ -5538,3 +5538,19 @@ def test_pipeline_city_wide_output_matches_pre_fix_order():
         copy.deepcopy(pool), target_districts=[], limit=4
     )
     assert fixed == legacy
+
+
+def test_expand_category_cafe_coffee_keys_match_real_poi_categories():
+    """F8: cafe/coffee POI ``keys`` must be the granular categories actually
+    stored in ``restaurant_poi.category`` — not the ``coffee_bakery`` meta
+    bucket, which ``normalize_category()`` never emits. The old keys matched
+    a near-empty greenfield, darkening the cafe brick-and-mortar competitor
+    leg.
+    """
+    from app.services.expansion_advisor import _expand_category
+
+    expected = ["cafe", "coffee", "bakery", "dessert"]
+    for category in ("cafe", "coffee"):
+        keys = _expand_category(category)["keys"]
+        assert keys == expected
+        assert "coffee_bakery" not in keys


### PR DESCRIPTION
## Summary

`_CATEGORY_ALIAS_MAP["cafe"]/["coffee"]` had POI `keys=["coffee_bakery"]`, a display/delivery meta-bucket that is **never stored** in `restaurant_poi.category` (`normalize_category()` only ever emits granular keys). So `_bulk_enrich_competitors`'s same-category brick-and-mortar leg — `lower(rp.category) = ANY(:category_keys)` — matched a near-empty greenfield for every cafe/coffee expansion search (probe: **6 rows** vs ~**24,400** real cafe/coffee/bakery/dessert rows). Cafe/coffee searches computed brick-and-mortar whitespace off a **phantom greenfield**, systematically inflating cafe whitespace scores and pushing cafe candidates up the ranking on a dark signal (cafe's competitor signal today is effectively DSR/delivery-only).

Corrected `keys` to the real granular set `["cafe", "coffee", "bakery", "dessert"]`. `raw_patterns` (the DSR regex side) are **untouched** — they were already correct (`cafe|coffee|bakery|dessert`). Only the two `keys` arrays changed.

```diff
 "cafe": {
-    "keys": ["coffee_bakery"],
+    "keys": ["cafe", "coffee", "bakery", "dessert"],
 "coffee": {
-    "keys": ["coffee_bakery"],
+    "keys": ["cafe", "coffee", "bakery", "dessert"],
```

## Decision rationale

- The four granular categories `{cafe, coffee, bakery, dessert}` are the real values stored in `restaurant_poi.category` (probe `[C2]`: cafe 7,882 / coffee 6,877 / bakery 4,677 / dessert 3,002).
- `dessert` is included because dessert venues compete for the café daypart in Riyadh.
- `coffee_bakery` is a downstream display/delivery meta-bucket never stored on `restaurant_poi.category`, so it must not be a POI key. It remains correctly used by the delivery-bucket maps (`_CATEGORY_TO_DELIVERY_BUCKETS` in both `expansion_advisor.py` and `restaurant_categories.py`, and `google_places_async.py`), which are unchanged.
- `coffee` and `cafe` keys are aligned per product decision — both are the same cafe daypart.

## Investigation notes

- `normalize_category()` (`app/services/restaurant_categories.py`) emits the granular `coffee`, `bakery`, `dessert` (and `cafe` is present in the table via import paths) and **never** `coffee_bakery` — confirmed.
- No other reader of `_CATEGORY_ALIAS_MAP["cafe"]["keys"]` expects `coffee_bakery`; the only consumers of these `keys` are the POI same-category match paths.
- **Other alias-map entries audited:** the only remaining meta-bucket-style key is `fast_food` in the `fast food` entry, which is never emitted either — but it survives because `burger`/`pizza`/`chicken` (its sibling keys) cover the real stored values. No fix here (out of scope). All other entries' `keys` intersect real `restaurant_poi.category` values.
- No existing test pinned the old `{coffee_bakery}` cafe keys or a cafe competitor count derived from it, so no fixture needed updating. (`test_expand_category_terms.py` exercises the separate delivery-terms function and is unaffected.)

## Tests / verification

- `python -m py_compile app/services/expansion_advisor.py` ✓
- `git diff` shows only the two `keys` arrays changed; `raw_patterns` untouched.
- `pytest tests/test_expansion_advisor_service.py tests/test_expansion_advisor_regression.py -q` → **306 passed**.
- Added `test_expand_category_cafe_coffee_keys_match_real_poi_categories` asserting `_expand_category("cafe"/"coffee")["keys"] == ["cafe","coffee","bakery","dessert"]` and not containing `coffee_bakery`.

## Confirmation probe

`scripts/diagnostics/f8_cafe_poi_keys_confirm.sql` (non-interactive, `psql -x -f` runnable): for recent cafe/coffee candidate centroids (1000 m), counts same-category `restaurant_poi` under **both** key sets in one query — `poi_count_old` (`{coffee_bakery}`, expected ≈ 0) vs `poi_count_new` (`{cafe,coffee,bakery,dessert}`, expected dozens-to-hundreds), per-candidate plus p50/p90 and the ratio. Proof the leg is no longer dark.

## Post-deploy validation plan (Ahmed runs after merge + deploy)

Ranking-affecting change — old searches do **not** backfill snapshots, so validate on **fresh** searches only:

1. Run the confirmation probe → cafe `poi_count_new` ≫ `poi_count_old`.
2. Run 3+ **new** cafe (and coffee) searches in geographically different districts.
3. For 3+ cafe candidates, compare `whitespace_score` / `provider_whitespace_score` and `competitor_count` vs comparable pre-fix candidates. Expected: competitor_count **UP**, whitespace **DOWN** into a realistic band (no more phantom ~100 greenfield on dense cafe districts).
4. Confirm no cafe candidate hard-fails from the larger competitor set — the count feeds whitespace + delivery_competition (both clamped); no gate keys directly off raw `competitor_count`, but verify.

## Interaction with F2 (note only — not actioned here)

F8 **grows** cafe POI counts; F2 (cross-source dedupe) will **shrink** all counts ~40%. The cafe `_WHITESPACE_LOG_REF` re-anchor cannot be sized until F8 is deployed and a fresh probe measures cafe's true (now non-dark) deduped p90 — today's `[D]` cafe row (44.4) is DSR-only and meaningless. So **F8 ships first**; F2's cafe REF re-anchor is sized from a post-F8 probe. qsr/dine_in REF re-anchors are unaffected by F8.

---

**Risk tier: high** (scoring logic + Arabic-adjacent data). Please review and merge explicitly — do not auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_013eB3HS54v8jUBUyus29wkr)_