### PR TITLE
chore(ci): pause all automatic workflow triggers (project on indefinite hold)

### DIFF
--- a/.github/workflows/aqar-scraper.yml
+++ b/.github/workflows/aqar-scraper.yml
@@ -26,11 +26,12 @@ on:
           - showroom
           - warehouse
           - building
-  schedule:
-    # Daily at 02:17 UTC (05:17 Riyadh time) — off-peak, with a 17-minute
-    # offset from the top of the hour to stagger against other cron jobs
-    # and avoid hammering Aqar at a predictable moment.
-    - cron: '17 2 * * *'
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # # Daily at 02:17 UTC (05:17 Riyadh time) — off-peak, with a 17-minute
+    # # offset from the top of the hour to stagger against other cron jobs
+    # # and avoid hammering Aqar at a predictable moment.
+    # - cron: '17 2 * * *'
 
 concurrency:
   group: aqar-scraper

--- a/.github/workflows/bayut-scraper.yml
+++ b/.github/workflows/bayut-scraper.yml
@@ -19,12 +19,13 @@ on:
         description: "Seconds to sleep between requests"
         required: false
         default: "1.0"
-  schedule:
-    # Daily at 08:30 UTC (11:30 Riyadh time). The Aqar scraper runs at
-    # 02:17 UTC (05:17 Riyadh); the ~6h offset lets Aqar's
-    # candidate-locations refresh finish before Bayut starts writing
-    # rows that the next refresh will rejoin.
-    - cron: '30 8 * * *'
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # # Daily at 08:30 UTC (11:30 Riyadh time). The Aqar scraper runs at
+    # # 02:17 UTC (05:17 Riyadh); the ~6h offset lets Aqar's
+    # # candidate-locations refresh finish before Bayut starts writing
+    # # rows that the next refresh will rejoin.
+    # - cron: '30 8 * * *'
 
 concurrency:
   group: bayut-scraper

--- a/.github/workflows/candidate-locations-refresh.yml
+++ b/.github/workflows/candidate-locations-refresh.yml
@@ -11,12 +11,13 @@ on:
         description: "Truncate and rebuild"
         type: boolean
         default: true
-  workflow_run:
-    workflows: ["Aqar Scraper", "Bayut Scraper"]
-    types:
-      - completed
-    branches:
-      - main
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # workflow_run:
+    # workflows: ["Aqar Scraper", "Bayut Scraper"]
+    # types:
+      # - completed
+    # branches:
+      # - main
 
 concurrency:
   group: candidate-locations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  pull_request:
-  push:
+  workflow_dispatch:
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # pull_request:
+  # push:
 
 jobs:
   validate-alembic:

--- a/.github/workflows/deploy-sccc.yml
+++ b/.github/workflows/deploy-sccc.yml
@@ -1,18 +1,19 @@
 name: Deploy to sccc (Alibaba Cloud Riyadh)
 
 on:
-  push:
-    branches: [ "main" ]
-    paths:
-      - "app/**"
-      - "alembic/**"
-      - "frontend/**"
-      - "Dockerfile"
-      - ".github/workflows/deploy-sccc.yml"
-      - "k8s/**"
-      - "sql/**"
-      - "models/**"
-      - "Makefile"
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # push:
+    # branches: [ "main" ]
+    # paths:
+      # - "app/**"
+      # - "alembic/**"
+      # - "frontend/**"
+      # - "Dockerfile"
+      # - ".github/workflows/deploy-sccc.yml"
+      # - "k8s/**"
+      # - "sql/**"
+      # - "models/**"
+      # - "Makefile"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/expansion-advisor-data-competitors.yml
+++ b/.github/workflows/expansion-advisor-data-competitors.yml
@@ -1,8 +1,9 @@
 name: "Expansion Advisor Data — Competitor Quality"
 
 on:
-  schedule:
-    - cron: "0 7 * * 5"  # Weekly on Friday at 07:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 7 * * 5"  # Weekly on Friday at 07:00 UTC
   workflow_dispatch:
     inputs:
       refresh_google_reviews:

--- a/.github/workflows/expansion-advisor-data-delivery-sccc.yml
+++ b/.github/workflows/expansion-advisor-data-delivery-sccc.yml
@@ -1,8 +1,9 @@
 name: "Expansion Advisor Data — Delivery (SCCC)"
 
 on:
-  schedule:
-    - cron: "0 5 * * *"  # Daily at 05:00 UTC (08:00 AST)
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 5 * * *"  # Daily at 05:00 UTC (08:00 AST)
   workflow_dispatch:
     inputs:
       platforms:

--- a/.github/workflows/expansion-advisor-data-district-labels.yml
+++ b/.github/workflows/expansion-advisor-data-district-labels.yml
@@ -3,9 +3,10 @@ name: "Expansion Advisor: District Labels"
 on:
   workflow_dispatch: {}
   # Also run after the ArcGIS parcels ingest completes
-  workflow_run:
-    workflows: ["Ingest ArcGIS Riyadh Parcels"]
-    types: [completed]
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # workflow_run:
+    # workflows: ["Ingest ArcGIS Riyadh Parcels"]
+    # types: [completed]
 
 jobs:
   district-labels:

--- a/.github/workflows/expansion-advisor-data-parking-google.yml
+++ b/.github/workflows/expansion-advisor-data-parking-google.yml
@@ -1,8 +1,9 @@
 name: "Expansion Advisor Data — Google Places Parking"
 
 on:
-  schedule:
-    - cron: "0 4 1 6,12 *"  # 04:00 UTC on Jun 1 and Dec 1 (6-month cadence)
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 4 1 6,12 *"  # 04:00 UTC on Jun 1 and Dec 1 (6-month cadence)
   workflow_dispatch:
     inputs:
       replace_mode:

--- a/.github/workflows/expansion-advisor-data-parking.yml
+++ b/.github/workflows/expansion-advisor-data-parking.yml
@@ -1,8 +1,9 @@
 name: "Expansion Advisor Data — Parking Context"
 
 on:
-  schedule:
-    - cron: "0 4 * * 2"  # Weekly on Tuesday at 04:00 UTC (offset from roads)
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 4 * * 2"  # Weekly on Tuesday at 04:00 UTC (offset from roads)
   workflow_dispatch:
     inputs:
       replace_mode:

--- a/.github/workflows/expansion-advisor-data-rent-comps.yml
+++ b/.github/workflows/expansion-advisor-data-rent-comps.yml
@@ -1,8 +1,9 @@
 name: "Expansion Advisor Data — Retail Rent & Lease Comps"
 
 on:
-  schedule:
-    - cron: "0 6 * * 4"  # Weekly on Thursday at 06:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 6 * * 4"  # Weekly on Thursday at 06:00 UTC
   workflow_dispatch:
     inputs:
       kaggle_dataset:

--- a/.github/workflows/expansion-advisor-data-roads.yml
+++ b/.github/workflows/expansion-advisor-data-roads.yml
@@ -1,8 +1,9 @@
 name: "Expansion Advisor Data — Roads & Access"
 
 on:
-  schedule:
-    - cron: "0 3 * * 1"  # Weekly on Monday at 03:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 3 * * 1"  # Weekly on Monday at 03:00 UTC
   workflow_dispatch:
     inputs:
       pbf_url:

--- a/.github/workflows/google-places-grid-search.yml
+++ b/.github/workflows/google-places-grid-search.yml
@@ -19,8 +19,9 @@ on:
         description: "Ignore previous progress, re-process all cells"
         type: boolean
         default: false
-  schedule:
-    - cron: "0 4 1 1,4,7,10 *"   # quarterly: Jan/Apr/Jul/Oct 1st @ 04:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 4 1 1,4,7,10 *"   # quarterly: Jan/Apr/Jul/Oct 1st @ 04:00 UTC
 
 concurrency:
   group: google-places-grid

--- a/.github/workflows/ingest-blackmarble.yml
+++ b/.github/workflows/ingest-blackmarble.yml
@@ -11,8 +11,9 @@
 name: Ingest Black Marble VNP46A3
 
 on:
-  schedule:
-    - cron: "0 5 15 * *"  # 15th of each month at 05:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 5 15 * *"  # 15th of each month at 05:00 UTC
   workflow_dispatch:
     inputs:
       year_month:

--- a/.github/workflows/ingest-population.yml
+++ b/.github/workflows/ingest-population.yml
@@ -7,8 +7,9 @@ on:
         description: "Override URL to a population density GeoTIFF (leave empty to use pinned Saudi Arabia dataset)"
         required: false
         default: ""
-  schedule:
-    - cron: "0 5 1 */3 *"  # Quarterly: 1st of Jan/Apr/Jul/Oct at 05:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 5 1 */3 *"  # Quarterly: 1st of Jan/Apr/Jul/Oct at 05:00 UTC
 
 # Pinned dataset: WorldPop — Saudi Arabia 2020 population (constrained, UN-adjusted)
 # Source: https://data.worldpop.org/GIS/Population/Global_2000_2020_Constrained/2020/BSGM/SAU/

--- a/.github/workflows/ingest-restaurant-pois.yml
+++ b/.github/workflows/ingest-restaurant-pois.yml
@@ -23,8 +23,9 @@ on:
         description: "Specific delivery platforms (comma-separated, e.g. hungerstation,jahez,keeta). Empty = all."
         required: false
         default: ""
-  schedule:
-    - cron: "0 3 * * 1"  # Weekly Monday 03:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 3 * * 1"  # Weekly Monday 03:00 UTC
 
 # Prevent two ingestion runs from overlapping
 concurrency:

--- a/.github/workflows/llm-suitability-backfill.yml
+++ b/.github/workflows/llm-suitability-backfill.yml
@@ -11,12 +11,13 @@ on:
         description: "Reclassify rows that already have llm_classified_at"
         required: false
         default: "false"
-  workflow_run:
-    workflows:
-      - "Deploy to sccc (Alibaba Cloud Riyadh)"
-      - "Aqar Scraper"
-      - "Bayut Scraper"
-    types: [completed]
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # workflow_run:
+    # workflows:
+      # - "Deploy to sccc (Alibaba Cloud Riyadh)"
+      # - "Aqar Scraper"
+      # - "Bayut Scraper"
+    # types: [completed]
 
 jobs:
   backfill:

--- a/.github/workflows/osm-import.yml
+++ b/.github/workflows/osm-import.yml
@@ -15,8 +15,9 @@ on:
         description: "Tile size in degrees (smaller = more Overpass calls)"
         required: false
         default: "0.10"
-  schedule:
-    - cron: '0 4 * * 0'  # Sundays at 04:00 UTC — low-traffic window for SCCC pipeline
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: '0 4 * * 0'  # Sundays at 04:00 UTC — low-traffic window for SCCC pipeline
 
 env:
   # south,west,north,east (Overpass ordering) — Riyadh metro

--- a/.github/workflows/train-profitability-model.yml
+++ b/.github/workflows/train-profitability-model.yml
@@ -2,8 +2,9 @@ name: Train Profitability Model
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 6 * * 0"  # Weekly Sunday 06:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 6 * * 0"  # Weekly Sunday 06:00 UTC
 
 jobs:
   train:

--- a/.github/workflows/train-restaurant-heatmap.yml
+++ b/.github/workflows/train-restaurant-heatmap.yml
@@ -2,8 +2,9 @@ name: Train Restaurant Heatmap AI Model
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 6 * * 0"  # Weekly Sunday 06:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 6 * * 0"  # Weekly Sunday 06:00 UTC
 
 jobs:
   train:

--- a/.github/workflows/train-restaurant-model.yml
+++ b/.github/workflows/train-restaurant-model.yml
@@ -2,8 +2,9 @@ name: Train Restaurant Location Model
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 5 * * 0"  # Weekly Sunday 05:00 UTC
+  # [PAUSED 2026-06-15] project on indefinite hold — auto-trigger disabled; re-enable by uncommenting.
+  # schedule:
+    # - cron: "0 5 * * 0"  # Weekly Sunday 05:00 UTC
 
 jobs:
   train:


### PR DESCRIPTION
Comment out schedule/push/pull_request/workflow_run triggers across all
workflows so nothing runs automatically (no scheduled ingests/scrapers/
training, no deploy on push, no CI on push/PR, no workflow_run chains).

workflow_dispatch is preserved on every workflow so each can still be run
manually and re-enabled by uncommenting the trigger block. CI gains an
explicit workflow_dispatch since it previously had no manual trigger.

enrich-google-reviews.yml left as-is (schedule already disabled).

NOTE: GitHub reads schedule/push triggers from the default branch, so this
takes effect once merged to main (or disable workflows in the Actions UI
for immediate effect).